### PR TITLE
feat: add personalized learning ML module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -30,6 +30,7 @@ const educationAnalyticsRoutes = require('./routes/educationAnalytics');
 const financialAnalyticsRoutes = require('./routes/financialAnalytics');
 const paymentRoutes = require('./routes/payments');
 const employmentAnalyticsRoutes = require('./routes/employmentAnalytics');
+const personalizedLearningRoutes = require('./routes/personalizedLearning');
 
 const app = express();
 app.use(cors());
@@ -67,6 +68,7 @@ app.use('/education-analytics', educationAnalyticsRoutes);
 app.use('/financial-analytics', financialAnalyticsRoutes);
 app.use('/agency/:agencyId/payments', paymentRoutes);
 app.use('/analytics/employment', employmentAnalyticsRoutes);
+app.use('/ml', personalizedLearningRoutes);
 
 // Commission rate adjustment notifications
 app.use('/affiliates/notifications', notificationRoutes);

--- a/backend/controllers/personalizedLearning.js
+++ b/backend/controllers/personalizedLearning.js
@@ -1,0 +1,29 @@
+const { getAdaptiveContent, evaluateAssessment } = require('../services/personalizedLearning');
+const logger = require('../utils/logger');
+
+async function adaptiveContentHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const content = await getAdaptiveContent(userId);
+    res.json(content);
+  } catch (err) {
+    logger.error('Failed to generate adaptive content', { error: err.message, userId });
+    res.status(500).json({ error: 'Unable to generate adaptive content' });
+  }
+}
+
+async function assessmentEvaluationHandler(req, res) {
+  const { userId, assessmentId, answers } = req.body;
+  try {
+    const result = await evaluateAssessment(userId, assessmentId, answers);
+    res.json(result);
+  } catch (err) {
+    logger.error('Failed to evaluate assessment', { error: err.message, userId, assessmentId });
+    res.status(500).json({ error: 'Assessment evaluation failed' });
+  }
+}
+
+module.exports = {
+  adaptiveContentHandler,
+  assessmentEvaluationHandler,
+};

