### PR TITLE
feat: add predictive analytics and forecasting ML module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -30,6 +30,7 @@ const educationAnalyticsRoutes = require('./routes/educationAnalytics');
 const financialAnalyticsRoutes = require('./routes/financialAnalytics');
 const paymentRoutes = require('./routes/payments');
 const employmentAnalyticsRoutes = require('./routes/employmentAnalytics');
+const predictiveMlRoutes = require('./routes/predictiveAnalyticsForecastingML');
 
 const app = express();
 app.use(cors());
@@ -67,6 +68,7 @@ app.use('/education-analytics', educationAnalyticsRoutes);
 app.use('/financial-analytics', financialAnalyticsRoutes);
 app.use('/agency/:agencyId/payments', paymentRoutes);
 app.use('/analytics/employment', employmentAnalyticsRoutes);
+app.use('/ml', predictiveMlRoutes);
 
 // Commission rate adjustment notifications
 app.use('/affiliates/notifications', notificationRoutes);

--- a/backend/controllers/predictiveAnalyticsForecastingML.js
+++ b/backend/controllers/predictiveAnalyticsForecastingML.js
@@ -1,0 +1,29 @@
+const { predictUserRetention, forecastMarketTrends } = require('../services/predictiveAnalyticsForecastingML');
+const logger = require('../utils/logger');
+
+async function predictUserRetentionHandler(req, res) {
+  try {
+    const { days } = req.query;
+    const data = await predictUserRetention(Number(days));
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to predict user retention', { error: err.message });
+    res.status(500).json({ error: 'Unable to predict user retention' });
+  }
+}
+
+async function forecastMarketTrendsHandler(req, res) {
+  try {
+    const { industry, horizon } = req.query;
+    const data = await forecastMarketTrends(industry, Number(horizon));
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to forecast market trends', { error: err.message });
+    res.status(500).json({ error: 'Unable to forecast market trends' });
+  }
+}
+
+module.exports = {
+  predictUserRetentionHandler,
+  forecastMarketTrendsHandler,
+};

