### PR TITLE
Add feedback module for agency quality control

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const authRoutes = require('./routes/auth');
 const affiliateRoutes = require('./routes/affiliates');
+const feedbackRoutes = require('./routes/feedback');
 
 const app = express();
 app.use(cors());
@@ -11,6 +12,7 @@ app.use(express.json());
 // with "/api" when integrating the backend.
 app.use('/auth', authRoutes);
 app.use('/affiliates', affiliateRoutes);
+app.use('/agency', feedbackRoutes);
 
 const port = process.env.PORT || 5000;
 if (require.main === module) {

--- a/backend/controllers/feedback.js
+++ b/backend/controllers/feedback.js
@@ -1,0 +1,43 @@
+const {
+  submitClientFeedback,
+  submitEmployeeFeedback,
+  getQualityScores,
+} = require('../services/feedback');
+const logger = require('../utils/logger');
+
+async function submitClientFeedbackHandler(req, res) {
+  try {
+    const feedback = await submitClientFeedback(req.body);
+    res.status(201).json(feedback);
+  } catch (err) {
+    logger.error('Failed to submit client feedback', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function submitEmployeeFeedbackHandler(req, res) {
+  try {
+    const feedback = await submitEmployeeFeedback(req.body);
+    res.status(201).json(feedback);
+  } catch (err) {
+    logger.error('Failed to submit employee feedback', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function getQualityScoresHandler(req, res) {
+  const { agencyId } = req.params;
+  try {
+    const scores = await getQualityScores(agencyId);
+    res.json(scores);
+  } catch (err) {
+    logger.error('Failed to retrieve quality scores', { error: err.message, agencyId });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  submitClientFeedbackHandler,
+  submitEmployeeFeedbackHandler,
+  getQualityScoresHandler,
+};

--- a/backend/database/database.sql
+++ b/backend/database/database.sql
@@ -18,3 +18,23 @@ CREATE TABLE IF NOT EXISTS affiliate_agreements (
     agreed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+
+-- Feedback Module Tables
+
+CREATE TABLE IF NOT EXISTS client_feedback (
+    id UUID PRIMARY KEY,
+    agency_id UUID NOT NULL,
+    client_id UUID NOT NULL,
+    rating INTEGER CHECK (rating BETWEEN 1 AND 5),
+    comment TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS employee_feedback (
+    id UUID PRIMARY KEY,
+    agency_id UUID NOT NULL,
+    employee_id UUID NOT NULL,
+    rating INTEGER CHECK (rating BETWEEN 1 AND 5),
+    comment TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/models/feedback.js
+++ b/backend/models/feedback.js
@@ -1,0 +1,45 @@
+const { randomUUID } = require('crypto');
+
+const clientFeedbacks = [];
+const employeeFeedbacks = [];
+
+function addClientFeedback({ agencyId, clientId, rating, comment }) {
+  const record = {
+    id: randomUUID(),
+    agencyId,
+    clientId,
+    rating,
+    comment: comment || null,
+    createdAt: new Date(),
+  };
+  clientFeedbacks.push(record);
+  return record;
+}
+
+function addEmployeeFeedback({ agencyId, employeeId, rating, comment }) {
+  const record = {
+    id: randomUUID(),
+    agencyId,
+    employeeId,
+    rating,
+    comment: comment || null,
+    createdAt: new Date(),
+  };
+  employeeFeedbacks.push(record);
+  return record;
+}
+
+function getClientFeedbackByAgency(agencyId) {
+  return clientFeedbacks.filter(f => f.agencyId === agencyId);
+}
+
+function getEmployeeFeedbackByAgency(agencyId) {
+  return employeeFeedbacks.filter(f => f.agencyId === agencyId);
+}
+
+module.exports = {
+  addClientFeedback,
+  addEmployeeFeedback,
+  getClientFeedbackByAgency,
+  getEmployeeFeedbackByAgency,
+};

--- a/backend/routes/feedback.js
+++ b/backend/routes/feedback.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const {
+  submitClientFeedbackHandler,
+  submitEmployeeFeedbackHandler,
+  getQualityScoresHandler,
+} = require('../controllers/feedback');
+const auth = require('../middleware/auth');
+const validate = require('../middleware/validate');
+const {
+  clientFeedbackSchema,
+  employeeFeedbackSchema,
+} = require('../validation/feedback');
+
+const router = express.Router();
+
+router.post('/feedback/client', auth, validate(clientFeedbackSchema), submitClientFeedbackHandler);
+router.post('/feedback/employee', auth, validate(employeeFeedbackSchema), submitEmployeeFeedbackHandler);
+router.get('/:agencyId/quality/scores', auth, getQualityScoresHandler);
+
+module.exports = router;

--- a/backend/services/feedback.js
+++ b/backend/services/feedback.js
@@ -1,0 +1,47 @@
+const feedbackModel = require('../models/feedback');
+const logger = require('../utils/logger');
+
+async function submitClientFeedback(data) {
+  const record = feedbackModel.addClientFeedback(data);
+  logger.info('Client feedback submitted', { agencyId: data.agencyId, clientId: data.clientId });
+  return record;
+}
+
+async function submitEmployeeFeedback(data) {
+  const record = feedbackModel.addEmployeeFeedback(data);
+  logger.info('Employee feedback submitted', { agencyId: data.agencyId, employeeId: data.employeeId });
+  return record;
+}
+
+async function getQualityScores(agencyId) {
+  const clientFeedbacks = feedbackModel.getClientFeedbackByAgency(agencyId);
+  const employeeFeedbacks = feedbackModel.getEmployeeFeedbackByAgency(agencyId);
+
+  const average = arr => (arr.length ? arr.reduce((sum, f) => sum + f.rating, 0) / arr.length : 0);
+  const clientAvg = average(clientFeedbacks);
+  const employeeAvg = average(employeeFeedbacks);
+  const totalCount = clientFeedbacks.length + employeeFeedbacks.length;
+  const overallRating = totalCount
+    ? ((clientAvg * clientFeedbacks.length) + (employeeAvg * employeeFeedbacks.length)) / totalCount
+    : 0;
+
+  logger.info('Quality scores retrieved', { agencyId });
+  return {
+    agencyId,
+    clientFeedback: {
+      count: clientFeedbacks.length,
+      averageRating: clientAvg,
+    },
+    employeeFeedback: {
+      count: employeeFeedbacks.length,
+      averageRating: employeeAvg,
+    },
+    overallRating,
+  };
+}
+
+module.exports = {
+  submitClientFeedback,
+  submitEmployeeFeedback,
+  getQualityScores,
+};

--- a/backend/validation/feedback.js
+++ b/backend/validation/feedback.js
@@ -1,0 +1,20 @@
+const Joi = require('joi');
+
+const clientFeedbackSchema = Joi.object({
+  agencyId: Joi.string().required(),
+  clientId: Joi.string().required(),
+  rating: Joi.number().integer().min(1).max(5).required(),
+  comment: Joi.string().max(1000).allow('', null),
+});
+
+const employeeFeedbackSchema = Joi.object({
+  agencyId: Joi.string().required(),
+  employeeId: Joi.string().required(),
+  rating: Joi.number().integer().min(1).max(5).required(),
+  comment: Joi.string().max(1000).allow('', null),
+});
+
+module.exports = {
+  clientFeedbackSchema,
+  employeeFeedbackSchema,
+};


### PR DESCRIPTION
## Summary
- add feedback controller, service, model, route, and validation to capture client and employee feedback and retrieve aggregated quality scores
- extend SQL schema with client_feedback and employee_feedback tables
- register feedback routes in app

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68923c8bf5f483209673966e5f6e27e7