### PR TITLE
feat: add financial analytics module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const authRoutes = require('./routes/auth');
 const affiliateRoutes = require('./routes/affiliates');
+const financialAnalyticsRoutes = require('./routes/financialAnalytics');
 
 const app = express();
 app.use(cors());
@@ -11,6 +12,7 @@ app.use(express.json());
 // with "/api" when integrating the backend.
 app.use('/auth', authRoutes);
 app.use('/affiliates', affiliateRoutes);
+app.use('/financial-analytics', financialAnalyticsRoutes);
 
 const port = process.env.PORT || 5000;
 if (require.main === module) {

--- a/backend/controllers/auth.js
+++ b/backend/controllers/auth.js
@@ -1,9 +1,9 @@
 const { register, login, verifyToken } = require('../services/auth');
 
 async function registerHandler(req, res) {
-  const { username, password } = req.body;
+  const { username, password, role } = req.body;
   try {
-    const user = await register(username, password);
+    const user = await register(username, password, role);
     res.status(201).json(user);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -26,7 +26,7 @@ function meHandler(req, res) {
   if (!payload) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
-  res.json({ username: payload.username });
+  res.json({ username: payload.username, role: payload.role });
 }
 
 module.exports = { registerHandler, loginHandler, meHandler };

--- a/backend/controllers/financialAnalytics.js
+++ b/backend/controllers/financialAnalytics.js
@@ -1,0 +1,54 @@
+const {
+  getOverview,
+  getRevenueAnalytics,
+  getExpenseAnalytics,
+  getCryptoAnalytics,
+} = require('../services/financialAnalytics');
+const logger = require('../utils/logger');
+
+async function overviewHandler(req, res) {
+  try {
+    const data = await getOverview(req.query);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to retrieve financial overview', { error: err.message });
+    res.status(500).json({ error: 'Unable to retrieve financial overview' });
+  }
+}
+
+async function revenueHandler(req, res) {
+  try {
+    const data = await getRevenueAnalytics(req.query);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to retrieve revenue analytics', { error: err.message });
+    res.status(500).json({ error: 'Unable to retrieve revenue analytics' });
+  }
+}
+
+async function expensesHandler(req, res) {
+  try {
+    const data = await getExpenseAnalytics(req.query);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to retrieve expense analytics', { error: err.message });
+    res.status(500).json({ error: 'Unable to retrieve expense analytics' });
+  }
+}
+
+async function cryptoTransactionsHandler(req, res) {
+  try {
+    const data = await getCryptoAnalytics(req.query);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to retrieve crypto transaction analytics', { error: err.message });
+    res.status(500).json({ error: 'Unable to retrieve crypto transaction analytics' });
+  }
+}
+
+module.exports = {
+  overviewHandler,
+  revenueHandler,
+  expensesHandler,
+  cryptoTransactionsHandler,
+};

--- a/backend/database/database.sql
+++ b/backend/database/database.sql
@@ -18,3 +18,27 @@ CREATE TABLE IF NOT EXISTS affiliate_agreements (
     agreed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Financial Analytics Module Tables
+
+CREATE TABLE IF NOT EXISTS financial_revenues (
+    id UUID PRIMARY KEY,
+    source VARCHAR(100) NOT NULL,
+    amount NUMERIC(12, 2) NOT NULL,
+    recorded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS financial_expenses (
+    id UUID PRIMARY KEY,
+    category VARCHAR(100) NOT NULL,
+    amount NUMERIC(12, 2) NOT NULL,
+    recorded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS crypto_transactions (
+    id UUID PRIMARY KEY,
+    currency VARCHAR(20) NOT NULL,
+    amount NUMERIC(18, 8) NOT NULL,
+    value_usd NUMERIC(12, 2) NOT NULL,
+    recorded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/backend/middleware/authorize.js
+++ b/backend/middleware/authorize.js
@@ -1,0 +1,13 @@
+const logger = require('../utils/logger');
+
+// Middleware to check if authenticated user has required role(s)
+module.exports = (...allowedRoles) => {
+  return (req, res, next) => {
+    const role = req.user?.role;
+    if (!role || !allowedRoles.includes(role)) {
+      logger.error('Access denied', { requiredRoles: allowedRoles, userRole: role });
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+};

--- a/backend/models/financialAnalytics.js
+++ b/backend/models/financialAnalytics.js
@@ -1,0 +1,54 @@
+const { randomUUID } = require('crypto');
+
+// In-memory mock data for demonstration purposes
+const revenues = [
+  { id: randomUUID(), amount: 10000, source: 'product sales', recordedAt: new Date('2024-01-15') },
+  { id: randomUUID(), amount: 20000, source: 'services', recordedAt: new Date('2024-02-10') },
+];
+
+const expenses = [
+  { id: randomUUID(), amount: 5000, category: 'marketing', recordedAt: new Date('2024-01-20') },
+  { id: randomUUID(), amount: 3000, category: 'operations', recordedAt: new Date('2024-02-05') },
+];
+
+const cryptoTransactions = [
+  { id: randomUUID(), amount: 0.5, currency: 'BTC', valueUSD: 15000, recordedAt: new Date('2024-02-01') },
+  { id: randomUUID(), amount: 10, currency: 'ETH', valueUSD: 25000, recordedAt: new Date('2024-02-07') },
+];
+
+function filterByDate(data, startDate, endDate) {
+  return data.filter(item => {
+    const date = new Date(item.recordedAt);
+    if (startDate && date < new Date(startDate)) return false;
+    if (endDate && date > new Date(endDate)) return false;
+    return true;
+  });
+}
+
+function getRevenues(range = {}) {
+  return filterByDate(revenues, range.startDate, range.endDate);
+}
+
+function getExpenses(range = {}) {
+  return filterByDate(expenses, range.startDate, range.endDate);
+}
+
+function getCryptoTransactions(range = {}) {
+  return filterByDate(cryptoTransactions, range.startDate, range.endDate);
+}
+
+function getOverview(range = {}) {
+  const rev = getRevenues(range);
+  const exp = getExpenses(range);
+  const totalRevenue = rev.reduce((sum, r) => sum + r.amount, 0);
+  const totalExpenses = exp.reduce((sum, e) => sum + e.amount, 0);
+  const net = totalRevenue - totalExpenses;
+  return { totalRevenue, totalExpenses, net };
+}
+
+module.exports = {
+  getRevenues,
+  getExpenses,
+  getCryptoTransactions,
+  getOverview,
+};

--- a/backend/routes/financialAnalytics.js
+++ b/backend/routes/financialAnalytics.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const {
+  overviewHandler,
+  revenueHandler,
+  expensesHandler,
+  cryptoTransactionsHandler,
+} = require('../controllers/financialAnalytics');
+const auth = require('../middleware/auth');
+const authorize = require('../middleware/authorize');
+const validate = require('../middleware/validate');
+const { dateRangeSchema } = require('../validation/financialAnalytics');
+
+const router = express.Router();
+
+router.get('/overview', auth, authorize('admin', 'finance-manager'), validate(dateRangeSchema, 'query'), overviewHandler);
+router.get('/revenue', auth, authorize('admin', 'finance-manager'), validate(dateRangeSchema, 'query'), revenueHandler);
+router.get('/expenses', auth, authorize('admin', 'finance-manager'), validate(dateRangeSchema, 'query'), expensesHandler);
+router.get('/crypto-transactions', auth, authorize('admin', 'finance-manager'), validate(dateRangeSchema, 'query'), cryptoTransactionsHandler);
+
+module.exports = router;

--- a/backend/services/auth.js
+++ b/backend/services/auth.js
@@ -4,15 +4,15 @@ const { findUser, addUser } = require('../models/user');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
 
-async function register(username, password) {
+async function register(username, password, role = 'user') {
   const existing = findUser(username);
   if (existing) {
     throw new Error('User already exists');
   }
   const hashed = await bcrypt.hash(password, 10);
-  const user = { username, password: hashed };
+  const user = { username, password: hashed, role };
   addUser(user);
-  return { username };
+  return { username, role };
 }
 
 async function login(username, password) {
@@ -24,7 +24,7 @@ async function login(username, password) {
   if (!match) {
     throw new Error('Invalid credentials');
   }
-  const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: '1h' });
+  const token = jwt.sign({ username, role: user.role }, JWT_SECRET, { expiresIn: '1h' });
   return { token };
 }
 

--- a/backend/services/financialAnalytics.js
+++ b/backend/services/financialAnalytics.js
@@ -1,0 +1,36 @@
+const logger = require('../utils/logger');
+const model = require('../models/financialAnalytics');
+
+async function getOverview(range) {
+  const overview = model.getOverview(range);
+  logger.info('Retrieved financial overview', { range });
+  return overview;
+}
+
+async function getRevenueAnalytics(range) {
+  const records = model.getRevenues(range);
+  const total = records.reduce((sum, r) => sum + r.amount, 0);
+  logger.info('Retrieved revenue analytics', { count: records.length });
+  return { total, records };
+}
+
+async function getExpenseAnalytics(range) {
+  const records = model.getExpenses(range);
+  const total = records.reduce((sum, e) => sum + e.amount, 0);
+  logger.info('Retrieved expense analytics', { count: records.length });
+  return { total, records };
+}
+
+async function getCryptoAnalytics(range) {
+  const records = model.getCryptoTransactions(range);
+  const totalValueUSD = records.reduce((sum, t) => sum + t.valueUSD, 0);
+  logger.info('Retrieved crypto transaction analytics', { count: records.length });
+  return { totalValueUSD, records };
+}
+
+module.exports = {
+  getOverview,
+  getRevenueAnalytics,
+  getExpenseAnalytics,
+  getCryptoAnalytics,
+};

--- a/backend/validation/financialAnalytics.js
+++ b/backend/validation/financialAnalytics.js
@@ -1,0 +1,13 @@
+const Joi = require('joi');
+
+const dateRangeSchema = Joi.object({
+  startDate: Joi.date().iso().optional(),
+  endDate: Joi.date().iso().optional(),
+}).custom((value, helpers) => {
+  if (value.startDate && value.endDate && value.startDate > value.endDate) {
+    return helpers.error('any.invalid');
+  }
+  return value;
+}, 'date range validation');
+
+module.exports = { dateRangeSchema };


### PR DESCRIPTION
## Summary
- add financial analytics routes, controllers, services, models, validation and role-based middleware
- extend auth with role support and mount financial analytics endpoints
- define financial tables in SQL schema for revenues, expenses and crypto transactions

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68923d237cc083209e530735b0adbe6a