### PR TITLE
feat: add podcast analytics module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -30,6 +30,7 @@ const educationAnalyticsRoutes = require('./routes/educationAnalytics');
 const financialAnalyticsRoutes = require('./routes/financialAnalytics');
 const paymentRoutes = require('./routes/payments');
 const employmentAnalyticsRoutes = require('./routes/employmentAnalytics');
+const podcastAnalyticsRoutes = require('./routes/podcastAnalytics');
 
 const app = express();
 app.use(cors());
@@ -67,6 +68,7 @@ app.use('/education-analytics', educationAnalyticsRoutes);
 app.use('/financial-analytics', financialAnalyticsRoutes);
 app.use('/agency/:agencyId/payments', paymentRoutes);
 app.use('/analytics/employment', employmentAnalyticsRoutes);
+app.use('/podcast-analytics', podcastAnalyticsRoutes);
 
 // Commission rate adjustment notifications
 app.use('/affiliates/notifications', notificationRoutes);

--- a/backend/controllers/podcastAnalytics.js
+++ b/backend/controllers/podcastAnalytics.js
@@ -1,0 +1,93 @@
+const {
+  getOverview,
+  getEpisodeAnalytics,
+  getDemographics,
+  getEngagement,
+  getSeriesOverview,
+  getEpisodeDetails,
+} = require('../services/podcastAnalytics');
+const logger = require('../utils/logger');
+
+async function overviewHandler(req, res) {
+  try {
+    const data = await getOverview(req.query);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to retrieve podcast analytics overview', { error: err.message });
+    res.status(err.status || 500).json({ error: err.message });
+  }
+}
+
+async function episodeAnalyticsHandler(req, res) {
+  try {
+    const data = await getEpisodeAnalytics(req.params.episodeId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to retrieve episode analytics', {
+      error: err.message,
+      episodeId: req.params.episodeId,
+    });
+    res.status(err.status || 500).json({ error: err.message });
+  }
+}
+
+async function demographicsHandler(req, res) {
+  try {
+    const data = await getDemographics(req.params.podcastId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to retrieve podcast demographics', {
+      error: err.message,
+      podcastId: req.params.podcastId,
+    });
+    res.status(err.status || 500).json({ error: err.message });
+  }
+}
+
+async function engagementHandler(req, res) {
+  try {
+    const data = await getEngagement(req.params.podcastId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to retrieve podcast engagement metrics', {
+      error: err.message,
+      podcastId: req.params.podcastId,
+    });
+    res.status(err.status || 500).json({ error: err.message });
+  }
+}
+
+async function seriesOverviewHandler(req, res) {
+  try {
+    const data = await getSeriesOverview(req.params.seriesId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to retrieve series analytics overview', {
+      error: err.message,
+      seriesId: req.params.seriesId,
+    });
+    res.status(err.status || 500).json({ error: err.message });
+  }
+}
+
+async function episodeDetailsHandler(req, res) {
+  try {
+    const data = await getEpisodeDetails(req.params.episodeId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to retrieve detailed episode analytics', {
+      error: err.message,
+      episodeId: req.params.episodeId,
+    });
+    res.status(err.status || 500).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  overviewHandler,
+  episodeAnalyticsHandler,
+  demographicsHandler,
+  engagementHandler,
+  seriesOverviewHandler,
+  episodeDetailsHandler,
+};

