### PR TITLE
Add external data integration module with analytics reports

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -30,6 +30,7 @@ const educationAnalyticsRoutes = require('./routes/educationAnalytics');
 const financialAnalyticsRoutes = require('./routes/financialAnalytics');
 const paymentRoutes = require('./routes/payments');
 const employmentAnalyticsRoutes = require('./routes/employmentAnalytics');
+const externalDataMLRoutes = require('./routes/externalDataML');
 
 const app = express();
 app.use(cors());
@@ -67,6 +68,7 @@ app.use('/education-analytics', educationAnalyticsRoutes);
 app.use('/financial-analytics', financialAnalyticsRoutes);
 app.use('/agency/:agencyId/payments', paymentRoutes);
 app.use('/analytics/employment', employmentAnalyticsRoutes);
+app.use('/', externalDataMLRoutes);
 
 // Commission rate adjustment notifications
 app.use('/affiliates/notifications', notificationRoutes);

--- a/backend/controllers/externalDataML.js
+++ b/backend/controllers/externalDataML.js
@@ -1,0 +1,70 @@
+const service = require('../services/externalDataML');
+const logger = require('../utils/logger');
+
+async function analyzeExternalData(req, res) {
+  try {
+    const analysis = await service.analyzeExternalData(req.body);
+    res.json(analysis);
+  } catch (err) {
+    logger.error('External data analysis failed', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function listReports(req, res) {
+  try {
+    const reports = await service.listReports();
+    res.json(reports);
+  } catch (err) {
+    logger.error('Failed to list custom reports', { error: err.message });
+    res.status(500).json({ error: 'Failed to retrieve reports' });
+  }
+}
+
+async function getReportById(req, res) {
+  try {
+    res.json(req.report);
+  } catch (err) {
+    logger.error('Failed to get report', { reportId: req.params.reportId, error: err.message });
+    res.status(500).json({ error: 'Failed to retrieve report' });
+  }
+}
+
+async function createReport(req, res) {
+  try {
+    const report = await service.createReport({ ...req.body, userId: req.user.id });
+    res.status(201).json(report);
+  } catch (err) {
+    logger.error('Failed to create report', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function updateReport(req, res) {
+  try {
+    const updated = await service.updateReport(req.params.reportId, req.body, req.user.id);
+    res.json(updated);
+  } catch (err) {
+    logger.error('Failed to update report', { reportId: req.params.reportId, error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function deleteReport(req, res) {
+  try {
+    await service.deleteReport(req.params.reportId, req.user.id);
+    res.status(204).send();
+  } catch (err) {
+    logger.error('Failed to delete report', { reportId: req.params.reportId, error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  analyzeExternalData,
+  listReports,
+  getReportById,
+  createReport,
+  updateReport,
+  deleteReport,
+};

--- a/backend/database/externalDataML.sql
+++ b/backend/database/externalDataML.sql
@@ -1,0 +1,19 @@
+-- Tables for integrating external data and custom analytics reports
+
+CREATE TABLE IF NOT EXISTS external_data_sources (
+  id SERIAL PRIMARY KEY,
+  source_type VARCHAR(50) NOT NULL,
+  source_name VARCHAR(255) NOT NULL,
+  config JSONB,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS custom_analytics_reports (
+  id UUID PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  description TEXT,
+  metrics JSONB NOT NULL,
+  created_by UUID NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/middleware/loadCustomReport.js
+++ b/backend/middleware/loadCustomReport.js
@@ -1,0 +1,13 @@
+const model = require('../models/externalDataML');
+const logger = require('../utils/logger');
+
+module.exports = (req, res, next) => {
+  const { reportId } = req.params;
+  const report = model.getReport(reportId);
+  if (!report) {
+    logger.error('Custom analytics report not found', { reportId });
+    return res.status(404).json({ error: 'Report not found' });
+  }
+  req.report = report;
+  next();
+};

--- a/backend/models/externalDataML.js
+++ b/backend/models/externalDataML.js
@@ -1,0 +1,57 @@
+const { v4: uuidv4 } = require('uuid');
+
+// In-memory storage for internal metrics and custom reports
+const internalMetrics = [
+  { metric: 'engagement', value: 75 },
+  { metric: 'revenue', value: 5000 },
+  { metric: 'completion_rate', value: 0.85 },
+];
+
+const reports = new Map(); // reportId => report
+
+function getInternalMetrics() {
+  return internalMetrics;
+}
+
+function createReport({ title, description, metrics, createdBy }) {
+  const report = {
+    id: uuidv4(),
+    title,
+    description: description || '',
+    metrics,
+    createdBy,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  reports.set(report.id, report);
+  return report;
+}
+
+function getAllReports() {
+  return Array.from(reports.values());
+}
+
+function getReport(id) {
+  return reports.get(id) || null;
+}
+
+function updateReport(id, data) {
+  const existing = reports.get(id);
+  if (!existing) return null;
+  const updated = { ...existing, ...data, updatedAt: new Date() };
+  reports.set(id, updated);
+  return updated;
+}
+
+function deleteReport(id) {
+  return reports.delete(id);
+}
+
+module.exports = {
+  getInternalMetrics,
+  createReport,
+  getAllReports,
+  getReport,
+  updateReport,
+  deleteReport,
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,10 +12,10 @@
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "express": "^5.1.0",
-        "express-validator": "^7.0.1",
         "express-validator": "^7.2.1",
         "joi": "^17.11.0",
-        "jsonwebtoken": "^9.0.2"
+        "jsonwebtoken": "^9.0.2",
+        "uuid": "^9.0.0"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -1021,6 +1021,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validator": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,10 +14,9 @@
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "jsonwebtoken": "^9.0.2",
-    "express-validator": "^7.0.1"
     "express-validator": "^7.2.1",
     "joi": "^17.11.0",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "uuid": "^9.0.0"
   }
 }

--- a/backend/routes/externalDataML.js
+++ b/backend/routes/externalDataML.js
@@ -1,0 +1,69 @@
+const express = require('express');
+const router = express.Router();
+
+const auth = require('../middleware/auth');
+const authorize = require('../middleware/authorize');
+const validate = require('../middleware/validate');
+const loadCustomReport = require('../middleware/loadCustomReport');
+const controller = require('../controllers/externalDataML');
+const {
+  analyzeExternalDataSchema,
+  createReportSchema,
+  updateReportSchema,
+  reportIdParamSchema,
+} = require('../validation/externalDataML');
+
+// Analyze external data
+router.post(
+  '/ml/external-data/analyze',
+  auth,
+  authorize('admin', 'analytics-manager'),
+  validate(analyzeExternalDataSchema),
+  controller.analyzeExternalData
+);
+
+// Custom analytics reports CRUD
+router.get(
+  '/analytics/custom-reports',
+  auth,
+  authorize('admin', 'analytics-manager'),
+  controller.listReports
+);
+
+router.get(
+  '/analytics/custom-reports/:reportId',
+  auth,
+  authorize('admin', 'analytics-manager'),
+  validate(reportIdParamSchema, 'params'),
+  loadCustomReport,
+  controller.getReportById
+);
+
+router.post(
+  '/analytics/custom-reports',
+  auth,
+  authorize('admin', 'analytics-manager'),
+  validate(createReportSchema),
+  controller.createReport
+);
+
+router.put(
+  '/analytics/custom-reports/:reportId',
+  auth,
+  authorize('admin', 'analytics-manager'),
+  validate(reportIdParamSchema, 'params'),
+  loadCustomReport,
+  validate(updateReportSchema),
+  controller.updateReport
+);
+
+router.delete(
+  '/analytics/custom-reports/:reportId',
+  auth,
+  authorize('admin', 'analytics-manager'),
+  validate(reportIdParamSchema, 'params'),
+  loadCustomReport,
+  controller.deleteReport
+);
+
+module.exports = router;

--- a/backend/services/externalDataML.js
+++ b/backend/services/externalDataML.js
@@ -1,0 +1,62 @@
+const model = require('../models/externalDataML');
+const logger = require('../utils/logger');
+
+async function analyzeExternalData({ sourceType, sourceName, data }) {
+  const internalMetrics = model.getInternalMetrics();
+  const analysis = data.map(item => {
+    const internal = internalMetrics.find(m => m.metric === item.metric);
+    return {
+      metric: item.metric,
+      externalValue: item.value,
+      internalValue: internal ? internal.value : null,
+      combinedValue: internal ? (item.value + internal.value) / 2 : item.value,
+    };
+  });
+  logger.info('External data analyzed', { sourceType, sourceName });
+  return { sourceType, sourceName, metrics: analysis };
+}
+
+async function listReports() {
+  return model.getAllReports();
+}
+
+async function getReportById(id) {
+  const report = model.getReport(id);
+  if (!report) {
+    throw new Error('Report not found');
+  }
+  return report;
+}
+
+async function createReport({ title, description, metrics, userId }) {
+  const report = model.createReport({ title, description, metrics, createdBy: userId });
+  logger.info('Custom analytics report created', { reportId: report.id, userId });
+  return report;
+}
+
+async function updateReport(id, data, userId) {
+  const report = model.updateReport(id, data);
+  if (!report) {
+    throw new Error('Report not found');
+  }
+  logger.info('Custom analytics report updated', { reportId: id, userId });
+  return report;
+}
+
+async function deleteReport(id, userId) {
+  const deleted = model.deleteReport(id);
+  if (!deleted) {
+    throw new Error('Report not found');
+  }
+  logger.info('Custom analytics report deleted', { reportId: id, userId });
+  return true;
+}
+
+module.exports = {
+  analyzeExternalData,
+  listReports,
+  getReportById,
+  createReport,
+  updateReport,
+  deleteReport,
+};

--- a/backend/validation/externalDataML.js
+++ b/backend/validation/externalDataML.js
@@ -1,0 +1,35 @@
+const Joi = require('joi');
+
+const metricSchema = Joi.object({
+  metric: Joi.string().max(255).required(),
+  value: Joi.number().required(),
+});
+
+const analyzeExternalDataSchema = Joi.object({
+  sourceType: Joi.string().max(50).required(),
+  sourceName: Joi.string().max(255).required(),
+  data: Joi.array().items(metricSchema).min(1).required(),
+});
+
+const createReportSchema = Joi.object({
+  title: Joi.string().max(255).required(),
+  description: Joi.string().allow('').max(1000),
+  metrics: Joi.array().items(metricSchema).min(1).required(),
+});
+
+const updateReportSchema = Joi.object({
+  title: Joi.string().max(255),
+  description: Joi.string().allow('').max(1000),
+  metrics: Joi.array().items(metricSchema).min(1),
+}).min(1);
+
+const reportIdParamSchema = Joi.object({
+  reportId: Joi.string().guid({ version: 'uuidv4' }).required(),
+});
+
+module.exports = {
+  analyzeExternalDataSchema,
+  createReportSchema,
+  updateReportSchema,
+  reportIdParamSchema,
+};


### PR DESCRIPTION
## Summary
- add external data ML controller, service, model, and routes
- support custom analytics report CRUD with validation and auth
- create SQL schema and integrate module into backend app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68924c9bdb04832089c7fae7da3104f1