--- a/backend/database/predictive_analytics_forecasting_ml.sql
+++ b/backend/database/predictive_analytics_forecasting_ml.sql
@@ -1,0 +1,16 @@
+-- Predictive Analytics and Forecasting Machine Learning Tables
+
+CREATE TABLE IF NOT EXISTS user_retention_predictions (
+    id UUID PRIMARY KEY,
+    days INTEGER NOT NULL,
+    retention_rate DECIMAL(5,2) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS market_trend_forecasts (
+    id UUID PRIMARY KEY,
+    industry VARCHAR(100),
+    horizon INTEGER NOT NULL,
+    forecast JSONB NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/middleware/mlRequestLogger.js
+++ b/backend/middleware/mlRequestLogger.js
@@ -1,0 +1,6 @@
+const logger = require('../utils/logger');
+
+module.exports = (req, res, next) => {
+  logger.info('ML request received', { path: req.originalUrl, user: req.user?.id });
+  next();
+};

--- a/backend/models/predictiveAnalyticsForecastingML.js
+++ b/backend/models/predictiveAnalyticsForecastingML.js
@@ -1,0 +1,31 @@
+const { randomUUID } = require('crypto');
+
+// Mock data representing user activity and market history
+const userActivities = [
+  { id: randomUUID(), userId: randomUUID(), lastActive: new Date('2024-04-10'), sessions: 5 },
+  { id: randomUUID(), userId: randomUUID(), lastActive: new Date('2024-03-25'), sessions: 2 },
+  { id: randomUUID(), userId: randomUUID(), lastActive: new Date('2024-04-15'), sessions: 3 },
+  { id: randomUUID(), userId: randomUUID(), lastActive: new Date('2024-04-18'), sessions: 7 },
+];
+
+const marketHistory = [
+  { id: randomUUID(), industry: 'technology', date: new Date('2024-01-01'), index: 100 },
+  { id: randomUUID(), industry: 'technology', date: new Date('2024-02-01'), index: 105 },
+  { id: randomUUID(), industry: 'technology', date: new Date('2024-03-01'), index: 107 },
+  { id: randomUUID(), industry: 'finance', date: new Date('2024-01-01'), index: 80 },
+  { id: randomUUID(), industry: 'finance', date: new Date('2024-02-01'), index: 82 },
+  { id: randomUUID(), industry: 'finance', date: new Date('2024-03-01'), index: 81 },
+];
+
+function getUserActivities() {
+  return userActivities;
+}
+
+function getMarketHistory(industry) {
+  return marketHistory.filter(record => !industry || record.industry === industry);
+}
+
+module.exports = {
+  getUserActivities,
+  getMarketHistory,
+};

--- a/backend/routes/predictiveAnalyticsForecastingML.js
+++ b/backend/routes/predictiveAnalyticsForecastingML.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const {
+  predictUserRetentionHandler,
+  forecastMarketTrendsHandler,
+} = require('../controllers/predictiveAnalyticsForecastingML');
+const auth = require('../middleware/auth');
+const authorize = require('../middleware/authorize');
+const validate = require('../middleware/validate');
+const mlRequestLogger = require('../middleware/mlRequestLogger');
+const {
+  retentionQuerySchema,
+  marketTrendsQuerySchema,
+} = require('../validation/predictiveAnalyticsForecastingML');
+
+const router = express.Router();
+
+router.get(
+  '/predictive-analytics/user-retention',
+  auth,
+  authorize('admin', 'analyst'),
+  mlRequestLogger,
+  validate(retentionQuerySchema, 'query'),
+  predictUserRetentionHandler,
+);
+
+router.get(
+  '/forecasting/market-trends',
+  auth,
+  authorize('admin', 'analyst'),
+  mlRequestLogger,
+  validate(marketTrendsQuerySchema, 'query'),
+  forecastMarketTrendsHandler,
+);
+
+module.exports = router;

--- a/backend/services/predictiveAnalyticsForecastingML.js
+++ b/backend/services/predictiveAnalyticsForecastingML.js
@@ -1,0 +1,39 @@
+const logger = require('../utils/logger');
+const model = require('../models/predictiveAnalyticsForecastingML');
+
+async function predictUserRetention(days = 30) {
+  const activities = model.getUserActivities();
+  const threshold = Date.now() - days * 24 * 60 * 60 * 1000;
+  const activeUsers = activities.filter(a => a.lastActive.getTime() >= threshold);
+  const retentionRate = activities.length ? activeUsers.length / activities.length : 0;
+  logger.info('Predicted user retention', { days, retentionRate });
+  return { days, retentionRate };
+}
+
+async function forecastMarketTrends(industry, horizon = 30) {
+  const history = model.getMarketHistory(industry).sort((a, b) => a.date - b.date);
+  if (history.length < 2) {
+    logger.error('Insufficient market history for forecasting', { industry });
+    return { industry, horizon, forecast: [] };
+  }
+  const growthRates = [];
+  for (let i = 1; i < history.length; i++) {
+    const prev = history[i - 1].index;
+    const curr = history[i].index;
+    growthRates.push((curr - prev) / prev);
+  }
+  const avgGrowth = growthRates.reduce((sum, g) => sum + g, 0) / growthRates.length;
+  let lastIndex = history[history.length - 1].index;
+  const forecast = [];
+  for (let i = 1; i <= horizon; i++) {
+    lastIndex *= 1 + avgGrowth;
+    forecast.push({ day: i, expectedIndex: parseFloat(lastIndex.toFixed(2)) });
+  }
+  logger.info('Generated market trend forecast', { industry, horizon });
+  return { industry: industry || 'all', horizon, forecast };
+}
+
+module.exports = {
+  predictUserRetention,
+  forecastMarketTrends,
+};

--- a/backend/validation/predictiveAnalyticsForecastingML.js
+++ b/backend/validation/predictiveAnalyticsForecastingML.js
@@ -1,0 +1,15 @@
+const Joi = require('joi');
+
+const retentionQuerySchema = Joi.object({
+  days: Joi.number().integer().min(1).max(365).default(30),
+});
+
+const marketTrendsQuerySchema = Joi.object({
+  industry: Joi.string().optional(),
+  horizon: Joi.number().integer().min(1).max(365).default(30),
+});
+
+module.exports = {
+  retentionQuerySchema,
+  marketTrendsQuerySchema,
+};


### PR DESCRIPTION
## Summary
- add predictive analytics and market forecasting services
- secure ML routes with auth, role-based access, logging and validation
- define SQL schema for retention predictions and trend forecasts

## Testing
- `cd backend && npm test` *(fails: Invalid package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68924c492fe08320b1ba8a4556b60f61