### PR TITLE
Serve frontend through main app and mount backend routes

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,1 +1,29 @@
+const path = require('path');
+
+// Reuse Express from the backend dependencies to avoid duplicating
+// installations at the repository root.
+const express = require('./backend/node_modules/express');
+const backend = require('./backend/app');
+
+const app = express();
+
+// Serve the frontend static assets
+const frontendPath = path.join(__dirname, 'frontend');
+app.use(express.static(frontendPath));
+
+// Delegate API requests to the backend under the "/api" prefix
+app.use('/api', backend);
+
+// Fallback to index.html for any other request (SPA behavior)
+// Catch-all handler: send back index.html for any unmatched routes
+app.use((req, res) => {
+  res.sendFile(path.join(frontendPath, 'index.html'));
+});
+
+const port = process.env.PORT || 3000;
+if (require.main === module) {
+  app.listen(port, () => console.log(`Server running on port ${port}`));
+}
+
+module.exports = app;
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -6,7 +6,9 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-app.use('/api/auth', authRoutes);
+// Mount authentication routes. The parent application may prefix these
+// with "/api" when integrating the backend.
+app.use('/auth', authRoutes);
 
 const port = process.env.PORT || 5000;
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- Add root Express server to serve frontend and route API calls through backend
- Adjust backend auth routes so main app can prefix them with `/api`

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`
- `node app.js`

------
https://chatgpt.com/codex/tasks/task_e_68923055988c8320ae39c7cb6a1dd4c4