### PR TITLE
Add sentiment analysis backend module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -30,6 +30,7 @@ const educationAnalyticsRoutes = require('./routes/educationAnalytics');
 const financialAnalyticsRoutes = require('./routes/financialAnalytics');
 const paymentRoutes = require('./routes/payments');
 const employmentAnalyticsRoutes = require('./routes/employmentAnalytics');
+const sentimentAnalysisRoutes = require('./routes/sentimentAnalysis');
 
 const app = express();
 app.use(cors());
@@ -67,6 +68,7 @@ app.use('/education-analytics', educationAnalyticsRoutes);
 app.use('/financial-analytics', financialAnalyticsRoutes);
 app.use('/agency/:agencyId/payments', paymentRoutes);
 app.use('/analytics/employment', employmentAnalyticsRoutes);
+app.use('/sentiment', sentimentAnalysisRoutes);
 
 // Commission rate adjustment notifications
 app.use('/affiliates/notifications', notificationRoutes);

--- a/backend/controllers/sentimentAnalysis.js
+++ b/backend/controllers/sentimentAnalysis.js
@@ -1,0 +1,132 @@
+const {
+  getSentimentAnalysis,
+  trainSentimentModel,
+  getSentimentModelInfo,
+  getSentimentHistory,
+  getAggregatedSentimentAnalysis,
+  performCustomSentimentAnalysis,
+  getSentimentScores,
+  analyzeEmotionalSentiment,
+  generateSentimentMap,
+  submitSentimentFeedback,
+} = require('../services/sentimentAnalysis');
+const logger = require('../utils/logger');
+
+async function getSentimentAnalysisHandler(req, res) {
+  const { domain } = req.params;
+  try {
+    const result = await getSentimentAnalysis(domain);
+    res.json(result);
+  } catch (err) {
+    logger.error('Failed to get sentiment analysis', { error: err.message, domain });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function trainSentimentModelHandler(req, res) {
+  try {
+    const info = await trainSentimentModel(req.body.dataset);
+    res.status(201).json(info);
+  } catch (err) {
+    logger.error('Failed to train sentiment model', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function getSentimentModelInfoHandler(req, res) {
+  try {
+    const info = await getSentimentModelInfo();
+    res.json(info);
+  } catch (err) {
+    logger.error('Failed to retrieve sentiment model info', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function getSentimentHistoryHandler(req, res) {
+  const { domain } = req.params;
+  try {
+    const history = await getSentimentHistory(domain);
+    res.json(history);
+  } catch (err) {
+    logger.error('Failed to retrieve sentiment history', { error: err.message, domain });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function getAggregatedSentimentAnalysisHandler(req, res) {
+  try {
+    const data = await getAggregatedSentimentAnalysis();
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to retrieve aggregated sentiment analysis', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function performCustomSentimentAnalysisHandler(req, res) {
+  try {
+    const result = await performCustomSentimentAnalysis(req.body.text);
+    res.json(result);
+  } catch (err) {
+    logger.error('Failed to perform custom sentiment analysis', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function getSentimentScoresHandler(req, res) {
+  const { domain } = req.params;
+  try {
+    const scores = await getSentimentScores(domain);
+    res.json(scores);
+  } catch (err) {
+    logger.error('Failed to retrieve sentiment scores', { error: err.message, domain });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function analyzeEmotionalSentimentHandler(req, res) {
+  const { domain } = req.params;
+  try {
+    const emotions = await analyzeEmotionalSentiment(domain);
+    res.json(emotions);
+  } catch (err) {
+    logger.error('Failed to analyze emotional sentiment', { error: err.message, domain });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function generateSentimentMapHandler(req, res) {
+  const { domain } = req.params;
+  try {
+    const map = await generateSentimentMap(domain);
+    res.json(map);
+  } catch (err) {
+    logger.error('Failed to generate sentiment map', { error: err.message, domain });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function submitSentimentFeedbackHandler(req, res) {
+  const { domain } = req.params;
+  try {
+    const record = await submitSentimentFeedback(domain, req.body);
+    res.status(201).json(record);
+  } catch (err) {
+    logger.error('Failed to submit sentiment feedback', { error: err.message, domain });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  getSentimentAnalysisHandler,
+  trainSentimentModelHandler,
+  getSentimentModelInfoHandler,
+  getSentimentHistoryHandler,
+  getAggregatedSentimentAnalysisHandler,
+  performCustomSentimentAnalysisHandler,
+  getSentimentScoresHandler,
+  analyzeEmotionalSentimentHandler,
+  generateSentimentMapHandler,
+  submitSentimentFeedbackHandler,
+};

--- a/backend/database/sentiment_analysis.sql
+++ b/backend/database/sentiment_analysis.sql
@@ -1,0 +1,26 @@
+-- Table to store individual sentiment analysis records
+CREATE TABLE IF NOT EXISTS sentiment_analysis_records (
+  id UUID PRIMARY KEY,
+  domain VARCHAR(255) NOT NULL,
+  text TEXT NOT NULL,
+  score INTEGER NOT NULL,
+  label VARCHAR(20) NOT NULL,
+  emotions JSONB,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Table to store feedback used for training and model improvement
+CREATE TABLE IF NOT EXISTS sentiment_feedback (
+  id UUID PRIMARY KEY,
+  domain VARCHAR(255) NOT NULL,
+  text TEXT NOT NULL,
+  label VARCHAR(20) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Table to keep track of sentiment model metadata
+CREATE TABLE IF NOT EXISTS sentiment_model_info (
+  version VARCHAR(50) NOT NULL,
+  last_trained TIMESTAMP,
+  training_samples INTEGER DEFAULT 0
+);

--- a/backend/models/sentimentAnalysis.js
+++ b/backend/models/sentimentAnalysis.js
@@ -1,0 +1,65 @@
+const { randomUUID } = require('crypto');
+
+// In-memory storage for sentiment analyses and feedback by domain
+const analyses = {};
+const feedback = {};
+
+// Simple model info tracking training metadata
+let modelInfo = {
+  version: '1.0.0',
+  lastTrained: null,
+  trainingSamples: 0,
+};
+
+function addTrainingData(dataset = []) {
+  modelInfo.lastTrained = new Date();
+  modelInfo.trainingSamples += dataset.length;
+  return { ...modelInfo };
+}
+
+function addAnalysis(domain, { text, score, label, emotions }) {
+  if (!analyses[domain]) analyses[domain] = [];
+  const record = {
+    id: randomUUID(),
+    text,
+    score,
+    label,
+    emotions: emotions || null,
+    createdAt: new Date(),
+  };
+  analyses[domain].push(record);
+  return record;
+}
+
+function getAnalyses(domain) {
+  return analyses[domain] || [];
+}
+
+function getAllAnalyses() {
+  return analyses;
+}
+
+function addFeedback(domain, { text, label }) {
+  if (!feedback[domain]) feedback[domain] = [];
+  const record = {
+    id: randomUUID(),
+    text,
+    label,
+    createdAt: new Date(),
+  };
+  feedback[domain].push(record);
+  return record;
+}
+
+function getModelInfo() {
+  return { ...modelInfo };
+}
+
+module.exports = {
+  addTrainingData,
+  addAnalysis,
+  getAnalyses,
+  getAllAnalyses,
+  addFeedback,
+  getModelInfo,
+};

--- a/backend/routes/sentimentAnalysis.js
+++ b/backend/routes/sentimentAnalysis.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const {
+  getSentimentAnalysisHandler,
+  trainSentimentModelHandler,
+  getSentimentModelInfoHandler,
+  getSentimentHistoryHandler,
+  getAggregatedSentimentAnalysisHandler,
+  performCustomSentimentAnalysisHandler,
+  getSentimentScoresHandler,
+  analyzeEmotionalSentimentHandler,
+  generateSentimentMapHandler,
+  submitSentimentFeedbackHandler,
+} = require('../controllers/sentimentAnalysis');
+const auth = require('../middleware/auth');
+const authorize = require('../middleware/authorize');
+const validate = require('../middleware/validate');
+const {
+  domainParamSchema,
+  trainSchema,
+  customTextSchema,
+  feedbackSchema,
+} = require('../validation/sentimentAnalysis');
+
+const router = express.Router();
+
+router.post('/train', auth, authorize('admin'), validate(trainSchema), trainSentimentModelHandler);
+router.get('/model', auth, authorize('admin', 'content-manager'), getSentimentModelInfoHandler);
+router.get('/aggregate', auth, authorize('admin', 'content-manager'), getAggregatedSentimentAnalysisHandler);
+router.post('/custom', auth, validate(customTextSchema), performCustomSentimentAnalysisHandler);
+router.get('/score/:domain', auth, authorize('admin', 'content-manager'), validate(domainParamSchema, 'params'), getSentimentScoresHandler);
+router.get('/:domain/history', auth, authorize('admin', 'content-manager'), validate(domainParamSchema, 'params'), getSentimentHistoryHandler);
+router.get('/:domain/emotions', auth, authorize('admin', 'content-manager'), validate(domainParamSchema, 'params'), analyzeEmotionalSentimentHandler);
+router.get('/:domain/sentiment-map', auth, authorize('admin', 'content-manager'), validate(domainParamSchema, 'params'), generateSentimentMapHandler);
+router.post('/:domain/feedback', auth, validate(domainParamSchema, 'params'), validate(feedbackSchema), submitSentimentFeedbackHandler);
+router.get('/:domain', auth, authorize('admin', 'content-manager'), validate(domainParamSchema, 'params'), getSentimentAnalysisHandler);
+
+module.exports = router;

--- a/backend/services/sentimentAnalysis.js
+++ b/backend/services/sentimentAnalysis.js
@@ -1,0 +1,156 @@
+const model = require('../models/sentimentAnalysis');
+const logger = require('../utils/logger');
+
+const positiveWords = [
+  'good',
+  'great',
+  'excellent',
+  'positive',
+  'happy',
+  'love',
+  'awesome',
+  'fantastic',
+  'terrific',
+  'pleasant',
+  'amazing',
+];
+
+const negativeWords = [
+  'bad',
+  'poor',
+  'terrible',
+  'negative',
+  'sad',
+  'hate',
+  'awful',
+  'horrible',
+  'disappointing',
+  'unpleasant',
+  'angry',
+];
+
+const emotionWords = {
+  happy: 'joy',
+  joy: 'joy',
+  delightful: 'joy',
+  sad: 'sadness',
+  sorrow: 'sadness',
+  angry: 'anger',
+  mad: 'anger',
+  fear: 'fear',
+  scared: 'fear',
+  love: 'love',
+  surprise: 'surprise',
+};
+
+function analyzeText(text) {
+  const tokens = text.toLowerCase().split(/\W+/);
+  let score = 0;
+  tokens.forEach(token => {
+    if (positiveWords.includes(token)) score += 1;
+    if (negativeWords.includes(token)) score -= 1;
+  });
+  const label = score > 0 ? 'positive' : score < 0 ? 'negative' : 'neutral';
+  const emotions = {};
+  tokens.forEach(token => {
+    const emotion = emotionWords[token];
+    if (emotion) emotions[emotion] = (emotions[emotion] || 0) + 1;
+  });
+  return { score, label, emotions };
+}
+
+async function getSentimentAnalysis(domain) {
+  const records = model.getAnalyses(domain);
+  const averageScore = records.length
+    ? records.reduce((sum, r) => sum + r.score, 0) / records.length
+    : 0;
+  logger.info('Retrieved sentiment analysis', { domain, count: records.length });
+  return { domain, averageScore, total: records.length };
+}
+
+async function trainSentimentModel(dataset) {
+  const info = model.addTrainingData(dataset);
+  logger.info('Sentiment model trained', { samples: dataset.length });
+  return info;
+}
+
+async function getSentimentModelInfo() {
+  const info = model.getModelInfo();
+  logger.info('Fetched sentiment model info');
+  return info;
+}
+
+async function getSentimentHistory(domain) {
+  const records = model.getAnalyses(domain);
+  logger.info('Retrieved sentiment history', { domain, count: records.length });
+  return records;
+}
+
+async function getAggregatedSentimentAnalysis() {
+  const all = model.getAllAnalyses();
+  const result = Object.keys(all).map(domain => {
+    const records = all[domain];
+    const averageScore = records.length
+      ? records.reduce((sum, r) => sum + r.score, 0) / records.length
+      : 0;
+    return { domain, averageScore, total: records.length };
+  });
+  logger.info('Retrieved aggregated sentiment analysis');
+  return result;
+}
+
+async function performCustomSentimentAnalysis(text) {
+  const { score, label, emotions } = analyzeText(text);
+  model.addAnalysis('custom', { text, score, label, emotions });
+  logger.info('Performed custom sentiment analysis');
+  return { score, label, emotions };
+}
+
+async function getSentimentScores(domain) {
+  const records = model.getAnalyses(domain);
+  const scores = records.map(r => ({ id: r.id, score: r.score, label: r.label }));
+  logger.info('Retrieved sentiment scores', { domain, count: scores.length });
+  return scores;
+}
+
+async function analyzeEmotionalSentiment(domain) {
+  const records = model.getAnalyses(domain);
+  const totals = {};
+  records.forEach(r => {
+    const emotions = r.emotions || {};
+    for (const [emotion, count] of Object.entries(emotions)) {
+      totals[emotion] = (totals[emotion] || 0) + count;
+    }
+  });
+  logger.info('Retrieved emotional sentiment', { domain });
+  return totals;
+}
+
+async function generateSentimentMap(domain) {
+  const records = model.getAnalyses(domain);
+  const map = { positive: 0, negative: 0, neutral: 0 };
+  records.forEach(r => {
+    map[r.label] = (map[r.label] || 0) + 1;
+  });
+  logger.info('Generated sentiment map', { domain });
+  return map;
+}
+
+async function submitSentimentFeedback(domain, data) {
+  const record = model.addFeedback(domain, data);
+  logger.info('Submitted sentiment feedback', { domain });
+  return record;
+}
+
+module.exports = {
+  getSentimentAnalysis,
+  trainSentimentModel,
+  getSentimentModelInfo,
+  getSentimentHistory,
+  getAggregatedSentimentAnalysis,
+  performCustomSentimentAnalysis,
+  getSentimentScores,
+  analyzeEmotionalSentiment,
+  generateSentimentMap,
+  submitSentimentFeedback,
+};

--- a/backend/validation/sentimentAnalysis.js
+++ b/backend/validation/sentimentAnalysis.js
@@ -1,0 +1,33 @@
+const Joi = require('joi');
+
+const domainParamSchema = Joi.object({
+  domain: Joi.string().min(1).required(),
+});
+
+const trainSchema = Joi.object({
+  dataset: Joi.array()
+    .items(
+      Joi.object({
+        text: Joi.string().min(1).required(),
+        label: Joi.string().valid('positive', 'negative', 'neutral').required(),
+      })
+    )
+    .min(1)
+    .required(),
+});
+
+const customTextSchema = Joi.object({
+  text: Joi.string().min(1).required(),
+});
+
+const feedbackSchema = Joi.object({
+  text: Joi.string().min(1).required(),
+  label: Joi.string().valid('positive', 'negative', 'neutral').required(),
+});
+
+module.exports = {
+  domainParamSchema,
+  trainSchema,
+  customTextSchema,
+  feedbackSchema,
+};


### PR DESCRIPTION
## Summary
- implement sentiment analysis controller, service, model, validation, routes
- add SQL schema for sentiment data and register routes in app

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924bc13af083208f15d3a74cd4d864