### PR TITLE
feat: add service provider analytics module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -30,6 +30,7 @@ const educationAnalyticsRoutes = require('./routes/educationAnalytics');
 const financialAnalyticsRoutes = require('./routes/financialAnalytics');
 const paymentRoutes = require('./routes/payments');
 const employmentAnalyticsRoutes = require('./routes/employmentAnalytics');
+const serviceProviderAnalyticsRoutes = require('./routes/serviceProviderAnalytics');
 
 const app = express();
 app.use(cors());
@@ -67,6 +68,7 @@ app.use('/education-analytics', educationAnalyticsRoutes);
 app.use('/financial-analytics', financialAnalyticsRoutes);
 app.use('/agency/:agencyId/payments', paymentRoutes);
 app.use('/analytics/employment', employmentAnalyticsRoutes);
+app.use('/service-providers', serviceProviderAnalyticsRoutes);
 
 // Commission rate adjustment notifications
 app.use('/affiliates/notifications', notificationRoutes);

--- a/backend/controllers/serviceProviderAnalytics.js
+++ b/backend/controllers/serviceProviderAnalytics.js
@@ -1,0 +1,112 @@
+const service = require('../services/serviceProviderAnalytics');
+const logger = require('../utils/logger');
+
+exports.getAnalytics = (req, res) => {
+  try {
+    const providerId = req.user.id;
+    const analytics = service.getAnalytics(providerId);
+    res.json(analytics);
+  } catch (err) {
+    logger.error('Failed to fetch service provider analytics', err);
+    res.status(500).json({ error: 'Unable to retrieve analytics' });
+  }
+};
+
+exports.updatePricing = (req, res) => {
+  try {
+    const { serviceId } = req.params;
+    const { price } = req.validatedBody;
+    const updated = service.updatePricing(req.user.id, serviceId, price);
+    if (!updated) {
+      return res.status(404).json({ error: 'Service not found or unauthorized' });
+    }
+    res.json(updated);
+  } catch (err) {
+    logger.error('Failed to update service pricing', err);
+    res.status(500).json({ error: 'Unable to update pricing' });
+  }
+};
+
+exports.setAvailability = (req, res) => {
+  try {
+    const availability = service.setAvailability(req.user.id, req.validatedBody);
+    res.status(201).json(availability);
+  } catch (err) {
+    logger.error('Failed to set availability', err);
+    res.status(500).json({ error: 'Unable to set availability' });
+  }
+};
+
+exports.createBooking = (req, res) => {
+  try {
+    const booking = service.createBooking(req.user.id, req.validatedBody);
+    res.status(201).json(booking);
+  } catch (err) {
+    logger.error('Failed to create booking', err);
+    res.status(500).json({ error: 'Unable to create booking' });
+  }
+};
+
+exports.addPortfolioItem = (req, res) => {
+  try {
+    const item = service.addPortfolioItem(req.user.id, req.validatedBody);
+    res.status(201).json(item);
+  } catch (err) {
+    logger.error('Failed to add portfolio item', err);
+    res.status(500).json({ error: 'Unable to add portfolio item' });
+  }
+};
+
+exports.getPortfolio = (req, res) => {
+  try {
+    const { providerId } = req.params;
+    const portfolio = service.getPortfolio(providerId);
+    res.json(portfolio);
+  } catch (err) {
+    logger.error('Failed to fetch portfolio', err);
+    res.status(500).json({ error: 'Unable to retrieve portfolio' });
+  }
+};
+
+exports.addTestimonial = (req, res) => {
+  try {
+    const testimonial = service.addTestimonial(req.user.id, req.validatedBody);
+    res.status(201).json(testimonial);
+  } catch (err) {
+    logger.error('Failed to add testimonial', err);
+    res.status(500).json({ error: 'Unable to add testimonial' });
+  }
+};
+
+exports.getTestimonials = (req, res) => {
+  try {
+    const { providerId } = req.params;
+    const testimonials = service.getTestimonials(providerId);
+    res.json(testimonials);
+  } catch (err) {
+    logger.error('Failed to fetch testimonials', err);
+    res.status(500).json({ error: 'Unable to retrieve testimonials' });
+  }
+};
+
+exports.customizeService = (req, res) => {
+  try {
+    const { serviceId } = req.params;
+    const request = service.customizeService(req.user.id, serviceId, req.validatedBody);
+    res.status(201).json(request);
+  } catch (err) {
+    logger.error('Failed to submit customization request', err);
+    res.status(500).json({ error: 'Unable to submit customization request' });
+  }
+};
+
+exports.initiateChat = (req, res) => {
+  try {
+    const session = service.initiateChat(req.user.id, req.validatedBody);
+    res.status(201).json(session);
+  } catch (err) {
+    logger.error('Failed to initiate chat session', err);
+    res.status(500).json({ error: 'Unable to initiate chat' });
+  }
+};
+

