### PR TITLE
feat: add agency analytics module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const authRoutes = require('./routes/auth');
 const affiliateRoutes = require('./routes/affiliates');
+const agencyAnalyticsRoutes = require('./routes/agencyAnalytics');
 
 const app = express();
 app.use(cors());
@@ -11,6 +12,7 @@ app.use(express.json());
 // with "/api" when integrating the backend.
 app.use('/auth', authRoutes);
 app.use('/affiliates', affiliateRoutes);
+app.use('/analytics', agencyAnalyticsRoutes);
 
 const port = process.env.PORT || 5000;
 if (require.main === module) {

--- a/backend/controllers/agencyAnalytics.js
+++ b/backend/controllers/agencyAnalytics.js
@@ -1,0 +1,17 @@
+const { getAgencyAnalytics } = require('../services/agencyAnalytics');
+const logger = require('../utils/logger');
+
+async function getAgencyAnalyticsHandler(req, res) {
+  const { agencyId } = req.params;
+  try {
+    const analytics = await getAgencyAnalytics(agencyId);
+    res.json(analytics);
+  } catch (err) {
+    logger.error('Failed to fetch agency analytics', { error: err.message, agencyId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  getAgencyAnalyticsHandler,
+};

--- a/backend/controllers/auth.js
+++ b/backend/controllers/auth.js
@@ -1,9 +1,9 @@
 const { register, login, verifyToken } = require('../services/auth');
 
 async function registerHandler(req, res) {
-  const { username, password } = req.body;
+  const { username, password, role } = req.body;
   try {
-    const user = await register(username, password);
+    const user = await register(username, password, role);
     res.status(201).json(user);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -26,7 +26,7 @@ function meHandler(req, res) {
   if (!payload) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
-  res.json({ username: payload.username });
+  res.json({ username: payload.username, role: payload.role });
 }
 
 module.exports = { registerHandler, loginHandler, meHandler };

--- a/backend/database/database.sql
+++ b/backend/database/database.sql
@@ -18,3 +18,14 @@ CREATE TABLE IF NOT EXISTS affiliate_agreements (
     agreed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Agency Analytics Module Tables
+
+CREATE TABLE IF NOT EXISTS agency_analytics (
+    id UUID PRIMARY KEY,
+    agency_id UUID NOT NULL,
+    metrics JSONB NOT NULL,
+    calculated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_agency_analytics_agency_id ON agency_analytics(agency_id);
+

--- a/backend/middleware/authorize.js
+++ b/backend/middleware/authorize.js
@@ -1,0 +1,12 @@
+const logger = require('../utils/logger');
+
+module.exports = (allowedRoles = []) => {
+  return (req, res, next) => {
+    const userRole = req.user?.role;
+    if (!userRole || !allowedRoles.includes(userRole)) {
+      logger.error('Forbidden access', { user: req.user?.username, requiredRoles: allowedRoles });
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+};

--- a/backend/models/agencyAnalytics.js
+++ b/backend/models/agencyAnalytics.js
@@ -1,0 +1,23 @@
+const { randomUUID } = require('crypto');
+
+const analyticsStore = new Map();
+
+function saveAnalytics(agencyId, metrics) {
+  const record = {
+    id: randomUUID(),
+    agencyId,
+    metrics,
+    calculatedAt: new Date(),
+  };
+  analyticsStore.set(agencyId, record);
+  return record;
+}
+
+function getAnalytics(agencyId) {
+  return analyticsStore.get(agencyId);
+}
+
+module.exports = {
+  saveAnalytics,
+  getAnalytics,
+};

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -4,8 +4,8 @@ function findUser(username) {
   return users.find(u => u.username === username);
 }
 
-function addUser(user) {
-  users.push(user);
+function addUser({ username, password, role = 'user' }) {
+  users.push({ username, password, role });
 }
 
 module.exports = { users, findUser, addUser };

--- a/backend/routes/agencyAnalytics.js
+++ b/backend/routes/agencyAnalytics.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const { getAgencyAnalyticsHandler } = require('../controllers/agencyAnalytics');
+const auth = require('../middleware/auth');
+const authorize = require('../middleware/authorize');
+const validate = require('../middleware/validate');
+const { agencyIdParamSchema } = require('../validation/agencyAnalytics');
+
+const router = express.Router();
+
+router.get('/:agencyId', auth, authorize(['admin', 'agency-manager']), validate(agencyIdParamSchema, 'params'), getAgencyAnalyticsHandler);
+
+module.exports = router;

--- a/backend/services/agencyAnalytics.js
+++ b/backend/services/agencyAnalytics.js
@@ -1,0 +1,22 @@
+const logger = require('../utils/logger');
+const agencyAnalyticsModel = require('../models/agencyAnalytics');
+
+async function getAgencyAnalytics(agencyId) {
+  const analytics = agencyAnalyticsModel.getAnalytics(agencyId);
+  if (!analytics) {
+    throw new Error('Agency analytics not found');
+  }
+  logger.info('Agency analytics retrieved', { agencyId });
+  return analytics;
+}
+
+async function saveAgencyAnalytics(agencyId, metrics) {
+  const record = agencyAnalyticsModel.saveAnalytics(agencyId, metrics);
+  logger.info('Agency analytics saved', { agencyId });
+  return record;
+}
+
+module.exports = {
+  getAgencyAnalytics,
+  saveAgencyAnalytics,
+};

--- a/backend/services/auth.js
+++ b/backend/services/auth.js
@@ -4,15 +4,14 @@ const { findUser, addUser } = require('../models/user');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
 
-async function register(username, password) {
+async function register(username, password, role = 'user') {
   const existing = findUser(username);
   if (existing) {
     throw new Error('User already exists');
   }
   const hashed = await bcrypt.hash(password, 10);
-  const user = { username, password: hashed };
-  addUser(user);
-  return { username };
+  addUser({ username, password: hashed, role });
+  return { username, role };
 }
 
 async function login(username, password) {
@@ -24,7 +23,7 @@ async function login(username, password) {
   if (!match) {
     throw new Error('Invalid credentials');
   }
-  const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: '1h' });
+  const token = jwt.sign({ username, role: user.role }, JWT_SECRET, { expiresIn: '1h' });
   return { token };
 }
 

--- a/backend/validation/agencyAnalytics.js
+++ b/backend/validation/agencyAnalytics.js
@@ -1,0 +1,9 @@
+const Joi = require('joi');
+
+const agencyIdParamSchema = Joi.object({
+  agencyId: Joi.string().guid({ version: 'uuidv4' }).required(),
+});
+
+module.exports = {
+  agencyIdParamSchema,
+};


### PR DESCRIPTION
## Summary
- add agency analytics endpoint with role-based authorization
- support roles in authentication
- define agency analytics table

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68923ccca4fc83209eefcf2223176f27