### PR TITLE
feat: add AI analytics module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const authRoutes = require('./routes/auth');
 const affiliateRoutes = require('./routes/affiliates');
+const aiAnalyticsRoutes = require('./routes/aiAnalytics');
 
 const app = express();
 app.use(cors());
@@ -11,6 +12,7 @@ app.use(express.json());
 // with "/api" when integrating the backend.
 app.use('/auth', authRoutes);
 app.use('/affiliates', affiliateRoutes);
+app.use('/ai-analytics', aiAnalyticsRoutes);
 
 const port = process.env.PORT || 5000;
 if (require.main === module) {

--- a/backend/controllers/aiAnalytics.js
+++ b/backend/controllers/aiAnalytics.js
@@ -1,0 +1,29 @@
+const { getInsights, getRecommendations } = require('../services/aiAnalytics');
+const logger = require('../utils/logger');
+
+async function insightsHandler(req, res) {
+  const { domain } = req.params;
+  try {
+    const insights = await getInsights(domain);
+    res.json({ domain, insights });
+  } catch (err) {
+    logger.error('Failed to fetch AI insights', { error: err.message, domain });
+    res.status(500).json({ error: 'Failed to fetch insights' });
+  }
+}
+
+async function recommendationsHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const recommendations = await getRecommendations(userId);
+    res.json({ userId, recommendations });
+  } catch (err) {
+    logger.error('Failed to fetch AI recommendations', { error: err.message, userId });
+    res.status(500).json({ error: 'Failed to fetch recommendations' });
+  }
+}
+
+module.exports = {
+  insightsHandler,
+  recommendationsHandler,
+};

--- a/backend/database/ai_analytics.sql
+++ b/backend/database/ai_analytics.sql
@@ -1,0 +1,15 @@
+-- AI Analytics Module Tables
+
+CREATE TABLE IF NOT EXISTS ai_insights (
+    id UUID PRIMARY KEY,
+    domain VARCHAR(50) NOT NULL,
+    insight JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS ai_recommendations (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    recommendation JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/middleware/authorize.js
+++ b/backend/middleware/authorize.js
@@ -1,0 +1,18 @@
+const logger = require('../utils/logger');
+
+/**
+ * Middleware to authorize users based on role.
+ * @param {...string} allowedRoles - Roles permitted to access the route.
+ */
+module.exports = (...allowedRoles) => {
+  return (req, res, next) => {
+    const userRoles = req.user?.roles || [];
+    const rolesArray = Array.isArray(userRoles) ? userRoles : [userRoles];
+    const permitted = rolesArray.some(role => allowedRoles.includes(role));
+    if (!permitted) {
+      logger.error('Access denied', { user: req.user?.username, requiredRoles: allowedRoles });
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+};

--- a/backend/models/aiAnalytics.js
+++ b/backend/models/aiAnalytics.js
@@ -1,0 +1,35 @@
+const { randomUUID } = require('crypto');
+
+const insights = [];
+const recommendations = [];
+
+function seedData() {
+  if (insights.length === 0) {
+    insights.push(
+      { id: randomUUID(), domain: 'employment', insight: { trend: 'remote work increase', score: 0.87 }, createdAt: new Date() },
+      { id: randomUUID(), domain: 'freelance', insight: { trend: 'gig economy growth', score: 0.76 }, createdAt: new Date() },
+      { id: randomUUID(), domain: 'education', insight: { trend: 'online learning adoption', score: 0.92 }, createdAt: new Date() }
+    );
+  }
+  if (recommendations.length === 0) {
+    recommendations.push(
+      { id: randomUUID(), userId: 'user-1', recommendations: ['Take AI course', 'Update portfolio'], createdAt: new Date() },
+      { id: randomUUID(), userId: 'user-2', recommendations: ['Apply for remote jobs', 'Join freelancer community'], createdAt: new Date() }
+    );
+  }
+}
+
+seedData();
+
+function findInsightsByDomain(domain) {
+  return insights.filter(i => i.domain === domain);
+}
+
+function findRecommendationsByUser(userId) {
+  return recommendations.filter(r => r.userId === userId);
+}
+
+module.exports = {
+  findInsightsByDomain,
+  findRecommendationsByUser,
+};

--- a/backend/routes/aiAnalytics.js
+++ b/backend/routes/aiAnalytics.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const { insightsHandler, recommendationsHandler } = require('../controllers/aiAnalytics');
+const auth = require('../middleware/auth');
+const authorize = require('../middleware/authorize');
+const validate = require('../middleware/validate');
+const { insightsParamsSchema, recommendationsParamsSchema } = require('../validation/aiAnalytics');
+
+const router = express.Router();
+
+router.get('/insights/:domain', auth, authorize('admin', 'analyst'), validate(insightsParamsSchema, 'params'), insightsHandler);
+router.get('/recommendations/:userId', auth, authorize('admin', 'manager', 'user'), validate(recommendationsParamsSchema, 'params'), recommendationsHandler);
+
+module.exports = router;

--- a/backend/services/aiAnalytics.js
+++ b/backend/services/aiAnalytics.js
@@ -1,0 +1,19 @@
+const logger = require('../utils/logger');
+const model = require('../models/aiAnalytics');
+
+async function getInsights(domain) {
+  const data = model.findInsightsByDomain(domain);
+  logger.info('AI insights retrieved', { domain, count: data.length });
+  return data;
+}
+
+async function getRecommendations(userId) {
+  const data = model.findRecommendationsByUser(userId);
+  logger.info('AI recommendations retrieved', { userId, count: data.length });
+  return data;
+}
+
+module.exports = {
+  getInsights,
+  getRecommendations,
+};

--- a/backend/validation/aiAnalytics.js
+++ b/backend/validation/aiAnalytics.js
@@ -1,0 +1,14 @@
+const Joi = require('joi');
+
+const insightsParamsSchema = Joi.object({
+  domain: Joi.string().valid('employment', 'freelance', 'education').required(),
+});
+
+const recommendationsParamsSchema = Joi.object({
+  userId: Joi.string().required(),
+});
+
+module.exports = {
+  insightsParamsSchema,
+  recommendationsParamsSchema,
+};


### PR DESCRIPTION
## Summary
- add AI analytics controller, service, model, routes, validation
- introduce authorize middleware and SQL schema
- mount AI analytics endpoints in express app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923cd864408320b817c04a86aae36f