### PR TITLE
Add training module for HR

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const authRoutes = require('./routes/auth');
 const affiliateRoutes = require('./routes/affiliates');
+const trainingRoutes = require('./routes/training');
 
 const app = express();
 app.use(cors());
@@ -11,6 +12,7 @@ app.use(express.json());
 // with "/api" when integrating the backend.
 app.use('/auth', authRoutes);
 app.use('/affiliates', affiliateRoutes);
+app.use('/hr/training', trainingRoutes);
 
 const port = process.env.PORT || 5000;
 if (require.main === module) {

--- a/backend/controllers/training.js
+++ b/backend/controllers/training.js
@@ -1,0 +1,39 @@
+const {
+  scheduleSession,
+  listAllSessions,
+  recordSessionAttendance,
+} = require('../services/training');
+const logger = require('../utils/logger');
+
+async function scheduleSessionHandler(req, res) {
+  try {
+    const session = await scheduleSession(req.body);
+    res.status(201).json(session);
+  } catch (err) {
+    logger.error('Failed to schedule training session', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function listSessionsHandler(req, res) {
+  const sessions = await listAllSessions();
+  res.json(sessions);
+}
+
+async function recordAttendanceHandler(req, res) {
+  const { sessionId } = req.params;
+  const { userId } = req.body;
+  try {
+    const record = await recordSessionAttendance(sessionId, userId);
+    res.status(201).json(record);
+  } catch (err) {
+    logger.error('Failed to record training attendance', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  scheduleSessionHandler,
+  listSessionsHandler,
+  recordAttendanceHandler,
+};

--- a/backend/database/database.sql
+++ b/backend/database/database.sql
@@ -18,3 +18,21 @@ CREATE TABLE IF NOT EXISTS affiliate_agreements (
     agreed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Training Module Tables
+
+CREATE TABLE IF NOT EXISTS training_sessions (
+    id UUID PRIMARY KEY,
+    title VARCHAR(200) NOT NULL,
+    description TEXT,
+    scheduled_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS training_attendance (
+    id UUID PRIMARY KEY,
+    session_id UUID NOT NULL REFERENCES training_sessions(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL,
+    attended_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/backend/models/training.js
+++ b/backend/models/training.js
@@ -1,0 +1,54 @@
+const { randomUUID } = require('crypto');
+
+const sessions = new Map();
+const attendanceRecords = [];
+
+function createSession({ title, description, scheduledAt }) {
+  const id = randomUUID();
+  const timestamp = new Date();
+  const session = {
+    id,
+    title,
+    description: description || null,
+    scheduledAt: new Date(scheduledAt),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  sessions.set(id, session);
+  return session;
+}
+
+function listSessions() {
+  return Array.from(sessions.values());
+}
+
+function getSessionById(id) {
+  return sessions.get(id);
+}
+
+function recordAttendance(sessionId, userId) {
+  const session = sessions.get(sessionId);
+  if (!session) return null;
+
+  const already = attendanceRecords.find(
+    (r) => r.sessionId === sessionId && r.userId === userId
+  );
+  if (already) return already;
+
+  const record = {
+    id: randomUUID(),
+    sessionId,
+    userId,
+    attendedAt: new Date(),
+  };
+  attendanceRecords.push(record);
+  return record;
+}
+
+module.exports = {
+  createSession,
+  listSessions,
+  getSessionById,
+  recordAttendance,
+};
+

--- a/backend/routes/training.js
+++ b/backend/routes/training.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const {
+  scheduleSessionHandler,
+  listSessionsHandler,
+  recordAttendanceHandler,
+} = require('../controllers/training');
+const auth = require('../middleware/auth');
+const validate = require('../middleware/validate');
+const {
+  scheduleSessionSchema,
+  attendanceSchema,
+} = require('../validation/training');
+
+const router = express.Router();
+
+router.post('/sessions', auth, validate(scheduleSessionSchema), scheduleSessionHandler);
+router.get('/sessions', auth, listSessionsHandler);
+router.post('/attendance/:sessionId', auth, validate(attendanceSchema), recordAttendanceHandler);
+
+module.exports = router;

--- a/backend/services/training.js
+++ b/backend/services/training.js
@@ -1,0 +1,28 @@
+const logger = require('../utils/logger');
+const trainingModel = require('../models/training');
+
+async function scheduleSession(data) {
+  const session = trainingModel.createSession(data);
+  logger.info('Training session scheduled', { sessionId: session.id });
+  return session;
+}
+
+async function listAllSessions() {
+  return trainingModel.listSessions();
+}
+
+async function recordSessionAttendance(sessionId, userId) {
+  const session = trainingModel.getSessionById(sessionId);
+  if (!session) {
+    throw new Error('Training session not found');
+  }
+  const record = trainingModel.recordAttendance(sessionId, userId);
+  logger.info('Training attendance recorded', { sessionId, userId });
+  return record;
+}
+
+module.exports = {
+  scheduleSession,
+  listAllSessions,
+  recordSessionAttendance,
+};

--- a/backend/validation/training.js
+++ b/backend/validation/training.js
@@ -1,0 +1,16 @@
+const Joi = require('joi');
+
+const scheduleSessionSchema = Joi.object({
+  title: Joi.string().min(3).max(200).required(),
+  description: Joi.string().max(1000).optional(),
+  scheduledAt: Joi.date().iso().required(),
+});
+
+const attendanceSchema = Joi.object({
+  userId: Joi.string().required(),
+});
+
+module.exports = {
+  scheduleSessionSchema,
+  attendanceSchema,
+};


### PR DESCRIPTION
## Summary
- add in-memory training session and attendance models with service layer
- expose `/hr/training` routes to schedule sessions, list sessions, and record attendance
- extend database schema for training tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923ca75b248320a41a1eeec3f588d3