--- a/backend/database/personalized_learning.sql
+++ b/backend/database/personalized_learning.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS personalized_learning_progress (
+  id SERIAL PRIMARY KEY,
+  user_id UUID NOT NULL,
+  level VARCHAR(50) NOT NULL,
+  topics TEXT,
+  last_assessment_score INT,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS assessment_results (
+  id SERIAL PRIMARY KEY,
+  user_id UUID NOT NULL,
+  assessment_id VARCHAR(255) NOT NULL,
+  score INT NOT NULL,
+  feedback TEXT,
+  evaluated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/middleware/personalizedLearning.js
+++ b/backend/middleware/personalizedLearning.js
@@ -1,0 +1,18 @@
+const logger = require('../utils/logger');
+
+module.exports = function verifyUserAccess(req, res, next) {
+  const targetUserId = req.params.userId || req.body.userId;
+  const requester = req.user;
+  if (!requester) {
+    logger.error('No authenticated user found');
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  if (requester.role === 'admin' || requester.role === 'instructor' || requester.id === targetUserId) {
+    return next();
+  }
+  logger.error('Forbidden personalized learning access', {
+    requesterId: requester.id,
+    targetUserId,
+  });
+  return res.status(403).json({ error: 'Forbidden' });
+};

--- a/backend/models/personalizedLearning.js
+++ b/backend/models/personalizedLearning.js
@@ -1,0 +1,43 @@
+const { randomUUID } = require('crypto');
+
+const userProgress = new Map();
+const assessmentResults = [];
+
+function getProgress(userId) {
+  if (!userProgress.has(userId)) {
+    userProgress.set(userId, {
+      userId,
+      level: 'beginner',
+      topics: [],
+      lastAssessmentScore: 0,
+      updatedAt: new Date(),
+    });
+  }
+  return userProgress.get(userId);
+}
+
+function saveProgress(userId, progress) {
+  const existing = getProgress(userId);
+  const updated = { ...existing, ...progress, updatedAt: new Date() };
+  userProgress.set(userId, updated);
+  return updated;
+}
+
+function saveAssessmentResult({ userId, assessmentId, score, feedback, evaluatedAt }) {
+  const record = {
+    id: randomUUID(),
+    userId,
+    assessmentId,
+    score,
+    feedback,
+    evaluatedAt,
+  };
+  assessmentResults.push(record);
+  return record;
+}
+
+module.exports = {
+  getProgress,
+  saveProgress,
+  saveAssessmentResult,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,9 +15,7 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "express-validator": "^7.0.1"
     "express-validator": "^7.2.1",
-    "joi": "^17.11.0",
-    "jsonwebtoken": "^9.0.2"
+    "joi": "^17.11.0"
   }
 }

--- a/backend/routes/personalizedLearning.js
+++ b/backend/routes/personalizedLearning.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const {
+  adaptiveContentHandler,
+  assessmentEvaluationHandler,
+} = require('../controllers/personalizedLearning');
+const auth = require('../middleware/auth');
+const authorize = require('../middleware/authorize');
+const verifyUserAccess = require('../middleware/personalizedLearning');
+const validate = require('../middleware/validate');
+const {
+  adaptiveContentParamsSchema,
+  assessmentEvaluationSchema,
+} = require('../validation/personalizedLearning');
+
+const router = express.Router();
+
+router.get(
+  '/personalized-learning/adaptive-content/:userId',
+  auth,
+  authorize('user', 'instructor', 'admin'),
+  verifyUserAccess,
+  validate(adaptiveContentParamsSchema, 'params'),
+  adaptiveContentHandler
+);
+
+router.post(
+  '/learning/assessment/evaluate',
+  auth,
+  authorize('user', 'instructor', 'admin'),
+  verifyUserAccess,
+  validate(assessmentEvaluationSchema),
+  assessmentEvaluationHandler
+);
+
+module.exports = router;

--- a/backend/services/personalizedLearning.js
+++ b/backend/services/personalizedLearning.js
@@ -1,0 +1,48 @@
+const logger = require('../utils/logger');
+const model = require('../models/personalizedLearning');
+
+async function getAdaptiveContent(userId) {
+  const progress = model.getProgress(userId);
+  let level = progress.level;
+  const score = progress.lastAssessmentScore || 0;
+  if (score >= 80) level = 'advanced';
+  else if (score >= 50) level = 'intermediate';
+  else level = 'beginner';
+
+  const recommendedContent = {
+    level,
+    topics: progress.topics.length ? progress.topics : ['core concepts'],
+  };
+
+  model.saveProgress(userId, { level });
+  logger.info('Generated adaptive content', { userId, level });
+  return { userId, recommendedContent };
+}
+
+async function evaluateAssessment(userId, assessmentId, answers) {
+  const total = answers.length;
+  const correct = answers.filter(a => a.userAnswer === a.correctAnswer).length;
+  const score = Math.round((correct / total) * 100);
+
+  let feedback;
+  if (score >= 80) feedback = 'Excellent progress!';
+  else if (score >= 50) feedback = 'Good effort, keep improving.';
+  else feedback = 'Needs improvement. Review the material.';
+
+  model.saveProgress(userId, { lastAssessmentScore: score });
+  const result = model.saveAssessmentResult({
+    userId,
+    assessmentId,
+    score,
+    feedback,
+    evaluatedAt: new Date(),
+  });
+
+  logger.info('Assessment evaluated', { userId, assessmentId, score });
+  return result;
+}
+
+module.exports = {
+  getAdaptiveContent,
+  evaluateAssessment,
+};

--- a/backend/validation/personalizedLearning.js
+++ b/backend/validation/personalizedLearning.js
@@ -1,0 +1,25 @@
+const Joi = require('joi');
+
+const adaptiveContentParamsSchema = Joi.object({
+  userId: Joi.string().uuid().required(),
+});
+
+const assessmentEvaluationSchema = Joi.object({
+  userId: Joi.string().uuid().required(),
+  assessmentId: Joi.string().required(),
+  answers: Joi.array()
+    .items(
+      Joi.object({
+        questionId: Joi.string().required(),
+        correctAnswer: Joi.any().required(),
+        userAnswer: Joi.any().required(),
+      })
+    )
+    .min(1)
+    .required(),
+});
+
+module.exports = {
+  adaptiveContentParamsSchema,
+  assessmentEvaluationSchema,
+};


### PR DESCRIPTION
## Summary
- add Stage 49 Personalized Learning & Development ML controller
- store learner progress and assessment results in memory with SQL schema placeholders
- secure and validate ML routes for adaptive content and assessment evaluation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68924c54fe6c8320a462b198cd7134b9