--- a/backend/database/service_provider_analytics.sql
+++ b/backend/database/service_provider_analytics.sql
@@ -1,0 +1,70 @@
+-- Tables for service provider analytics module
+
+CREATE TABLE service_providers (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL,
+  name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE services (
+  id UUID PRIMARY KEY,
+  provider_id UUID REFERENCES service_providers(id),
+  name VARCHAR(255) NOT NULL,
+  description TEXT,
+  price NUMERIC(10,2) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE service_availability (
+  id UUID PRIMARY KEY,
+  provider_id UUID REFERENCES service_providers(id),
+  date DATE NOT NULL,
+  slots JSONB NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE service_bookings (
+  id UUID PRIMARY KEY,
+  client_id UUID NOT NULL,
+  provider_id UUID REFERENCES service_providers(id),
+  service_id UUID REFERENCES services(id),
+  date TIMESTAMP NOT NULL,
+  status VARCHAR(50) DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE portfolio_items (
+  id UUID PRIMARY KEY,
+  provider_id UUID REFERENCES service_providers(id),
+  title VARCHAR(255) NOT NULL,
+  description TEXT NOT NULL,
+  media_url TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE testimonials (
+  id UUID PRIMARY KEY,
+  provider_id UUID REFERENCES service_providers(id),
+  client_id UUID NOT NULL,
+  rating INT CHECK (rating BETWEEN 1 AND 5),
+  comment TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE customization_requests (
+  id UUID PRIMARY KEY,
+  service_id UUID REFERENCES services(id),
+  client_id UUID NOT NULL,
+  details TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE chat_sessions (
+  id UUID PRIMARY KEY,
+  provider_id UUID REFERENCES service_providers(id),
+  client_id UUID NOT NULL,
+  messages JSONB NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/backend/middleware/requireRole.js
+++ b/backend/middleware/requireRole.js
@@ -1,0 +1,12 @@
+const logger = require('../utils/logger');
+
+module.exports = (...roles) => {
+  return (req, res, next) => {
+    const role = req.user?.role;
+    if (!role || !roles.includes(role)) {
+      logger.error('Access denied', { userId: req.user?.id, role, required: roles });
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+};

--- a/backend/middleware/validateRequest.js
+++ b/backend/middleware/validateRequest.js
@@ -1,0 +1,13 @@
+const logger = require('../utils/logger');
+
+module.exports = schema => {
+  return (req, res, next) => {
+    const { error, value } = schema.validate(req.body);
+    if (error) {
+      logger.error('Validation error', { message: error.message });
+      return res.status(400).json({ error: error.message });
+    }
+    req.validatedBody = value;
+    next();
+  };
+};

--- a/backend/models/serviceProviderAnalytics.js
+++ b/backend/models/serviceProviderAnalytics.js
@@ -1,0 +1,130 @@
+const { randomUUID } = require('crypto');
+
+const services = [];
+const availabilities = [];
+const bookings = [];
+const portfolioItems = [];
+const testimonials = [];
+const customizationRequests = [];
+const chatSessions = [];
+
+function findServiceById(id) {
+  return services.find(s => s.id === id);
+}
+
+function updateServicePricing(providerId, serviceId, price) {
+  const service = services.find(s => s.id === serviceId && s.providerId === providerId);
+  if (!service) return null;
+  service.price = price;
+  service.updatedAt = new Date();
+  return service;
+}
+
+function addAvailability(providerId, { date, slots }) {
+  const entry = { id: randomUUID(), providerId, date: new Date(date), slots, createdAt: new Date() };
+  availabilities.push(entry);
+  return entry;
+}
+
+function createBooking(clientId, { providerId, serviceId, date }) {
+  const booking = {
+    id: randomUUID(),
+    clientId,
+    providerId,
+    serviceId,
+    date: new Date(date),
+    status: 'pending',
+    createdAt: new Date(),
+  };
+  bookings.push(booking);
+  return booking;
+}
+
+function addPortfolioItem(providerId, { title, description, mediaUrl }) {
+  const item = { id: randomUUID(), providerId, title, description, mediaUrl, createdAt: new Date() };
+  portfolioItems.push(item);
+  return item;
+}
+
+function getPortfolioByProvider(providerId) {
+  return portfolioItems.filter(p => p.providerId === providerId);
+}
+
+function addTestimonial(clientId, { providerId, rating, comment }) {
+  const testimonial = {
+    id: randomUUID(),
+    providerId,
+    clientId,
+    rating,
+    comment,
+    createdAt: new Date(),
+  };
+  testimonials.push(testimonial);
+  return testimonial;
+}
+
+function getTestimonialsByProvider(providerId) {
+  return testimonials.filter(t => t.providerId === providerId);
+}
+
+function addCustomizationRequest(clientId, serviceId, { details }) {
+  const request = {
+    id: randomUUID(),
+    serviceId,
+    clientId,
+    details,
+    createdAt: new Date(),
+  };
+  customizationRequests.push(request);
+  return request;
+}
+
+function createChatSession(userId, { providerId, message }) {
+  const session = {
+    id: randomUUID(),
+    providerId,
+    clientId: userId,
+    messages: [ { senderId: userId, message, timestamp: new Date() } ],
+    createdAt: new Date(),
+  };
+  chatSessions.push(session);
+  return session;
+}
+
+function computeAnalytics(providerId) {
+  const providerBookings = bookings.filter(b => b.providerId === providerId);
+  const revenue = providerBookings.reduce((sum, b) => {
+    const service = findServiceById(b.serviceId);
+    return sum + (service ? service.price : 0);
+  }, 0);
+  return {
+    totalServices: services.filter(s => s.providerId === providerId).length,
+    totalBookings: providerBookings.length,
+    revenue,
+    rating:
+      testimonials
+        .filter(t => t.providerId === providerId)
+        .reduce((sum, t, _, arr) => sum + t.rating / arr.length, 0),
+  };
+}
+
+module.exports = {
+  services,
+  availabilities,
+  bookings,
+  portfolioItems,
+  testimonials,
+  customizationRequests,
+  chatSessions,
+  findServiceById,
+  updateServicePricing,
+  addAvailability,
+  createBooking,
+  addPortfolioItem,
+  getPortfolioByProvider,
+  addTestimonial,
+  getTestimonialsByProvider,
+  addCustomizationRequest,
+  createChatSession,
+  computeAnalytics,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,8 +14,6 @@
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "jsonwebtoken": "^9.0.2",
-    "express-validator": "^7.0.1"
     "express-validator": "^7.2.1",
     "joi": "^17.11.0",
     "jsonwebtoken": "^9.0.2"

--- a/backend/routes/serviceProviderAnalytics.js
+++ b/backend/routes/serviceProviderAnalytics.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const controller = require('../controllers/serviceProviderAnalytics');
+const authenticate = require('../middleware/auth');
+const requireRole = require('../middleware/requireRole');
+const validate = require('../middleware/validateRequest');
+const schemas = require('../validation/serviceProviderAnalytics');
+
+const router = express.Router();
+
+router.get('/analytics', authenticate, requireRole('service_provider'), controller.getAnalytics);
+router.put('/services/:serviceId/pricing', authenticate, requireRole('service_provider'), validate(schemas.pricingUpdateSchema), controller.updatePricing);
+router.post('/calendar/availability', authenticate, requireRole('service_provider'), validate(schemas.availabilitySchema), controller.setAvailability);
+router.post('/bookings', authenticate, requireRole('client'), validate(schemas.bookingSchema), controller.createBooking);
+router.post('/portfolio', authenticate, requireRole('service_provider'), validate(schemas.portfolioSchema), controller.addPortfolioItem);
+router.get('/portfolio/:providerId', controller.getPortfolio);
+router.post('/testimonials', authenticate, requireRole('client'), validate(schemas.testimonialSchema), controller.addTestimonial);
+router.get('/testimonials/:providerId', controller.getTestimonials);
+router.post('/services/:serviceId/customize', authenticate, requireRole('client'), validate(schemas.customizationSchema), controller.customizeService);
+router.post('/chat/initiate', authenticate, validate(schemas.chatInitSchema), controller.initiateChat);
+
+module.exports = router;

--- a/backend/services/serviceProviderAnalytics.js
+++ b/backend/services/serviceProviderAnalytics.js
@@ -1,0 +1,65 @@
+const model = require('../models/serviceProviderAnalytics');
+const logger = require('../utils/logger');
+
+function getAnalytics(providerId) {
+  logger.info('Fetching analytics', { providerId });
+  return model.computeAnalytics(providerId);
+}
+
+function updatePricing(providerId, serviceId, price) {
+  logger.info('Updating pricing', { providerId, serviceId, price });
+  return model.updateServicePricing(providerId, serviceId, price);
+}
+
+function setAvailability(providerId, availability) {
+  logger.info('Setting availability', { providerId });
+  return model.addAvailability(providerId, availability);
+}
+
+function createBooking(clientId, bookingData) {
+  logger.info('Creating booking', { clientId, providerId: bookingData.providerId });
+  return model.createBooking(clientId, bookingData);
+}
+
+function addPortfolioItem(providerId, data) {
+  logger.info('Adding portfolio item', { providerId });
+  return model.addPortfolioItem(providerId, data);
+}
+
+function getPortfolio(providerId) {
+  logger.info('Retrieving portfolio', { providerId });
+  return model.getPortfolioByProvider(providerId);
+}
+
+function addTestimonial(clientId, data) {
+  logger.info('Adding testimonial', { providerId: data.providerId, clientId });
+  return model.addTestimonial(clientId, data);
+}
+
+function getTestimonials(providerId) {
+  logger.info('Retrieving testimonials', { providerId });
+  return model.getTestimonialsByProvider(providerId);
+}
+
+function customizeService(clientId, serviceId, data) {
+  logger.info('Submitting customization request', { clientId, serviceId });
+  return model.addCustomizationRequest(clientId, serviceId, data);
+}
+
+function initiateChat(clientId, data) {
+  logger.info('Initiating chat', { clientId, providerId: data.providerId });
+  return model.createChatSession(clientId, data);
+}
+
+module.exports = {
+  getAnalytics,
+  updatePricing,
+  setAvailability,
+  createBooking,
+  addPortfolioItem,
+  getPortfolio,
+  addTestimonial,
+  getTestimonials,
+  customizeService,
+  initiateChat,
+};

--- a/backend/validation/serviceProviderAnalytics.js
+++ b/backend/validation/serviceProviderAnalytics.js
@@ -1,0 +1,50 @@
+const Joi = require('joi');
+
+const pricingUpdateSchema = Joi.object({
+  price: Joi.number().positive().required(),
+});
+
+const availabilitySchema = Joi.object({
+  date: Joi.date().iso().required(),
+  slots: Joi.array()
+    .items(Joi.object({ start: Joi.string().required(), end: Joi.string().required() }))
+    .min(1)
+    .required(),
+});
+
+const bookingSchema = Joi.object({
+  providerId: Joi.string().required(),
+  serviceId: Joi.string().required(),
+  date: Joi.date().iso().required(),
+});
+
+const portfolioSchema = Joi.object({
+  title: Joi.string().max(255).required(),
+  description: Joi.string().max(1024).required(),
+  mediaUrl: Joi.string().uri().optional(),
+});
+
+const testimonialSchema = Joi.object({
+  providerId: Joi.string().required(),
+  rating: Joi.number().integer().min(1).max(5).required(),
+  comment: Joi.string().max(1024).optional(),
+});
+
+const customizationSchema = Joi.object({
+  details: Joi.string().max(2048).required(),
+});
+
+const chatInitSchema = Joi.object({
+  providerId: Joi.string().required(),
+  message: Joi.string().max(1024).required(),
+});
+
+module.exports = {
+  pricingUpdateSchema,
+  availabilitySchema,
+  bookingSchema,
+  portfolioSchema,
+  testimonialSchema,
+  customizationSchema,
+  chatInitSchema,
+};


### PR DESCRIPTION
## Summary
- implement service provider analytics controller, services, routes, and models
- add validation, role middleware, and SQL schema for service provider features
- expose endpoints for analytics, pricing, availability, bookings, portfolio, testimonials, customization, and chat

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68924bccfbfc83209432908f344c27be