### PR TITLE
feat: add commission management module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const authRoutes = require('./routes/auth');
+const commissionRoutes = require('./routes/commission');
 
 const app = express();
 app.use(cors());
@@ -9,6 +10,7 @@ app.use(express.json());
 // Mount authentication routes. The parent application may prefix these
 // with "/api" when integrating the backend.
 app.use('/auth', authRoutes);
+app.use('/commissions', commissionRoutes);
 
 const port = process.env.PORT || 5000;
 if (require.main === module) {

--- a/backend/controllers/commission.js
+++ b/backend/controllers/commission.js
@@ -1,0 +1,83 @@
+const {
+  getCommissionRates,
+  updateCommissionRate,
+  getCommissionRateHistory,
+  recordCommission,
+  getCommissionHistory,
+  calculateCommission,
+  adjustRateForPerformance,
+} = require('../services/commission');
+
+async function getRatesHandler(req, res) {
+  try {
+    res.json(getCommissionRates());
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function updateRatesHandler(req, res) {
+  try {
+    const { tier, rate } = req.body;
+    const result = updateCommissionRate(tier, rate);
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function getRateHistoryHandler(req, res) {
+  try {
+    res.json(getCommissionRateHistory());
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function recordCommissionHandler(req, res) {
+  try {
+    const commission = recordCommission(req.body);
+    res.status(201).json(commission);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function getCommissionHistoryHandler(req, res) {
+  try {
+    const history = getCommissionHistory(req.params.affiliateId);
+    res.json(history);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function calculateCommissionHandler(req, res) {
+  try {
+    const { tier, serviceFee } = req.body;
+    const result = calculateCommission(tier, serviceFee);
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function performanceAdjustHandler(req, res) {
+  try {
+    const { tier, rate } = req.body;
+    const result = adjustRateForPerformance(tier, rate);
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  getRatesHandler,
+  updateRatesHandler,
+  getRateHistoryHandler,
+  recordCommissionHandler,
+  getCommissionHistoryHandler,
+  calculateCommissionHandler,
+  performanceAdjustHandler,
+};

--- a/backend/database/commission.sql
+++ b/backend/database/commission.sql
@@ -1,0 +1,23 @@
+CREATE TABLE commission_rates (
+  tier VARCHAR(50) PRIMARY KEY,
+  rate DECIMAL(5, 4) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE commission_rate_history (
+  id SERIAL PRIMARY KEY,
+  tier VARCHAR(50) NOT NULL,
+  old_rate DECIMAL(5, 4),
+  new_rate DECIMAL(5, 4) NOT NULL,
+  changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  reason VARCHAR(255)
+);
+
+CREATE TABLE commissions (
+  id UUID PRIMARY KEY,
+  affiliate_id VARCHAR(255) NOT NULL,
+  amount DECIMAL(10, 2) NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'pending',
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,0 +1,21 @@
+const { verifyToken } = require('../services/auth');
+const logger = require('../utils/logger');
+
+function authMiddleware(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) {
+    logger.error('Authorization header missing');
+    return res.status(401).json({ error: 'Authorization header missing' });
+  }
+  const token = authHeader.split(' ')[1];
+  const payload = verifyToken(token);
+  if (!payload) {
+    logger.error('Invalid or expired token');
+    return res.status(401).json({ error: 'Invalid or expired token' });
+  }
+  req.user = payload;
+  logger.info(`Authenticated user ${payload.username}`);
+  next();
+}
+
+module.exports = authMiddleware;

--- a/backend/middleware/validateCommission.js
+++ b/backend/middleware/validateCommission.js
@@ -1,0 +1,38 @@
+function validateRateUpdate(req, res, next) {
+  const { tier, rate } = req.body;
+  if (!tier || typeof tier !== 'string') {
+    return res.status(400).json({ error: 'tier is required and must be a string' });
+  }
+  if (typeof rate !== 'number' || rate < 0) {
+    return res.status(400).json({ error: 'rate must be a non-negative number' });
+  }
+  next();
+}
+
+function validateRecordCommission(req, res, next) {
+  const { affiliateId, amount } = req.body;
+  if (!affiliateId || typeof affiliateId !== 'string') {
+    return res.status(400).json({ error: 'affiliateId is required and must be a string' });
+  }
+  if (typeof amount !== 'number' || amount <= 0) {
+    return res.status(400).json({ error: 'amount must be a positive number' });
+  }
+  next();
+}
+
+function validateCalculateCommission(req, res, next) {
+  const { tier, serviceFee } = req.body;
+  if (!tier || typeof tier !== 'string') {
+    return res.status(400).json({ error: 'tier is required and must be a string' });
+  }
+  if (typeof serviceFee !== 'number' || serviceFee < 0) {
+    return res.status(400).json({ error: 'serviceFee must be a non-negative number' });
+  }
+  next();
+}
+
+module.exports = {
+  validateRateUpdate,
+  validateRecordCommission,
+  validateCalculateCommission,
+};

--- a/backend/models/commission.js
+++ b/backend/models/commission.js
@@ -1,0 +1,24 @@
+const commissions = new Map();
+const commissionRates = new Map(); // tier -> rate
+const rateHistory = [];
+
+function addCommission(commission) {
+  commissions.set(commission.id, commission);
+}
+
+function getCommissionsByAffiliate(affiliateId) {
+  return Array.from(commissions.values()).filter(c => c.affiliateId === affiliateId);
+}
+
+function addRateHistory(entry) {
+  rateHistory.push(entry);
+}
+
+module.exports = {
+  commissions,
+  commissionRates,
+  rateHistory,
+  addCommission,
+  getCommissionsByAffiliate,
+  addRateHistory,
+};

--- a/backend/routes/commission.js
+++ b/backend/routes/commission.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const {
+  getRatesHandler,
+  updateRatesHandler,
+  getRateHistoryHandler,
+  recordCommissionHandler,
+  getCommissionHistoryHandler,
+  calculateCommissionHandler,
+  performanceAdjustHandler,
+} = require('../controllers/commission');
+const auth = require('../middleware/auth');
+const {
+  validateRateUpdate,
+  validateRecordCommission,
+  validateCalculateCommission,
+} = require('../middleware/validateCommission');
+
+const router = express.Router();
+
+router.use(auth);
+
+router.get('/rates', getRatesHandler);
+router.put('/rates/update', validateRateUpdate, updateRatesHandler);
+router.get('/rates/history', getRateHistoryHandler);
+router.post('/rates/performance-adjust', validateRateUpdate, performanceAdjustHandler);
+router.post('/record', validateRecordCommission, recordCommissionHandler);
+router.get('/:affiliateId/history', getCommissionHistoryHandler);
+router.post('/calculate', validateCalculateCommission, calculateCommissionHandler);
+
+module.exports = router;

--- a/backend/services/commission.js
+++ b/backend/services/commission.js
@@ -1,0 +1,66 @@
+const crypto = require('crypto');
+const logger = require('../utils/logger');
+const {
+  commissionRates,
+  rateHistory,
+  addCommission,
+  getCommissionsByAffiliate,
+  addRateHistory,
+} = require('../models/commission');
+
+function getCommissionRates() {
+  return Object.fromEntries(commissionRates);
+}
+
+function updateCommissionRate(tier, rate, reason = 'manual update') {
+  const oldRate = commissionRates.get(tier) || 0;
+  commissionRates.set(tier, rate);
+  addRateHistory({ tier, oldRate, newRate: rate, changedAt: new Date().toISOString(), reason });
+  logger.info(`Commission rate updated for ${tier} from ${oldRate} to ${rate}`);
+  return { tier, rate };
+}
+
+function getCommissionRateHistory() {
+  return rateHistory;
+}
+
+function recordCommission({ affiliateId, amount }) {
+  const commission = {
+    id: crypto.randomUUID(),
+    affiliateId,
+    amount,
+    status: 'pending',
+    createdAt: new Date().toISOString(),
+  };
+  addCommission(commission);
+  logger.info('Commission recorded', commission);
+  return commission;
+}
+
+function getCommissionHistory(affiliateId) {
+  return getCommissionsByAffiliate(affiliateId);
+}
+
+function calculateCommission(tier, serviceFee) {
+  const rate = commissionRates.get(tier) || 0;
+  return {
+    tier,
+    rate,
+    commission: serviceFee * rate,
+  };
+}
+
+function adjustRateForPerformance(tier, rate) {
+  // In a real implementation this might consider performance metrics.
+  return updateCommissionRate(tier, rate, 'performance-adjust');
+}
+
+module.exports = {
+  getCommissionRates,
+  updateCommissionRate,
+  getCommissionRateHistory,
+  recordCommission,
+  getCommissionHistory,
+  calculateCommission,
+  adjustRateForPerformance,
+};

--- a/backend/utils/logger.js
+++ b/backend/utils/logger.js
@@ -1,0 +1,10 @@
+const logger = {
+  info: (message, ...args) => {
+    console.log(`[INFO] ${new Date().toISOString()} - ${message}`, ...args);
+  },
+  error: (message, ...args) => {
+    console.error(`[ERROR] ${new Date().toISOString()} - ${message}`, ...args);
+  },
+};
+
+module.exports = logger;


### PR DESCRIPTION
## Summary
- implement commission management routes, controller, service, model and SQL schema
- add JWT auth and request validation middleware for commission endpoints
- integrate commission routes into app and add simple logging utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689237eaf5648320bb16a507869991c5