### PR TITLE
feat: add session management module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -30,6 +30,7 @@ const educationAnalyticsRoutes = require('./routes/educationAnalytics');
 const financialAnalyticsRoutes = require('./routes/financialAnalytics');
 const paymentRoutes = require('./routes/payments');
 const employmentAnalyticsRoutes = require('./routes/employmentAnalytics');
+const sessionRoutes = require('./routes/sessions');
 
 const app = express();
 app.use(cors());
@@ -67,6 +68,7 @@ app.use('/education-analytics', educationAnalyticsRoutes);
 app.use('/financial-analytics', financialAnalyticsRoutes);
 app.use('/agency/:agencyId/payments', paymentRoutes);
 app.use('/analytics/employment', employmentAnalyticsRoutes);
+app.use('/sessions', sessionRoutes);
 
 // Commission rate adjustment notifications
 app.use('/affiliates/notifications', notificationRoutes);

--- a/backend/controllers/sessionManagement.js
+++ b/backend/controllers/sessionManagement.js
@@ -1,0 +1,109 @@
+const {
+  scheduleSession,
+  setAgenda,
+  getReminders,
+  shareNotes,
+  rescheduleSession,
+  cancelSession,
+  getUpcomingSessions,
+  requestMaterials,
+} = require('../services/session');
+const logger = require('../utils/logger');
+
+async function scheduleSessionHandler(req, res) {
+  try {
+    const session = scheduleSession(req.body);
+    res.status(201).json(session);
+  } catch (err) {
+    logger.error('Failed to schedule session', err);
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function setAgendaHandler(req, res) {
+  const { sessionId } = req.params;
+  try {
+    const session = setAgenda(sessionId, req.body.agenda);
+    res.json(session);
+  } catch (err) {
+    logger.error('Failed to set agenda', err);
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getRemindersHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const reminders = getReminders(userId);
+    res.json(reminders);
+  } catch (err) {
+    logger.error('Failed to get reminders', err);
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function shareNotesHandler(req, res) {
+  const { sessionId } = req.params;
+  try {
+    const session = shareNotes(sessionId, req.body.note);
+    res.json(session);
+  } catch (err) {
+    logger.error('Failed to share notes', err);
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function rescheduleSessionHandler(req, res) {
+  const { sessionId } = req.params;
+  try {
+    const session = rescheduleSession(sessionId, req.body.newTime);
+    res.json(session);
+  } catch (err) {
+    logger.error('Failed to reschedule session', err);
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function cancelSessionHandler(req, res) {
+  const { sessionId } = req.params;
+  try {
+    const session = cancelSession(sessionId);
+    res.json(session);
+  } catch (err) {
+    logger.error('Failed to cancel session', err);
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getUpcomingSessionsHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const sessions = getUpcomingSessions(userId);
+    res.json(sessions);
+  } catch (err) {
+    logger.error('Failed to get upcoming sessions', err);
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function requestMaterialsHandler(req, res) {
+  const { sessionId } = req.params;
+  try {
+    const session = requestMaterials(sessionId, req.body.materials);
+    res.json(session);
+  } catch (err) {
+    logger.error('Failed to request materials', err);
+    res.status(404).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  scheduleSessionHandler,
+  setAgendaHandler,
+  getRemindersHandler,
+  shareNotesHandler,
+  rescheduleSessionHandler,
+  cancelSessionHandler,
+  getUpcomingSessionsHandler,
+  requestMaterialsHandler,
+};

--- a/backend/database/sessions.sql
+++ b/backend/database/sessions.sql
@@ -1,0 +1,12 @@
+CREATE TABLE sessions (
+  id SERIAL PRIMARY KEY,
+  mentor_id INTEGER NOT NULL,
+  mentee_id INTEGER NOT NULL,
+  scheduled_for TIMESTAMP NOT NULL,
+  agenda TEXT,
+  notes TEXT,
+  materials TEXT,
+  status VARCHAR(20) DEFAULT 'scheduled',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/middleware/session.js
+++ b/backend/middleware/session.js
@@ -1,0 +1,13 @@
+const { getSessionById } = require('../models/session');
+const logger = require('../utils/logger');
+
+module.exports = (req, res, next) => {
+  const { sessionId } = req.params;
+  const session = getSessionById(sessionId);
+  if (!session) {
+    logger.error('Session not found', { sessionId });
+    return res.status(404).json({ error: 'Session not found' });
+  }
+  req.session = session;
+  next();
+};

--- a/backend/models/session.js
+++ b/backend/models/session.js
@@ -1,0 +1,44 @@
+const sessions = [];
+let idCounter = 1;
+
+function createSession({ mentorId, menteeId, scheduledFor }) {
+  const session = {
+    id: idCounter++,
+    mentorId: Number(mentorId),
+    menteeId: Number(menteeId),
+    scheduledFor: new Date(scheduledFor),
+    agenda: null,
+    notes: [],
+    materials: [],
+    status: 'scheduled',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  sessions.push(session);
+  return session;
+}
+
+function getSessionById(id) {
+  return sessions.find((s) => s.id === Number(id));
+}
+
+function updateSession(id, updates) {
+  const session = getSessionById(id);
+  if (!session) return null;
+  Object.assign(session, updates, { updatedAt: new Date() });
+  return session;
+}
+
+function getSessionsByUser(userId) {
+  return sessions.filter(
+    (s) => s.mentorId === Number(userId) || s.menteeId === Number(userId)
+  );
+}
+
+module.exports = {
+  sessions,
+  createSession,
+  getSessionById,
+  updateSession,
+  getSessionsByUser,
+};

--- a/backend/routes/sessions.js
+++ b/backend/routes/sessions.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const { authenticate } = require('../middleware/auth');
+const validate = require('../middleware/validate');
+const sessionExists = require('../middleware/session');
+const {
+  scheduleSessionSchema,
+  agendaSchema,
+  noteSchema,
+  rescheduleSchema,
+  materialsRequestSchema,
+} = require('../validation/session');
+const {
+  scheduleSessionHandler,
+  setAgendaHandler,
+  getRemindersHandler,
+  shareNotesHandler,
+  rescheduleSessionHandler,
+  cancelSessionHandler,
+  getUpcomingSessionsHandler,
+  requestMaterialsHandler,
+} = require('../controllers/sessionManagement');
+
+const router = express.Router();
+
+router.post('/schedule', authenticate, validate(scheduleSessionSchema), scheduleSessionHandler);
+
+router.put('/agenda/set/:sessionId', authenticate, sessionExists, validate(agendaSchema), setAgendaHandler);
+
+router.get('/reminders/:userId', authenticate, getRemindersHandler);
+
+router.post('/notes/share/:sessionId', authenticate, sessionExists, validate(noteSchema), shareNotesHandler);
+
+router.post('/reschedule/:sessionId', authenticate, sessionExists, validate(rescheduleSchema), rescheduleSessionHandler);
+
+router.post('/cancel/:sessionId', authenticate, sessionExists, cancelSessionHandler);
+
+router.get('/upcoming/:userId', authenticate, getUpcomingSessionsHandler);
+
+router.post('/materials/request/:sessionId', authenticate, sessionExists, validate(materialsRequestSchema), requestMaterialsHandler);
+
+module.exports = router;

--- a/backend/services/session.js
+++ b/backend/services/session.js
@@ -1,0 +1,86 @@
+const {
+  createSession,
+  getSessionById,
+  updateSession,
+  getSessionsByUser,
+} = require('../models/session');
+const logger = require('../utils/logger');
+
+function scheduleSession(data) {
+  logger.info('Scheduling session', { mentorId: data.mentorId, menteeId: data.menteeId });
+  return createSession(data);
+}
+
+function setAgenda(sessionId, agenda) {
+  const session = updateSession(sessionId, { agenda });
+  if (!session) {
+    throw new Error('Session not found');
+  }
+  logger.info('Agenda set for session', { sessionId });
+  return session;
+}
+
+function getReminders(userId) {
+  const now = new Date();
+  return getSessionsByUser(userId).filter(
+    (s) => s.status === 'scheduled' && s.scheduledFor > now
+  );
+}
+
+function shareNotes(sessionId, note) {
+  const session = getSessionById(sessionId);
+  if (!session) {
+    throw new Error('Session not found');
+  }
+  session.notes.push({ note, createdAt: new Date() });
+  session.updatedAt = new Date();
+  logger.info('Note shared for session', { sessionId });
+  return session;
+}
+
+function rescheduleSession(sessionId, newTime) {
+  const session = updateSession(sessionId, { scheduledFor: new Date(newTime) });
+  if (!session) {
+    throw new Error('Session not found');
+  }
+  logger.info('Session rescheduled', { sessionId });
+  return session;
+}
+
+function cancelSession(sessionId) {
+  const session = updateSession(sessionId, { status: 'cancelled' });
+  if (!session) {
+    throw new Error('Session not found');
+  }
+  logger.info('Session cancelled', { sessionId });
+  return session;
+}
+
+function getUpcomingSessions(userId) {
+  const now = new Date();
+  return getSessionsByUser(userId).filter(
+    (s) => s.status === 'scheduled' && s.scheduledFor > now
+  );
+}
+
+function requestMaterials(sessionId, materials) {
+  const session = getSessionById(sessionId);
+  if (!session) {
+    throw new Error('Session not found');
+  }
+  session.materials.push(...materials);
+  session.updatedAt = new Date();
+  logger.info('Materials requested for session', { sessionId });
+  return session;
+}
+
+module.exports = {
+  scheduleSession,
+  setAgenda,
+  getReminders,
+  shareNotes,
+  rescheduleSession,
+  cancelSession,
+  getUpcomingSessions,
+  requestMaterials,
+};

--- a/backend/validation/session.js
+++ b/backend/validation/session.js
@@ -1,0 +1,31 @@
+const Joi = require('joi');
+
+const scheduleSessionSchema = Joi.object({
+  mentorId: Joi.number().integer().required(),
+  menteeId: Joi.number().integer().required(),
+  scheduledFor: Joi.date().iso().required(),
+});
+
+const agendaSchema = Joi.object({
+  agenda: Joi.string().min(1).required(),
+});
+
+const noteSchema = Joi.object({
+  note: Joi.string().min(1).required(),
+});
+
+const rescheduleSchema = Joi.object({
+  newTime: Joi.date().iso().required(),
+});
+
+const materialsRequestSchema = Joi.object({
+  materials: Joi.array().items(Joi.string().min(1)).min(1).required(),
+});
+
+module.exports = {
+  scheduleSessionSchema,
+  agendaSchema,
+  noteSchema,
+  rescheduleSchema,
+  materialsRequestSchema,
+};


### PR DESCRIPTION
## Summary
- add session management model, service, and controller
- expose scheduling, notes, rescheduling, cancellation, reminders, upcoming sessions, and material request routes
- wire session routes into application and provide SQL schema

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924d5051b083208708920d41810187