### PR TITLE
Add Material UI home page

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4,7 +4,8 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<LandingPage />} />
+        <Route path="/" element={<HomePage />} />
+        <Route path="/login" element={<LandingPage />} />
         <Route path="/dashboard" element={<Protected><HomeDashboard /></Protected>} />
       </Routes>
     </BrowserRouter>
@@ -14,7 +15,7 @@ function App() {
 function Protected({ children }) {
   const token = localStorage.getItem('token');
   if (!token) {
-    return <Navigate to="/" />;
+    return <Navigate to="/login" />;
   }
   return children;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,13 +3,25 @@
   <head>
     <meta charset="UTF-8" />
     <title>Workhouse</title>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+    />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/@emotion/react@11/umd/emotion-react.umd.min.js"></script>
+    <script crossorigin src="https://unpkg.com/@emotion/styled@11/umd/emotion-styled.umd.min.js"></script>
+    <script crossorigin src="https://unpkg.com/@mui/material@5/umd/material-ui.development.js"></script>
     <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   </head>
   <body>
     <div id="root"></div>
+    <script type="text/babel" src="views/home_page.js"></script>
     <script type="text/babel" src="views/landing_page.js"></script>
     <script type="text/babel" src="views/home_dashboard.js"></script>
     <script type="text/babel" src="app.js"></script>

--- a/frontend/views/home_page.js
+++ b/frontend/views/home_page.js
@@ -1,0 +1,33 @@
+const { Container, Typography, Button, AppBar, Toolbar, Box } = MaterialUI;
+const { useNavigate } = ReactRouterDOM;
+
+function HomePage() {
+  const navigate = useNavigate();
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <AppBar position="static">
+        <Toolbar>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            Workhouse
+          </Typography>
+          <Button color="inherit" onClick={() => navigate('/login')}>
+            Login
+          </Button>
+        </Toolbar>
+      </AppBar>
+      <Container sx={{ mt: 4 }}>
+        <Typography variant="h4" gutterBottom>
+          Welcome to Workhouse
+        </Typography>
+        <Typography variant="body1" gutterBottom>
+          Manage your work efficiently with our platform.
+        </Typography>
+        <Button variant="contained" onClick={() => navigate('/login')}>
+          Get Started
+        </Button>
+      </Container>
+    </Box>
+  );
+}
+
+window.HomePage = HomePage;


### PR DESCRIPTION
## Summary
- Add Material UI setup and script loading in frontend index
- Create HomePage component with MUI AppBar and call-to-action
- Route root to HomePage and redirect unauthorized users to login

## Testing
- `npm test`
- `node app.js`

------
https://chatgpt.com/codex/tasks/task_e_68923252e0b8832082496281407c03cd