### PR TITLE
feat: add financial management and forecasting module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const authRoutes = require('./routes/auth');
 const affiliateRoutes = require('./routes/affiliates');
+const financialRoutes = require('./routes/financial');
 
 const app = express();
 app.use(cors());
@@ -11,6 +12,7 @@ app.use(express.json());
 // with "/api" when integrating the backend.
 app.use('/auth', authRoutes);
 app.use('/affiliates', affiliateRoutes);
+app.use('/agency', financialRoutes);
 
 const port = process.env.PORT || 5000;
 if (require.main === module) {

--- a/backend/controllers/financial.js
+++ b/backend/controllers/financial.js
@@ -1,0 +1,29 @@
+const { getFinancialOverview, generateFinancialForecast } = require('../services/financial');
+const logger = require('../utils/logger');
+
+async function getFinancialOverviewHandler(req, res) {
+  const { agencyId } = req.params;
+  try {
+    const overview = await getFinancialOverview(agencyId);
+    res.json(overview);
+  } catch (err) {
+    logger.error('Failed to retrieve financial overview', { error: err.message, agencyId });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function generateFinancialForecastHandler(req, res) {
+  const { agencyId } = req.params;
+  try {
+    const forecast = await generateFinancialForecast(agencyId, req.body);
+    res.status(201).json(forecast);
+  } catch (err) {
+    logger.error('Failed to generate financial forecast', { error: err.message, agencyId });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  getFinancialOverviewHandler,
+  generateFinancialForecastHandler,
+};

--- a/backend/database/database.sql
+++ b/backend/database/database.sql
@@ -18,3 +18,23 @@ CREATE TABLE IF NOT EXISTS affiliate_agreements (
     agreed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Financial Module Tables
+
+CREATE TABLE IF NOT EXISTS financial_records (
+    id UUID PRIMARY KEY,
+    agency_id UUID NOT NULL,
+    type VARCHAR(20) NOT NULL CHECK (type IN ('income', 'expense')),
+    amount NUMERIC(12,2) NOT NULL,
+    description VARCHAR(255),
+    recorded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS financial_forecasts (
+    id UUID PRIMARY KEY,
+    agency_id UUID NOT NULL,
+    month DATE NOT NULL,
+    projected_revenue NUMERIC(12,2) NOT NULL,
+    projected_expense NUMERIC(12,2) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/backend/models/financial.js
+++ b/backend/models/financial.js
@@ -1,0 +1,70 @@
+const { randomUUID } = require('crypto');
+
+// In-memory data store for financial transactions keyed by agency ID.
+// Each transaction: { id, type: 'income' | 'expense', amount, description, date }
+const financialData = new Map();
+
+function addTransaction(agencyId, { type, amount, description, date = new Date() }) {
+  if (!['income', 'expense'].includes(type)) {
+    throw new Error('Invalid transaction type');
+  }
+  const transaction = {
+    id: randomUUID(),
+    type,
+    amount,
+    description: description || null,
+    date: new Date(date),
+  };
+  if (!financialData.has(agencyId)) {
+    financialData.set(agencyId, []);
+  }
+  financialData.get(agencyId).push(transaction);
+  return transaction;
+}
+
+function getTransactions(agencyId) {
+  return financialData.get(agencyId) || [];
+}
+
+function calculateOverview(agencyId) {
+  const transactions = getTransactions(agencyId);
+  const earnings = transactions
+    .filter(t => t.type === 'income')
+    .reduce((sum, t) => sum + t.amount, 0);
+  const expenses = transactions
+    .filter(t => t.type === 'expense')
+    .reduce((sum, t) => sum + t.amount, 0);
+  return { earnings, expenses, net: earnings - expenses };
+}
+
+function getMonthlyAggregates(agencyId) {
+  const transactions = getTransactions(agencyId);
+  const monthly = new Map();
+
+  for (const t of transactions) {
+    const month = new Date(t.date).toISOString().slice(0, 7); // YYYY-MM
+    if (!monthly.has(month)) {
+      monthly.set(month, { revenue: 0, expense: 0 });
+    }
+    const data = monthly.get(month);
+    if (t.type === 'income') {
+      data.revenue += t.amount;
+    } else {
+      data.expense += t.amount;
+    }
+  }
+
+  return Array.from(monthly.entries()).map(([month, data]) => ({
+    month,
+    revenue: data.revenue,
+    expense: data.expense,
+    net: data.revenue - data.expense,
+  }));
+}
+
+module.exports = {
+  addTransaction,
+  getTransactions,
+  calculateOverview,
+  getMonthlyAggregates,
+};

--- a/backend/routes/financial.js
+++ b/backend/routes/financial.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const {
+  getFinancialOverviewHandler,
+  generateFinancialForecastHandler,
+} = require('../controllers/financial');
+const auth = require('../middleware/auth');
+const validate = require('../middleware/validate');
+const { forecastSchema } = require('../validation/financial');
+
+const router = express.Router();
+
+router.get('/:agencyId/financial/overview', auth, getFinancialOverviewHandler);
+router.post(
+  '/:agencyId/financial/forecast',
+  auth,
+  validate(forecastSchema),
+  generateFinancialForecastHandler
+);
+
+module.exports = router;

--- a/backend/services/financial.js
+++ b/backend/services/financial.js
@@ -1,0 +1,50 @@
+const logger = require('../utils/logger');
+const financialModel = require('../models/financial');
+
+async function getFinancialOverview(agencyId) {
+  const overview = financialModel.calculateOverview(agencyId);
+  logger.info('Retrieved financial overview', { agencyId });
+  return overview;
+}
+
+async function generateFinancialForecast(agencyId, { months, projectedContracts = [], projectedExpenses = [] }) {
+  const aggregates = financialModel.getMonthlyAggregates(agencyId);
+  const avgRevenue = aggregates.length
+    ? aggregates.reduce((sum, m) => sum + m.revenue, 0) / aggregates.length
+    : 0;
+  const avgExpense = aggregates.length
+    ? aggregates.reduce((sum, m) => sum + m.expense, 0) / aggregates.length
+    : 0;
+
+  const totalContractValue = projectedContracts.reduce((sum, c) => sum + c.value, 0);
+  const totalAdditionalExpense = projectedExpenses.reduce((sum, e) => sum + e.amount, 0);
+
+  const monthlyContractRevenue = months > 0 ? totalContractValue / months : 0;
+  const monthlyAdditionalExpense = months > 0 ? totalAdditionalExpense / months : 0;
+
+  const forecast = [];
+  for (let i = 1; i <= months; i++) {
+    const projectedRevenue = avgRevenue + monthlyContractRevenue;
+    const projectedExpense = avgExpense + monthlyAdditionalExpense;
+    const projectedNet = projectedRevenue - projectedExpense;
+    forecast.push({
+      month: i,
+      projectedRevenue,
+      projectedExpense,
+      projectedNet,
+    });
+  }
+
+  logger.info('Generated financial forecast', { agencyId, months });
+  return {
+    forecast,
+    assumptions: {
+      avgRevenue,
+      avgExpense,
+      monthlyContractRevenue,
+      monthlyAdditionalExpense,
+    },
+  };
+}
+
+module.exports = { getFinancialOverview, generateFinancialForecast };

--- a/backend/validation/financial.js
+++ b/backend/validation/financial.js
@@ -1,0 +1,13 @@
+const Joi = require('joi');
+
+const forecastSchema = Joi.object({
+  months: Joi.number().integer().min(1).max(60).required(),
+  projectedContracts: Joi.array()
+    .items(Joi.object({ value: Joi.number().positive().required() }))
+    .default([]),
+  projectedExpenses: Joi.array()
+    .items(Joi.object({ amount: Joi.number().positive().required() }))
+    .default([]),
+});
+
+module.exports = { forecastSchema };


### PR DESCRIPTION
## Summary
- add financial controller, model, service, route and validation for agency financial overview and forecasting
- define SQL tables for financial records and forecast results
- wire financial routes into application server

## Testing
- `npm test`
- `node backend/app.js`

------
https://chatgpt.com/codex/tasks/task_e_68923c9c262c832095faddfe593fb242