### PR TITLE
feat: add machine learning continuous improvement module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -30,6 +30,8 @@ const educationAnalyticsRoutes = require('./routes/educationAnalytics');
 const financialAnalyticsRoutes = require('./routes/financialAnalytics');
 const paymentRoutes = require('./routes/payments');
 const employmentAnalyticsRoutes = require('./routes/employmentAnalytics');
+const machineLearningRoutes = require('./routes/machineLearning');
+const trendRoutes = require('./routes/trends');
 
 const app = express();
 app.use(cors());
@@ -67,6 +69,8 @@ app.use('/education-analytics', educationAnalyticsRoutes);
 app.use('/financial-analytics', financialAnalyticsRoutes);
 app.use('/agency/:agencyId/payments', paymentRoutes);
 app.use('/analytics/employment', employmentAnalyticsRoutes);
+app.use('/ml', machineLearningRoutes);
+app.use('/trends', trendRoutes);
 
 // Commission rate adjustment notifications
 app.use('/affiliates/notifications', notificationRoutes);

--- a/backend/controllers/machineLearning.js
+++ b/backend/controllers/machineLearning.js
@@ -1,0 +1,128 @@
+const {
+  updateModelTraining,
+  evaluateModelPerformance,
+  getTrendAnalytics,
+  getMetricTrends,
+  getDomainMetricTrends,
+  getDomainMetricHistoryTrends,
+  getDomainMetricForecastTrends,
+  compareDomainMetricTrends,
+  customTrendAnalyticsQuery,
+} = require('../services/machineLearning');
+const logger = require('../utils/logger');
+
+async function updateModelTrainingHandler(req, res) {
+  const { modelName, data } = req.body;
+  try {
+    const update = await updateModelTraining(modelName, data);
+    res.status(201).json(update);
+  } catch (err) {
+    logger.error('Failed to update model training', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function evaluateModelPerformanceHandler(req, res) {
+  const { modelName } = req.query;
+  try {
+    const performance = await evaluateModelPerformance(modelName);
+    res.json(performance);
+  } catch (err) {
+    logger.error('Failed to evaluate model performance', { error: err.message });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getTrendAnalyticsHandler(req, res) {
+  try {
+    const data = await getTrendAnalytics();
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch trend analytics', { error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function getMetricTrendsHandler(req, res) {
+  const { metric } = req.params;
+  try {
+    const data = await getMetricTrends(metric);
+    res.json({ metric, data });
+  } catch (err) {
+    logger.error('Failed to fetch metric trends', { metric, error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function getDomainMetricTrendsHandler(req, res) {
+  const { metric, domain } = req.params;
+  try {
+    const data = await getDomainMetricTrends(metric, domain);
+    res.json({ metric, domain, data });
+  } catch (err) {
+    logger.error('Failed to fetch domain metric trends', { metric, domain, error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function getDomainMetricHistoryTrendsHandler(req, res) {
+  const { metric, domain } = req.params;
+  try {
+    const data = await getDomainMetricHistoryTrends(metric, domain);
+    res.json({ metric, domain, data });
+  } catch (err) {
+    logger.error('Failed to fetch domain metric history', { metric, domain, error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function getDomainMetricForecastTrendsHandler(req, res) {
+  const { metric, domain } = req.params;
+  try {
+    const forecast = await getDomainMetricForecastTrends(metric, domain);
+    res.json({ metric, domain, forecast });
+  } catch (err) {
+    logger.error('Failed to forecast domain metric trends', { metric, domain, error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function compareDomainMetricTrendsHandler(req, res) {
+  const { metric, domain } = req.params;
+  const { compareWith } = req.body;
+  try {
+    const result = await compareDomainMetricTrends(metric, domain, compareWith);
+    res.json(result);
+  } catch (err) {
+    logger.error('Failed to compare domain metric trends', { metric, domain, error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function customTrendAnalyticsQueryHandler(req, res) {
+  const { metric, domain, startDate, endDate } = req.body;
+  try {
+    const result = await customTrendAnalyticsQuery({
+      metric,
+      domain,
+      startDate: startDate ? new Date(startDate) : undefined,
+      endDate: endDate ? new Date(endDate) : undefined,
+    });
+    res.json(result);
+  } catch (err) {
+    logger.error('Failed custom trend analytics query', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  updateModelTrainingHandler,
+  evaluateModelPerformanceHandler,
+  getTrendAnalyticsHandler,
+  getMetricTrendsHandler,
+  getDomainMetricTrendsHandler,
+  getDomainMetricHistoryTrendsHandler,
+  getDomainMetricForecastTrendsHandler,
+  compareDomainMetricTrendsHandler,
+  customTrendAnalyticsQueryHandler,
+};

--- a/backend/database/machine_learning.sql
+++ b/backend/database/machine_learning.sql
@@ -1,0 +1,35 @@
+-- Machine Learning models table
+CREATE TABLE IF NOT EXISTS ml_models (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL UNIQUE,
+  version VARCHAR(100),
+  last_trained TIMESTAMP,
+  metrics JSONB
+);
+
+-- Model updates referencing training data
+CREATE TABLE IF NOT EXISTS model_updates (
+  id SERIAL PRIMARY KEY,
+  model_id INTEGER NOT NULL REFERENCES ml_models(id) ON DELETE CASCADE,
+  payload JSONB NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Model performance evaluations
+CREATE TABLE IF NOT EXISTS model_performance (
+  id SERIAL PRIMARY KEY,
+  model_id INTEGER NOT NULL REFERENCES ml_models(id) ON DELETE CASCADE,
+  accuracy NUMERIC,
+  precision NUMERIC,
+  recall NUMERIC,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Trend analytics metrics
+CREATE TABLE IF NOT EXISTS trend_metrics (
+  id SERIAL PRIMARY KEY,
+  metric VARCHAR(255) NOT NULL,
+  domain VARCHAR(255) NOT NULL,
+  value NUMERIC NOT NULL,
+  recorded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/models/machineLearning.js
+++ b/backend/models/machineLearning.js
@@ -1,0 +1,84 @@
+const { randomUUID } = require('crypto');
+
+// In-memory data stores
+const models = new Map(); // modelName -> { name, updates: [], performance: [], lastUpdated }
+const trends = new Map(); // `${metric}:${domain}` -> [{ timestamp, value }]
+
+// Seed some trend data for demonstration
+function seedTrends() {
+  const metrics = ['engagement', 'revenue'];
+  const domains = ['education', 'employment'];
+  metrics.forEach(metric => {
+    domains.forEach(domain => {
+      const key = `${metric}:${domain}`;
+      const series = [];
+      for (let i = 0; i < 5; i += 1) {
+        series.push({
+          timestamp: new Date(Date.now() - (5 - i) * 24 * 60 * 60 * 1000),
+          value: Number((Math.random() * 100).toFixed(2)),
+        });
+      }
+      trends.set(key, series);
+    });
+  });
+}
+
+seedTrends();
+
+function addModelUpdate(modelName, data) {
+  const model = models.get(modelName) || { name: modelName, updates: [], performance: [] };
+  const update = { id: randomUUID(), data, timestamp: new Date() };
+  model.updates.push(update);
+  model.lastUpdated = update.timestamp;
+  models.set(modelName, model);
+  return update;
+}
+
+function addModelPerformance(modelName, metrics) {
+  const model = models.get(modelName) || { name: modelName, updates: [], performance: [] };
+  const perf = { id: randomUUID(), ...metrics, timestamp: new Date() };
+  model.performance.push(perf);
+  models.set(modelName, model);
+  return perf;
+}
+
+function getLatestPerformance(modelName) {
+  const model = models.get(modelName);
+  if (!model || model.performance.length === 0) return null;
+  return model.performance[model.performance.length - 1];
+}
+
+function getAllTrends() {
+  const result = [];
+  trends.forEach((series, key) => {
+    const [metric, domain] = key.split(':');
+    const latest = series[series.length - 1];
+    result.push({ metric, domain, latest });
+  });
+  return result;
+}
+
+function getTrendsByMetric(metric) {
+  const result = [];
+  trends.forEach((series, key) => {
+    const [m, domain] = key.split(':');
+    if (m === metric) {
+      result.push({ domain, series });
+    }
+  });
+  return result;
+}
+
+function getTrendsByMetricDomain(metric, domain) {
+  const key = `${metric}:${domain}`;
+  return trends.get(key) || [];
+}
+
+module.exports = {
+  addModelUpdate,
+  addModelPerformance,
+  getLatestPerformance,
+  getAllTrends,
+  getTrendsByMetric,
+  getTrendsByMetricDomain,
+};

--- a/backend/routes/machineLearning.js
+++ b/backend/routes/machineLearning.js
@@ -1,0 +1,32 @@
+const express = require('express');
+const {
+  updateModelTrainingHandler,
+  evaluateModelPerformanceHandler,
+} = require('../controllers/machineLearning');
+const auth = require('../middleware/auth');
+const authorize = require('../middleware/authorize');
+const validate = require('../middleware/validate');
+const {
+  modelTrainingUpdateSchema,
+  modelPerformanceQuerySchema,
+} = require('../validation/machineLearning');
+
+const router = express.Router();
+
+router.post(
+  '/model-training/update',
+  auth,
+  authorize('admin', 'ml-engineer'),
+  validate(modelTrainingUpdateSchema),
+  updateModelTrainingHandler,
+);
+
+router.get(
+  '/model-performance/evaluation',
+  auth,
+  authorize('admin', 'ml-engineer'),
+  validate(modelPerformanceQuerySchema, 'query'),
+  evaluateModelPerformanceHandler,
+);
+
+module.exports = router;

--- a/backend/routes/trends.js
+++ b/backend/routes/trends.js
@@ -1,0 +1,74 @@
+const express = require('express');
+const {
+  getTrendAnalyticsHandler,
+  getMetricTrendsHandler,
+  getDomainMetricTrendsHandler,
+  getDomainMetricHistoryTrendsHandler,
+  getDomainMetricForecastTrendsHandler,
+  compareDomainMetricTrendsHandler,
+  customTrendAnalyticsQueryHandler,
+} = require('../controllers/machineLearning');
+const auth = require('../middleware/auth');
+const authorize = require('../middleware/authorize');
+const validate = require('../middleware/validate');
+const {
+  metricParamSchema,
+  metricDomainParamSchema,
+  compareDomainBodySchema,
+  customTrendSchema,
+} = require('../validation/machineLearning');
+
+const router = express.Router();
+
+router.get('/', auth, authorize('admin', 'analytics-manager'), getTrendAnalyticsHandler);
+
+router.get(
+  '/:metric',
+  auth,
+  authorize('admin', 'analytics-manager'),
+  validate(metricParamSchema, 'params'),
+  getMetricTrendsHandler,
+);
+
+router.get(
+  '/:metric/:domain',
+  auth,
+  authorize('admin', 'analytics-manager'),
+  validate(metricDomainParamSchema, 'params'),
+  getDomainMetricTrendsHandler,
+);
+
+router.get(
+  '/:metric/:domain/history',
+  auth,
+  authorize('admin', 'analytics-manager'),
+  validate(metricDomainParamSchema, 'params'),
+  getDomainMetricHistoryTrendsHandler,
+);
+
+router.get(
+  '/:metric/:domain/forecast',
+  auth,
+  authorize('admin', 'analytics-manager'),
+  validate(metricDomainParamSchema, 'params'),
+  getDomainMetricForecastTrendsHandler,
+);
+
+router.post(
+  '/:metric/:domain/compare',
+  auth,
+  authorize('admin', 'analytics-manager'),
+  validate(metricDomainParamSchema, 'params'),
+  validate(compareDomainBodySchema),
+  compareDomainMetricTrendsHandler,
+);
+
+router.post(
+  '/custom',
+  auth,
+  authorize('admin', 'analytics-manager'),
+  validate(customTrendSchema),
+  customTrendAnalyticsQueryHandler,
+);
+
+module.exports = router;

--- a/backend/services/machineLearning.js
+++ b/backend/services/machineLearning.js
@@ -1,0 +1,101 @@
+const logger = require('../utils/logger');
+const model = require('../models/machineLearning');
+
+async function updateModelTraining(modelName, data) {
+  const update = model.addModelUpdate(modelName, data);
+  logger.info('Model training updated', { modelName, updateId: update.id });
+  return update;
+}
+
+async function evaluateModelPerformance(modelName) {
+  const performance = model.getLatestPerformance(modelName);
+  if (!performance) {
+    const message = 'Performance data not found';
+    logger.error(message, { modelName });
+    throw new Error(message);
+  }
+  logger.info('Model performance retrieved', { modelName, performanceId: performance.id });
+  return performance;
+}
+
+async function getTrendAnalytics() {
+  const data = model.getAllTrends();
+  logger.info('Trend analytics retrieved', { count: data.length });
+  return data;
+}
+
+async function getMetricTrends(metric) {
+  const data = model.getTrendsByMetric(metric);
+  logger.info('Metric trends retrieved', { metric, count: data.length });
+  return data;
+}
+
+async function getDomainMetricTrends(metric, domain) {
+  const data = model.getTrendsByMetricDomain(metric, domain);
+  logger.info('Domain metric trends retrieved', { metric, domain, count: data.length });
+  return data;
+}
+
+async function getDomainMetricHistoryTrends(metric, domain) {
+  return getDomainMetricTrends(metric, domain);
+}
+
+async function getDomainMetricForecastTrends(metric, domain) {
+  const series = model.getTrendsByMetricDomain(metric, domain);
+  if (series.length < 2) {
+    const message = 'Insufficient data for forecast';
+    logger.error(message, { metric, domain });
+    throw new Error(message);
+  }
+  const diffs = [];
+  for (let i = 1; i < series.length; i += 1) {
+    diffs.push(series[i].value - series[i - 1].value);
+  }
+  const avgDiff = diffs.reduce((a, b) => a + b, 0) / diffs.length;
+  const last = series[series.length - 1];
+  const forecast = {
+    timestamp: new Date(last.timestamp.getTime() + 24 * 60 * 60 * 1000),
+    value: Number((last.value + avgDiff).toFixed(2)),
+  };
+  logger.info('Forecast generated', { metric, domain, forecast });
+  return forecast;
+}
+
+async function compareDomainMetricTrends(metric, domain, compareWith) {
+  const base = model.getTrendsByMetricDomain(metric, domain);
+  const comparisons = {};
+  compareWith.forEach(other => {
+    comparisons[other] = model.getTrendsByMetricDomain(metric, other);
+  });
+  logger.info('Domain metric comparison completed', { metric, domain, compareWith });
+  return { base: { domain, series: base }, comparisons };
+}
+
+async function customTrendAnalyticsQuery({ metric, domain, startDate, endDate }) {
+  let data;
+  if (domain) {
+    data = model.getTrendsByMetricDomain(metric, domain);
+  } else {
+    data = model.getTrendsByMetric(metric).flatMap(d => d.series);
+  }
+  if (startDate) {
+    data = data.filter(d => d.timestamp >= startDate);
+  }
+  if (endDate) {
+    data = data.filter(d => d.timestamp <= endDate);
+  }
+  logger.info('Custom trend analytics query executed', { metric, domain, count: data.length });
+  return data;
+}
+
+module.exports = {
+  updateModelTraining,
+  evaluateModelPerformance,
+  getTrendAnalytics,
+  getMetricTrends,
+  getDomainMetricTrends,
+  getDomainMetricHistoryTrends,
+  getDomainMetricForecastTrends,
+  compareDomainMetricTrends,
+  customTrendAnalyticsQuery,
+};

--- a/backend/validation/machineLearning.js
+++ b/backend/validation/machineLearning.js
@@ -1,0 +1,39 @@
+const Joi = require('joi');
+
+const modelTrainingUpdateSchema = Joi.object({
+  modelName: Joi.string().required(),
+  data: Joi.array().items(Joi.object()).min(1).required(),
+});
+
+const modelPerformanceQuerySchema = Joi.object({
+  modelName: Joi.string().required(),
+});
+
+const metricParamSchema = Joi.object({
+  metric: Joi.string().required(),
+});
+
+const metricDomainParamSchema = Joi.object({
+  metric: Joi.string().required(),
+  domain: Joi.string().required(),
+});
+
+const compareDomainBodySchema = Joi.object({
+  compareWith: Joi.array().items(Joi.string()).min(1).required(),
+});
+
+const customTrendSchema = Joi.object({
+  metric: Joi.string().required(),
+  domain: Joi.string().optional(),
+  startDate: Joi.date().optional(),
+  endDate: Joi.date().optional(),
+});
+
+module.exports = {
+  modelTrainingUpdateSchema,
+  modelPerformanceQuerySchema,
+  metricParamSchema,
+  metricDomainParamSchema,
+  compareDomainBodySchema,
+  customTrendSchema,
+};


### PR DESCRIPTION
## Summary
- add machine learning controller with model updates and performance evaluation endpoints
- implement trend analytics routes with history, forecast, comparison, and custom query features
- define SQL schema for ML models and analytics metrics

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924d25096c83209405051552d92908