### PR TITLE
feat: add profiles module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -30,6 +30,7 @@ const educationAnalyticsRoutes = require('./routes/educationAnalytics');
 const financialAnalyticsRoutes = require('./routes/financialAnalytics');
 const paymentRoutes = require('./routes/payments');
 const employmentAnalyticsRoutes = require('./routes/employmentAnalytics');
+const profilesRoutes = require('./routes/profiles');
 
 const app = express();
 app.use(cors());
@@ -67,6 +68,7 @@ app.use('/education-analytics', educationAnalyticsRoutes);
 app.use('/financial-analytics', financialAnalyticsRoutes);
 app.use('/agency/:agencyId/payments', paymentRoutes);
 app.use('/analytics/employment', employmentAnalyticsRoutes);
+app.use('/profiles', profilesRoutes);
 
 // Commission rate adjustment notifications
 app.use('/affiliates/notifications', notificationRoutes);

--- a/backend/controllers/profile.js
+++ b/backend/controllers/profile.js
@@ -1,0 +1,109 @@
+const {
+  createMentorProfile,
+  createMenteeProfile,
+  updateProfile,
+  getProfile,
+  uploadPortfolioItem,
+  getPreferences,
+  addOrUpdateSkills,
+  calculateMatchPotential,
+} = require('../services/profile');
+const logger = require('../utils/logger');
+
+async function createMentorProfileHandler(req, res) {
+  try {
+    const profile = await createMentorProfile(req.body);
+    res.status(201).json(profile);
+  } catch (err) {
+    logger.error('Failed to create mentor profile', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function createMenteeProfileHandler(req, res) {
+  try {
+    const profile = await createMenteeProfile(req.body);
+    res.status(201).json(profile);
+  } catch (err) {
+    logger.error('Failed to create mentee profile', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function updateProfileHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const profile = await updateProfile(userId, req.body);
+    res.json(profile);
+  } catch (err) {
+    logger.error('Failed to update profile', { error: err.message, userId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getProfileHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const profile = await getProfile(userId);
+    res.json(profile);
+  } catch (err) {
+    logger.error('Failed to retrieve profile', { error: err.message, userId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function uploadPortfolioItemHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const item = await uploadPortfolioItem(userId, req.body);
+    res.status(201).json(item);
+  } catch (err) {
+    logger.error('Failed to upload portfolio item', { error: err.message, userId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getPreferencesHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const prefs = await getPreferences(userId);
+    res.json(prefs);
+  } catch (err) {
+    logger.error('Failed to retrieve preferences', { error: err.message, userId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function addOrUpdateSkillsHandler(req, res) {
+  const { userId } = req.params;
+  const { skills } = req.body;
+  try {
+    const result = await addOrUpdateSkills(userId, skills);
+    res.json({ skills: result });
+  } catch (err) {
+    logger.error('Failed to update skills', { error: err.message, userId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getMatchPotentialHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const result = await calculateMatchPotential(userId);
+    res.json(result);
+  } catch (err) {
+    logger.error('Failed to calculate match potential', { error: err.message, userId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  createMentorProfileHandler,
+  createMenteeProfileHandler,
+  updateProfileHandler,
+  getProfileHandler,
+  uploadPortfolioItemHandler,
+  getPreferencesHandler,
+  addOrUpdateSkillsHandler,
+  getMatchPotentialHandler,
+};

--- a/backend/database/profiles.sql
+++ b/backend/database/profiles.sql
@@ -1,0 +1,11 @@
+CREATE TABLE profiles (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL UNIQUE,
+  role VARCHAR(10) NOT NULL CHECK (role IN ('mentor','mentee')),
+  bio TEXT,
+  preferences JSONB,
+  skills TEXT[],
+  portfolio JSONB,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/middleware/profileOwnership.js
+++ b/backend/middleware/profileOwnership.js
@@ -1,0 +1,17 @@
+const profileModel = require('../models/profile');
+const logger = require('../utils/logger');
+
+module.exports = (req, res, next) => {
+  const { userId } = req.params;
+  const profile = profileModel.findByUserId(userId);
+  if (!profile) {
+    logger.error('Profile not found', { userId });
+    return res.status(404).json({ error: 'Profile not found' });
+  }
+  if (req.user?.id !== userId) {
+    logger.error('Unauthorized profile access', { userId, requester: req.user?.id });
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  req.profile = profile;
+  next();
+};

--- a/backend/models/profile.js
+++ b/backend/models/profile.js
@@ -1,0 +1,64 @@
+const { randomUUID } = require('crypto');
+
+// In-memory storage for mentor and mentee profiles
+const profiles = [];
+
+function createProfile({ userId, role, bio = '', preferences = {}, skills = [] }) {
+  const profile = {
+    id: randomUUID(),
+    userId,
+    role, // 'mentor' or 'mentee'
+    bio,
+    preferences,
+    skills,
+    portfolio: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  profiles.push(profile);
+  return profile;
+}
+
+function findByUserId(userId) {
+  return profiles.find((p) => p.userId === userId);
+}
+
+function updateProfile(userId, updates) {
+  const profile = findByUserId(userId);
+  if (!profile) return null;
+  Object.assign(profile, updates, { updatedAt: new Date() });
+  return profile;
+}
+
+function addPortfolioItem(userId, item) {
+  const profile = findByUserId(userId);
+  if (!profile) return null;
+  const portfolioItem = { id: randomUUID(), ...item, createdAt: new Date() };
+  profile.portfolio.push(portfolioItem);
+  profile.updatedAt = new Date();
+  return portfolioItem;
+}
+
+function getPreferences(userId) {
+  const profile = findByUserId(userId);
+  return profile ? profile.preferences : null;
+}
+
+function addOrUpdateSkills(userId, skills = []) {
+  const profile = findByUserId(userId);
+  if (!profile) return null;
+  const uniqueSkills = new Set([...(profile.skills || []), ...skills]);
+  profile.skills = Array.from(uniqueSkills);
+  profile.updatedAt = new Date();
+  return profile.skills;
+}
+
+module.exports = {
+  profiles,
+  createProfile,
+  findByUserId,
+  updateProfile,
+  addPortfolioItem,
+  getPreferences,
+  addOrUpdateSkills,
+};

--- a/backend/routes/profiles.js
+++ b/backend/routes/profiles.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const {
+  createMentorProfileHandler,
+  createMenteeProfileHandler,
+  updateProfileHandler,
+  getProfileHandler,
+  uploadPortfolioItemHandler,
+  getPreferencesHandler,
+  addOrUpdateSkillsHandler,
+  getMatchPotentialHandler,
+} = require('../controllers/profile');
+const auth = require('../middleware/auth');
+const validate = require('../middleware/validate');
+const profileOwnership = require('../middleware/profileOwnership');
+const {
+  userIdParamSchema,
+  mentorProfileSchema,
+  menteeProfileSchema,
+  updateProfileSchema,
+  portfolioItemSchema,
+  skillsSchema,
+} = require('../validation/profile');
+
+const router = express.Router();
+
+router.post('/mentor/create', auth, validate(mentorProfileSchema), createMentorProfileHandler);
+router.post('/mentee/create', auth, validate(menteeProfileSchema), createMenteeProfileHandler);
+router.put('/update/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, validate(updateProfileSchema), updateProfileHandler);
+router.get('/:userId', auth, validate(userIdParamSchema, 'params'), getProfileHandler);
+router.post('/portfolio/upload/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, validate(portfolioItemSchema), uploadPortfolioItemHandler);
+router.get('/preferences/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, getPreferencesHandler);
+router.post('/skills/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, validate(skillsSchema), addOrUpdateSkillsHandler);
+router.get('/match-potential/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, getMatchPotentialHandler);
+
+module.exports = router;

--- a/backend/services/profile.js
+++ b/backend/services/profile.js
@@ -1,0 +1,87 @@
+const profileModel = require('../models/profile');
+const logger = require('../utils/logger');
+
+async function createMentorProfile(data) {
+  const profile = profileModel.createProfile({ ...data, role: 'mentor' });
+  logger.info('Mentor profile created', { userId: profile.userId });
+  return profile;
+}
+
+async function createMenteeProfile(data) {
+  const profile = profileModel.createProfile({ ...data, role: 'mentee' });
+  logger.info('Mentee profile created', { userId: profile.userId });
+  return profile;
+}
+
+async function updateProfile(userId, updates) {
+  const profile = profileModel.updateProfile(userId, updates);
+  if (!profile) {
+    logger.error('Profile not found for update', { userId });
+    throw new Error('Profile not found');
+  }
+  logger.info('Profile updated', { userId });
+  return profile;
+}
+
+async function getProfile(userId) {
+  const profile = profileModel.findByUserId(userId);
+  if (!profile) {
+    logger.error('Profile not found', { userId });
+    throw new Error('Profile not found');
+  }
+  return profile;
+}
+
+async function uploadPortfolioItem(userId, item) {
+  const result = profileModel.addPortfolioItem(userId, item);
+  if (!result) {
+    logger.error('Profile not found for portfolio upload', { userId });
+    throw new Error('Profile not found');
+  }
+  logger.info('Portfolio item added', { userId, itemId: result.id });
+  return result;
+}
+
+async function getPreferences(userId) {
+  const prefs = profileModel.getPreferences(userId);
+  if (!prefs) {
+    logger.error('Profile preferences not found', { userId });
+    throw new Error('Profile not found');
+  }
+  return prefs;
+}
+
+async function addOrUpdateSkills(userId, skills) {
+  const result = profileModel.addOrUpdateSkills(userId, skills);
+  if (!result) {
+    logger.error('Profile not found for skills update', { userId });
+    throw new Error('Profile not found');
+  }
+  logger.info('Skills updated', { userId, skillsCount: result.length });
+  return result;
+}
+
+async function calculateMatchPotential(userId) {
+  const profile = profileModel.findByUserId(userId);
+  if (!profile) {
+    logger.error('Profile not found for match potential', { userId });
+    throw new Error('Profile not found');
+  }
+  // Dummy logic: score based on number of skills and preferences
+  const skillScore = (profile.skills || []).length;
+  const preferenceScore = Object.keys(profile.preferences || {}).length;
+  const score = Math.min(100, (skillScore * 10) + (preferenceScore * 5));
+  logger.info('Match potential calculated', { userId, score });
+  return { userId, score };
+}
+
+module.exports = {
+  createMentorProfile,
+  createMenteeProfile,
+  updateProfile,
+  getProfile,
+  uploadPortfolioItem,
+  getPreferences,
+  addOrUpdateSkills,
+  calculateMatchPotential,
+};

--- a/backend/validation/profile.js
+++ b/backend/validation/profile.js
@@ -1,0 +1,48 @@
+const Joi = require('joi');
+
+const userIdParamSchema = Joi.object({
+  userId: Joi.string().uuid().required(),
+});
+
+const mentorProfileSchema = Joi.object({
+  userId: Joi.string().uuid().required(),
+  bio: Joi.string().allow('').optional(),
+  expertise: Joi.string().required(),
+  yearsExperience: Joi.number().integer().min(0).required(),
+  preferences: Joi.object().optional(),
+  skills: Joi.array().items(Joi.string()).optional(),
+});
+
+const menteeProfileSchema = Joi.object({
+  userId: Joi.string().uuid().required(),
+  bio: Joi.string().allow('').optional(),
+  goals: Joi.string().required(),
+  interests: Joi.array().items(Joi.string()).optional(),
+  preferences: Joi.object().optional(),
+  skills: Joi.array().items(Joi.string()).optional(),
+});
+
+const updateProfileSchema = Joi.object({
+  bio: Joi.string(),
+  preferences: Joi.object(),
+  skills: Joi.array().items(Joi.string()),
+}).min(1);
+
+const portfolioItemSchema = Joi.object({
+  title: Joi.string().min(1).required(),
+  description: Joi.string().optional(),
+  link: Joi.string().uri().optional(),
+});
+
+const skillsSchema = Joi.object({
+  skills: Joi.array().items(Joi.string().min(1)).min(1).required(),
+});
+
+module.exports = {
+  userIdParamSchema,
+  mentorProfileSchema,
+  menteeProfileSchema,
+  updateProfileSchema,
+  portfolioItemSchema,
+  skillsSchema,
+};


### PR DESCRIPTION
## Summary
- add mentorship profile controller, service, model, validation, middleware and routes
- include SQL schema for profiles table
- wire profiles routes into backend app

## Testing
- `npm test` *(fails: Invalid package.json - JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_68924d37bff08320a92212d24065647a