### PR TITLE
Add employment analytics module with role-based auth

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const authRoutes = require('./routes/auth');
 const affiliateRoutes = require('./routes/affiliates');
 const paymentRoutes = require('./routes/payments');
+const employmentAnalyticsRoutes = require('./routes/employmentAnalytics');
 
 const app = express();
 app.use(cors());
@@ -13,6 +14,7 @@ app.use(express.json());
 app.use('/auth', authRoutes);
 app.use('/affiliates', affiliateRoutes);
 app.use('/agency/:agencyId/payments', paymentRoutes);
+app.use('/analytics/employment', employmentAnalyticsRoutes);
 
 const port = process.env.PORT || 5000;
 if (require.main === module) {

--- a/backend/controllers/auth.js
+++ b/backend/controllers/auth.js
@@ -1,9 +1,9 @@
 const { register, login, verifyToken } = require('../services/auth');
 
 async function registerHandler(req, res) {
-  const { username, password } = req.body;
+  const { username, password, roles } = req.body;
   try {
-    const user = await register(username, password);
+    const user = await register(username, password, roles);
     res.status(201).json(user);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -26,7 +26,7 @@ function meHandler(req, res) {
   if (!payload) {
     return res.status(401).json({ error: 'Unauthorized' });
   }
-  res.json({ username: payload.username });
+  res.json({ username: payload.username, roles: payload.roles });
 }
 
 module.exports = { registerHandler, loginHandler, meHandler };

--- a/backend/controllers/employmentAnalytics.js
+++ b/backend/controllers/employmentAnalytics.js
@@ -1,0 +1,43 @@
+const {
+  getEmploymentOverview,
+  getJobAnalytics,
+  getApplicationAnalytics,
+} = require('../services/employmentAnalytics');
+const logger = require('../utils/logger');
+
+async function overviewHandler(req, res) {
+  try {
+    const data = await getEmploymentOverview();
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch employment overview', { error: err.message });
+    res.status(500).json({ error: 'Failed to retrieve overview' });
+  }
+}
+
+async function jobAnalyticsHandler(req, res) {
+  const { jobId } = req.params;
+  try {
+    const data = await getJobAnalytics(jobId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch job analytics', { error: err.message, jobId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function applicationAnalyticsHandler(req, res) {
+  try {
+    const data = await getApplicationAnalytics();
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch application analytics', { error: err.message });
+    res.status(500).json({ error: 'Failed to retrieve analytics' });
+  }
+}
+
+module.exports = {
+  overviewHandler,
+  jobAnalyticsHandler,
+  applicationAnalyticsHandler,
+};

--- a/backend/database/database.sql
+++ b/backend/database/database.sql
@@ -40,3 +40,23 @@ CREATE TABLE IF NOT EXISTS payment_adjustments (
     reason VARCHAR(255),
     adjusted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Employment Analytics Module Tables
+
+CREATE TABLE IF NOT EXISTS employment_analytics (
+    id UUID PRIMARY KEY,
+    job_id UUID UNIQUE NOT NULL,
+    views INTEGER DEFAULT 0,
+    applications INTEGER DEFAULT 0,
+    hires INTEGER DEFAULT 0,
+    status VARCHAR(20) DEFAULT 'open',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS application_analytics (
+    id UUID PRIMARY KEY,
+    job_id UUID NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/middleware/authorize.js
+++ b/backend/middleware/authorize.js
@@ -1,0 +1,13 @@
+const logger = require('../utils/logger');
+
+module.exports = (...allowedRoles) => {
+  return (req, res, next) => {
+    const userRoles = req.user?.roles || [];
+    const authorized = allowedRoles.some(role => userRoles.includes(role));
+    if (!authorized) {
+      logger.error('Access forbidden for user', { username: req.user?.username });
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+};

--- a/backend/models/employmentAnalytics.js
+++ b/backend/models/employmentAnalytics.js
@@ -1,0 +1,80 @@
+const { randomUUID } = require('crypto');
+
+const jobs = new Map();
+const applications = [];
+
+function addJob({ title, status = 'open', views = 0, applications: appCount = 0, hires = 0 }) {
+  const id = randomUUID();
+  const job = { id, title, status, views, applications: appCount, hires };
+  jobs.set(id, job);
+  return job;
+}
+
+function recordApplication(jobId, status = 'pending') {
+  const application = {
+    id: randomUUID(),
+    jobId,
+    status,
+    appliedAt: new Date(),
+  };
+  applications.push(application);
+  const job = jobs.get(jobId);
+  if (job) {
+    job.applications += 1;
+    if (status === 'hired') {
+      job.hires += 1;
+      job.status = 'closed';
+    }
+    jobs.set(jobId, job);
+  }
+  return application;
+}
+
+function getOverview() {
+  let openJobs = 0;
+  let closedJobs = 0;
+  jobs.forEach(job => {
+    if (job.status === 'open') openJobs += 1;
+    if (job.status === 'closed') closedJobs += 1;
+  });
+  const hiredApplications = applications.filter(a => a.status === 'hired').length;
+  return {
+    totalJobs: jobs.size,
+    openJobs,
+    closedJobs,
+    totalApplications: applications.length,
+    hiredApplications,
+  };
+}
+
+function getJobStats(jobId) {
+  return jobs.get(jobId) || null;
+}
+
+function getApplicationStats() {
+  const byStatus = applications.reduce((acc, curr) => {
+    acc[curr.status] = (acc[curr.status] || 0) + 1;
+    return acc;
+  }, {});
+  return {
+    total: applications.length,
+    byStatus,
+  };
+}
+
+// Seed with sample data
+(function seed() {
+  const jobA = addJob({ title: 'Software Engineer', views: 150 });
+  const jobB = addJob({ title: 'Project Manager', status: 'closed', views: 80, hires: 1 });
+  recordApplication(jobA.id, 'pending');
+  recordApplication(jobA.id, 'hired');
+  recordApplication(jobB.id, 'rejected');
+})();
+
+module.exports = {
+  addJob,
+  recordApplication,
+  getOverview,
+  getJobStats,
+  getApplicationStats,
+};

--- a/backend/routes/employmentAnalytics.js
+++ b/backend/routes/employmentAnalytics.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const {
+  overviewHandler,
+  jobAnalyticsHandler,
+  applicationAnalyticsHandler,
+} = require('../controllers/employmentAnalytics');
+const auth = require('../middleware/auth');
+const authorize = require('../middleware/authorize');
+const validate = require('../middleware/validate');
+const { jobParamSchema } = require('../validation/employmentAnalytics');
+
+const router = express.Router({ mergeParams: true });
+
+router.get('/overview', auth, authorize('admin', 'hr-manager'), overviewHandler);
+router.get('/jobs/:jobId', auth, authorize('admin', 'hr-manager'), validate(jobParamSchema, 'params'), jobAnalyticsHandler);
+router.get('/applications', auth, authorize('admin', 'hr-manager'), applicationAnalyticsHandler);
+
+module.exports = router;

--- a/backend/services/auth.js
+++ b/backend/services/auth.js
@@ -4,15 +4,15 @@ const { findUser, addUser } = require('../models/user');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
 
-async function register(username, password) {
+async function register(username, password, roles = ['user']) {
   const existing = findUser(username);
   if (existing) {
     throw new Error('User already exists');
   }
   const hashed = await bcrypt.hash(password, 10);
-  const user = { username, password: hashed };
+  const user = { username, password: hashed, roles };
   addUser(user);
-  return { username };
+  return { username, roles };
 }
 
 async function login(username, password) {
@@ -24,7 +24,7 @@ async function login(username, password) {
   if (!match) {
     throw new Error('Invalid credentials');
   }
-  const token = jwt.sign({ username }, JWT_SECRET, { expiresIn: '1h' });
+  const token = jwt.sign({ username, roles: user.roles }, JWT_SECRET, { expiresIn: '1h' });
   return { token };
 }
 

--- a/backend/services/employmentAnalytics.js
+++ b/backend/services/employmentAnalytics.js
@@ -1,0 +1,27 @@
+const logger = require('../utils/logger');
+const model = require('../models/employmentAnalytics');
+
+async function getEmploymentOverview() {
+  logger.info('Fetching employment overview analytics');
+  return model.getOverview();
+}
+
+async function getJobAnalytics(jobId) {
+  const stats = model.getJobStats(jobId);
+  if (!stats) {
+    throw new Error('Job not found');
+  }
+  logger.info('Fetched job analytics', { jobId });
+  return stats;
+}
+
+async function getApplicationAnalytics() {
+  logger.info('Fetching application analytics');
+  return model.getApplicationStats();
+}
+
+module.exports = {
+  getEmploymentOverview,
+  getJobAnalytics,
+  getApplicationAnalytics,
+};

--- a/backend/validation/employmentAnalytics.js
+++ b/backend/validation/employmentAnalytics.js
@@ -1,0 +1,7 @@
+const Joi = require('joi');
+
+const jobParamSchema = Joi.object({
+  jobId: Joi.string().guid({ version: 'uuidv4' }).required(),
+});
+
+module.exports = { jobParamSchema };


### PR DESCRIPTION
## Summary
- add employment analytics endpoints for overview, job, and application analytics
- support role-based access via new authorize middleware and enhanced auth
- define employment analytics data models, services, and SQL tables

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923d17004483209b112f62d7253747