--- a/backend/database/podcastAnalytics.sql
+++ b/backend/database/podcastAnalytics.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS podcast_analytics (
+  id SERIAL PRIMARY KEY,
+  podcast_id UUID NOT NULL,
+  episode_id UUID,
+  series_id UUID,
+  owner_id UUID NOT NULL,
+  listens INTEGER DEFAULT 0,
+  likes INTEGER DEFAULT 0,
+  donations INTEGER DEFAULT 0,
+  average_listen_time INTEGER DEFAULT 0,
+  demographics JSONB,
+  engagement JSONB,
+  collected_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/middleware/podcastOwnership.js
+++ b/backend/middleware/podcastOwnership.js
@@ -1,0 +1,58 @@
+const { getPodcast, getEpisode, getSeriesOverview } = require('../services/podcastAnalytics');
+const logger = require('../utils/logger');
+
+/**
+ * Ensure that a user with the 'creator' role owns the requested podcast resource.
+ * Admins and content managers bypass this check.
+ */
+module.exports = async (req, res, next) => {
+  try {
+    const user = req.user;
+    if (!user) {
+      logger.error('podcastOwnership: missing authenticated user');
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
+    const roles = Array.isArray(user.roles) ? user.roles : [user.role];
+    if (roles.includes('admin') || roles.includes('content-manager')) {
+      return next();
+    }
+
+    if (!roles.includes('creator')) {
+      logger.error('podcastOwnership: user lacks creator role', { userId: user.id });
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+
+    const { seriesId, podcastId, episodeId } = req.params;
+    const userId = user.id;
+
+    if (seriesId) {
+      const series = await getSeriesOverview(seriesId);
+      if (!series || series.ownerId !== userId) {
+        logger.error('Unauthorized series access attempt', { seriesId, userId });
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+    }
+
+    if (podcastId) {
+      const podcast = await getPodcast(podcastId);
+      if (!podcast || podcast.ownerId !== userId) {
+        logger.error('Unauthorized podcast access attempt', { podcastId, userId });
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+    }
+
+    if (episodeId) {
+      const episode = await getEpisode(episodeId);
+      if (!episode || episode.ownerId !== userId) {
+        logger.error('Unauthorized episode access attempt', { episodeId, userId });
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+    }
+
+    return next();
+  } catch (err) {
+    logger.error('podcastOwnership middleware error', { error: err.message });
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+};

--- a/backend/models/podcastAnalytics.js
+++ b/backend/models/podcastAnalytics.js
@@ -1,0 +1,117 @@
+const { randomUUID } = require('crypto');
+
+// Sample in-memory data representing analytics records
+const episodes = new Map();
+const podcasts = new Map();
+const seriesStats = new Map();
+
+const ownerId = 'user-123';
+const sampleSeriesId = randomUUID();
+const samplePodcastId = randomUUID();
+const sampleEpisodeId = randomUUID();
+
+seriesStats.set(sampleSeriesId, {
+  seriesId: sampleSeriesId,
+  ownerId,
+  listens: 5000,
+  likes: 1200,
+  donations: 300,
+  engagement: {
+    averageListenTime: 1800, // seconds
+  },
+});
+
+podcasts.set(samplePodcastId, {
+  podcastId: samplePodcastId,
+  seriesId: sampleSeriesId,
+  ownerId,
+  demographics: {
+    ageGroups: { '18-24': 40, '25-34': 35, '35-44': 25 },
+    locations: { US: 60, UK: 20, CA: 20 },
+    genders: { male: 55, female: 45 },
+  },
+  engagement: {
+    avgListenDuration: 1700,
+    completionRate: 0.75,
+    dropOffRate: 0.2,
+  },
+});
+
+episodes.set(sampleEpisodeId, {
+  episodeId: sampleEpisodeId,
+  podcastId: samplePodcastId,
+  seriesId: sampleSeriesId,
+  ownerId,
+  title: 'Episode 1',
+  listeners: 1000,
+  likes: 200,
+  comments: 50,
+  averageListenTime: 1600,
+  engagementTimeline: [
+    { timestamp: 0, listeners: 1000 },
+    { timestamp: 600, listeners: 800 },
+    { timestamp: 1200, listeners: 600 },
+  ],
+  demographics: {
+    ageGroups: { '18-24': 45, '25-34': 30, '35-44': 25 },
+    locations: { US: 50, UK: 30, CA: 20 },
+    genders: { male: 60, female: 40 },
+  },
+  dropOffRates: { '0-25%': 5, '25-50%': 10, '50-75%': 20, '75-100%': 65 },
+});
+
+function getOverview() {
+  let totalListeners = 0;
+  let totalLikes = 0;
+  episodes.forEach((ep) => {
+    totalListeners += ep.listeners;
+    totalLikes += ep.likes;
+  });
+  return {
+    totalPodcasts: podcasts.size,
+    totalEpisodes: episodes.size,
+    totalListeners,
+    totalLikes,
+  };
+}
+
+function getEpisode(episodeId) {
+  return episodes.get(episodeId);
+}
+
+function getEpisodeAnalytics(episodeId) {
+  return episodes.get(episodeId);
+}
+
+function getPodcast(podcastId) {
+  return podcasts.get(podcastId);
+}
+
+function getDemographics(podcastId) {
+  const podcast = podcasts.get(podcastId);
+  return podcast ? podcast.demographics : null;
+}
+
+function getEngagement(podcastId) {
+  const podcast = podcasts.get(podcastId);
+  return podcast ? podcast.engagement : null;
+}
+
+function getSeriesOverview(seriesId) {
+  return seriesStats.get(seriesId);
+}
+
+function getEpisodeDetails(episodeId) {
+  return episodes.get(episodeId);
+}
+
+module.exports = {
+  getOverview,
+  getEpisodeAnalytics,
+  getDemographics,
+  getEngagement,
+  getSeriesOverview,
+  getEpisodeDetails,
+  getPodcast,
+  getEpisode,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,8 +14,6 @@
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "jsonwebtoken": "^9.0.2",
-    "express-validator": "^7.0.1"
     "express-validator": "^7.2.1",
     "joi": "^17.11.0",
     "jsonwebtoken": "^9.0.2"

--- a/backend/routes/podcastAnalytics.js
+++ b/backend/routes/podcastAnalytics.js
@@ -1,0 +1,75 @@
+const express = require('express');
+const {
+  overviewHandler,
+  episodeAnalyticsHandler,
+  demographicsHandler,
+  engagementHandler,
+  seriesOverviewHandler,
+  episodeDetailsHandler,
+} = require('../controllers/podcastAnalytics');
+const auth = require('../middleware/auth');
+const authorize = require('../middleware/authorize');
+const validate = require('../middleware/validate');
+const ownership = require('../middleware/podcastOwnership');
+const {
+  episodeIdParamSchema,
+  podcastIdParamSchema,
+  seriesIdParamSchema,
+  dateRangeSchema,
+} = require('../validation/podcastAnalytics');
+
+const router = express.Router();
+
+// Administrative analytics endpoints
+router.get(
+  '/overview',
+  auth,
+  authorize('admin', 'content-manager'),
+  validate(dateRangeSchema, 'query'),
+  overviewHandler
+);
+
+router.get(
+  '/episode/:episodeId',
+  auth,
+  authorize('admin', 'content-manager'),
+  validate(episodeIdParamSchema, 'params'),
+  episodeAnalyticsHandler
+);
+
+router.get(
+  '/demographics/:podcastId',
+  auth,
+  authorize('admin', 'content-manager'),
+  validate(podcastIdParamSchema, 'params'),
+  demographicsHandler
+);
+
+router.get(
+  '/engagement/:podcastId',
+  auth,
+  authorize('admin', 'content-manager'),
+  validate(podcastIdParamSchema, 'params'),
+  engagementHandler
+);
+
+// Creator-specific analytics endpoints
+router.get(
+  '/series/:seriesId/overview',
+  auth,
+  authorize('admin', 'content-manager', 'creator'),
+  validate(seriesIdParamSchema, 'params'),
+  ownership,
+  seriesOverviewHandler
+);
+
+router.get(
+  '/episodes/:episodeId/details',
+  auth,
+  authorize('admin', 'content-manager', 'creator'),
+  validate(episodeIdParamSchema, 'params'),
+  ownership,
+  episodeDetailsHandler
+);
+
+module.exports = router;

--- a/backend/services/podcastAnalytics.js
+++ b/backend/services/podcastAnalytics.js
@@ -1,0 +1,81 @@
+const logger = require('../utils/logger');
+const podcastModel = require('../models/podcastAnalytics');
+
+async function getOverview(range = {}) {
+  logger.info('Fetching podcast analytics overview', { range });
+  return podcastModel.getOverview(range);
+}
+
+async function getEpisodeAnalytics(episodeId) {
+  const analytics = podcastModel.getEpisodeAnalytics(episodeId);
+  if (!analytics) {
+    const error = new Error('Episode analytics not found');
+    error.status = 404;
+    throw error;
+  }
+  logger.info('Episode analytics retrieved', { episodeId });
+  return analytics;
+}
+
+async function getDemographics(podcastId) {
+  const demographics = podcastModel.getDemographics(podcastId);
+  if (!demographics) {
+    const error = new Error('Podcast demographics not found');
+    error.status = 404;
+    throw error;
+  }
+  logger.info('Podcast demographics retrieved', { podcastId });
+  return demographics;
+}
+
+async function getEngagement(podcastId) {
+  const engagement = podcastModel.getEngagement(podcastId);
+  if (!engagement) {
+    const error = new Error('Podcast engagement metrics not found');
+    error.status = 404;
+    throw error;
+  }
+  logger.info('Podcast engagement retrieved', { podcastId });
+  return engagement;
+}
+
+async function getSeriesOverview(seriesId) {
+  const overview = podcastModel.getSeriesOverview(seriesId);
+  if (!overview) {
+    const error = new Error('Series analytics not found');
+    error.status = 404;
+    throw error;
+  }
+  logger.info('Series analytics overview retrieved', { seriesId });
+  return overview;
+}
+
+async function getEpisodeDetails(episodeId) {
+  const details = podcastModel.getEpisodeDetails(episodeId);
+  if (!details) {
+    const error = new Error('Episode analytics not found');
+    error.status = 404;
+    throw error;
+  }
+  logger.info('Detailed episode analytics retrieved', { episodeId });
+  return details;
+}
+
+async function getPodcast(podcastId) {
+  return podcastModel.getPodcast(podcastId);
+}
+
+async function getEpisode(episodeId) {
+  return podcastModel.getEpisode(episodeId);
+}
+
+module.exports = {
+  getOverview,
+  getEpisodeAnalytics,
+  getDemographics,
+  getEngagement,
+  getSeriesOverview,
+  getEpisodeDetails,
+  getPodcast,
+  getEpisode,
+};

--- a/backend/validation/podcastAnalytics.js
+++ b/backend/validation/podcastAnalytics.js
@@ -1,0 +1,25 @@
+const Joi = require('joi');
+
+const episodeIdParamSchema = Joi.object({
+  episodeId: Joi.string().guid({ version: 'uuidv4' }).required(),
+});
+
+const podcastIdParamSchema = Joi.object({
+  podcastId: Joi.string().guid({ version: 'uuidv4' }).required(),
+});
+
+const seriesIdParamSchema = Joi.object({
+  seriesId: Joi.string().guid({ version: 'uuidv4' }).required(),
+});
+
+const dateRangeSchema = Joi.object({
+  startDate: Joi.date().iso().optional(),
+  endDate: Joi.date().iso().optional(),
+});
+
+module.exports = {
+  episodeIdParamSchema,
+  podcastIdParamSchema,
+  seriesIdParamSchema,
+  dateRangeSchema,
+};


### PR DESCRIPTION
## Summary
- add podcast analytics models, services, controllers, and routes
- include ownership middleware and SQL schema for podcast analytics
- wire podcast analytics routes into application and fix backend package.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68924bb5b02c832090b8f10126d29917