### PR TITLE
feat: add affiliate program management module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const authRoutes = require('./routes/auth');
+const affiliateRoutes = require('./routes/affiliates');
 
 const app = express();
 app.use(cors());
@@ -9,6 +10,7 @@ app.use(express.json());
 // Mount authentication routes. The parent application may prefix these
 // with "/api" when integrating the backend.
 app.use('/auth', authRoutes);
+app.use('/affiliates', affiliateRoutes);
 
 const port = process.env.PORT || 5000;
 if (require.main === module) {

--- a/backend/controllers/affiliate.js
+++ b/backend/controllers/affiliate.js
@@ -1,0 +1,57 @@
+const {
+  registerAffiliate,
+  getAffiliateById,
+  updateAffiliate,
+  recordAffiliateAgreement,
+} = require('../services/affiliate');
+const logger = require('../utils/logger');
+
+async function registerAffiliateHandler(req, res) {
+  try {
+    const affiliate = await registerAffiliate(req.body);
+    res.status(201).json(affiliate);
+  } catch (err) {
+    logger.error('Failed to register affiliate', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function getAffiliateHandler(req, res) {
+  const { affiliateId } = req.params;
+  try {
+    const affiliate = await getAffiliateById(affiliateId);
+    res.json(affiliate);
+  } catch (err) {
+    logger.error('Failed to fetch affiliate', { error: err.message });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function updateAffiliateHandler(req, res) {
+  const { affiliateId } = req.params;
+  try {
+    const affiliate = await updateAffiliate(affiliateId, req.body);
+    res.json(affiliate);
+  } catch (err) {
+    logger.error('Failed to update affiliate', { error: err.message });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function updateAgreementHandler(req, res) {
+  const { affiliateId, agreementVersion } = req.body;
+  try {
+    const record = await recordAffiliateAgreement(affiliateId, agreementVersion);
+    res.status(201).json(record);
+  } catch (err) {
+    logger.error('Failed to record affiliate agreement', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  registerAffiliateHandler,
+  getAffiliateHandler,
+  updateAffiliateHandler,
+  updateAgreementHandler,
+};

--- a/backend/database/database.sql
+++ b/backend/database/database.sql
@@ -1,1 +1,20 @@
 
+-- Affiliate Module Tables
+
+CREATE TABLE IF NOT EXISTS affiliates (
+    id UUID PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    website VARCHAR(255),
+    status VARCHAR(20) DEFAULT 'active',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS affiliate_agreements (
+    id UUID PRIMARY KEY,
+    affiliate_id UUID NOT NULL REFERENCES affiliates(id) ON DELETE CASCADE,
+    agreement_version INTEGER NOT NULL,
+    agreed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,17 @@
+const { verifyToken } = require('../services/auth');
+const logger = require('../utils/logger');
+
+module.exports = (req, res, next) => {
+  const token = req.headers.authorization?.split(' ')[1];
+  if (!token) {
+    logger.error('Authentication token missing');
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  const payload = verifyToken(token);
+  if (!payload) {
+    logger.error('Invalid authentication token');
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+  req.user = payload;
+  next();
+};

--- a/backend/middleware/validate.js
+++ b/backend/middleware/validate.js
@@ -1,0 +1,9 @@
+module.exports = (schema, property = 'body') => {
+  return (req, res, next) => {
+    const { error } = schema.validate(req[property]);
+    if (error) {
+      return res.status(400).json({ error: error.details[0].message });
+    }
+    next();
+  };
+};

--- a/backend/models/affiliate.js
+++ b/backend/models/affiliate.js
@@ -1,0 +1,58 @@
+const { randomUUID } = require('crypto');
+
+const affiliates = new Map();
+const agreements = [];
+
+function createAffiliate({ name, email, website }) {
+  const id = randomUUID();
+  const timestamp = new Date();
+  const affiliate = {
+    id,
+    name,
+    email,
+    website: website || null,
+    status: 'active',
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  affiliates.set(id, affiliate);
+  return affiliate;
+}
+
+function findById(id) {
+  return affiliates.get(id);
+}
+
+function findByEmail(email) {
+  for (const affiliate of affiliates.values()) {
+    if (affiliate.email === email) return affiliate;
+  }
+  return null;
+}
+
+function updateAffiliate(id, updates) {
+  const affiliate = affiliates.get(id);
+  if (!affiliate) return null;
+  Object.assign(affiliate, updates, { updatedAt: new Date() });
+  affiliates.set(id, affiliate);
+  return affiliate;
+}
+
+function recordAgreement(affiliateId, agreementVersion) {
+  const record = {
+    id: randomUUID(),
+    affiliateId,
+    agreementVersion,
+    agreedAt: new Date(),
+  };
+  agreements.push(record);
+  return record;
+}
+
+module.exports = {
+  createAffiliate,
+  findById,
+  findByEmail,
+  updateAffiliate,
+  recordAgreement,
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,8 +12,45 @@
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "joi": "^17.11.0",
         "jsonwebtoken": "^9.0.2"
       }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -478,6 +515,19 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/joi": {
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
+      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "joi": "^17.11.0",
     "jsonwebtoken": "^9.0.2"
   }
 }

--- a/backend/routes/affiliates.js
+++ b/backend/routes/affiliates.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const {
+  registerAffiliateHandler,
+  getAffiliateHandler,
+  updateAffiliateHandler,
+  updateAgreementHandler,
+} = require('../controllers/affiliate');
+const auth = require('../middleware/auth');
+const validate = require('../middleware/validate');
+const {
+  registerSchema,
+  updateSchema,
+  agreementSchema,
+} = require('../validation/affiliate');
+
+const router = express.Router();
+
+router.post('/register', validate(registerSchema), registerAffiliateHandler);
+router.get('/:affiliateId', auth, getAffiliateHandler);
+router.put('/:affiliateId/update', auth, validate(updateSchema), updateAffiliateHandler);
+router.post('/agreements/update', auth, validate(agreementSchema), updateAgreementHandler);
+
+module.exports = router;

--- a/backend/services/affiliate.js
+++ b/backend/services/affiliate.js
@@ -1,0 +1,46 @@
+const logger = require('../utils/logger');
+const affiliateModel = require('../models/affiliate');
+
+async function registerAffiliate(data) {
+  const existing = affiliateModel.findByEmail(data.email);
+  if (existing) {
+    throw new Error('Affiliate already exists');
+  }
+  const affiliate = affiliateModel.createAffiliate(data);
+  logger.info('Affiliate registered', { affiliateId: affiliate.id });
+  return affiliate;
+}
+
+async function getAffiliateById(id) {
+  const affiliate = affiliateModel.findById(id);
+  if (!affiliate) {
+    throw new Error('Affiliate not found');
+  }
+  return affiliate;
+}
+
+async function updateAffiliate(id, updates) {
+  const affiliate = affiliateModel.updateAffiliate(id, updates);
+  if (!affiliate) {
+    throw new Error('Affiliate not found');
+  }
+  logger.info('Affiliate updated', { affiliateId: id });
+  return affiliate;
+}
+
+async function recordAffiliateAgreement(affiliateId, agreementVersion) {
+  const affiliate = affiliateModel.findById(affiliateId);
+  if (!affiliate) {
+    throw new Error('Affiliate not found');
+  }
+  const record = affiliateModel.recordAgreement(affiliateId, agreementVersion);
+  logger.info('Affiliate agreement updated', { affiliateId, agreementVersion });
+  return record;
+}
+
+module.exports = {
+  registerAffiliate,
+  getAffiliateById,
+  updateAffiliate,
+  recordAffiliateAgreement,
+};

--- a/backend/utils/logger.js
+++ b/backend/utils/logger.js
@@ -1,0 +1,9 @@
+const info = (message, meta = {}) => {
+  console.log(`[INFO] ${new Date().toISOString()} - ${message}`, meta);
+};
+
+const error = (message, meta = {}) => {
+  console.error(`[ERROR] ${new Date().toISOString()} - ${message}`, meta);
+};
+
+module.exports = { info, error };

--- a/backend/validation/affiliate.js
+++ b/backend/validation/affiliate.js
@@ -1,0 +1,25 @@
+const Joi = require('joi');
+
+const registerSchema = Joi.object({
+  name: Joi.string().min(3).max(100).required(),
+  email: Joi.string().email().required(),
+  website: Joi.string().uri().optional(),
+});
+
+const updateSchema = Joi.object({
+  name: Joi.string().min(3).max(100),
+  email: Joi.string().email(),
+  website: Joi.string().uri(),
+  status: Joi.string().valid('active', 'inactive'),
+}).min(1);
+
+const agreementSchema = Joi.object({
+  affiliateId: Joi.string().required(),
+  agreementVersion: Joi.number().integer().min(1).required(),
+});
+
+module.exports = {
+  registerSchema,
+  updateSchema,
+  agreementSchema,
+};


### PR DESCRIPTION
## Summary
- implement affiliate program management endpoints with controller, service, and model
- add validation, authentication middleware, and logging utilities
- define SQL schema for affiliates and agreement tracking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689237be7e848320ad2837bec5ed09c4