### PR TITLE
Add participant management module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -30,6 +30,7 @@ const educationAnalyticsRoutes = require('./routes/educationAnalytics');
 const financialAnalyticsRoutes = require('./routes/financialAnalytics');
 const paymentRoutes = require('./routes/payments');
 const employmentAnalyticsRoutes = require('./routes/employmentAnalytics');
+const participantRoutes = require('./routes/participants');
 
 const app = express();
 app.use(cors());
@@ -67,6 +68,7 @@ app.use('/education-analytics', educationAnalyticsRoutes);
 app.use('/financial-analytics', financialAnalyticsRoutes);
 app.use('/agency/:agencyId/payments', paymentRoutes);
 app.use('/analytics/employment', employmentAnalyticsRoutes);
+app.use('/participants', participantRoutes);
 
 // Commission rate adjustment notifications
 app.use('/affiliates/notifications', notificationRoutes);

--- a/backend/controllers/participant.js
+++ b/backend/controllers/participant.js
@@ -1,0 +1,116 @@
+const {
+  registerParticipant,
+  setPreferences,
+  getPreEventMatches,
+  joinWaitlist,
+  processRegistrationPayment,
+  getParticipantProfile,
+  updateParticipantProfile,
+  cancelRegistration,
+} = require('../services/participant');
+const logger = require('../utils/logger');
+
+async function registerParticipantHandler(req, res) {
+  const { eventId } = req.params;
+  const userId = req.user?.username;
+  try {
+    const participant = await registerParticipant(eventId, userId, req.body);
+    res.status(201).json(participant);
+  } catch (err) {
+    logger.error('Failed to register participant', { error: err.message, eventId, userId });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function setPreferencesHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const participant = await setPreferences(userId, req.body);
+    res.json(participant);
+  } catch (err) {
+    logger.error('Failed to update preferences', { error: err.message, userId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getPreEventMatchesHandler(req, res) {
+  const { eventId } = req.params;
+  const userId = req.user?.username;
+  try {
+    const matches = await getPreEventMatches(eventId, userId);
+    res.json(matches);
+  } catch (err) {
+    logger.error('Failed to get pre-event matches', { error: err.message, eventId, userId });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function joinWaitlistHandler(req, res) {
+  const { eventId } = req.params;
+  const userId = req.user?.username;
+  try {
+    const result = await joinWaitlist(eventId, userId);
+    res.status(201).json(result);
+  } catch (err) {
+    logger.error('Failed to join waitlist', { error: err.message, eventId, userId });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function processPaymentHandler(req, res) {
+  const { eventId } = req.params;
+  const userId = req.user?.username;
+  try {
+    const participant = await processRegistrationPayment(eventId, userId, req.body);
+    res.json(participant);
+  } catch (err) {
+    logger.error('Failed to process payment', { error: err.message, eventId, userId });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function viewProfileHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const participant = await getParticipantProfile(userId);
+    res.json(participant);
+  } catch (err) {
+    logger.error('Failed to view profile', { error: err.message, userId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function updateProfileHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const participant = await updateParticipantProfile(userId, req.body);
+    res.json(participant);
+  } catch (err) {
+    logger.error('Failed to update profile', { error: err.message, userId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function cancelRegistrationHandler(req, res) {
+  const { eventId } = req.params;
+  const userId = req.user?.username;
+  try {
+    const participant = await cancelRegistration(eventId, userId);
+    res.json(participant);
+  } catch (err) {
+    logger.error('Failed to cancel registration', { error: err.message, eventId, userId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  registerParticipantHandler,
+  setPreferencesHandler,
+  getPreEventMatchesHandler,
+  joinWaitlistHandler,
+  processPaymentHandler,
+  viewProfileHandler,
+  updateProfileHandler,
+  cancelRegistrationHandler,
+};
+

--- a/backend/database/participant.sql
+++ b/backend/database/participant.sql
@@ -1,0 +1,22 @@
+-- SQL schema for Participant Management module
+
+CREATE TABLE participants (
+  id SERIAL PRIMARY KEY,
+  event_id INTEGER NOT NULL,
+  user_id VARCHAR(255) NOT NULL,
+  profile JSONB,
+  preferences JSONB,
+  status VARCHAR(50) DEFAULT 'registered',
+  payment_amount NUMERIC,
+  payment_method VARCHAR(100),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE event_waitlists (
+  event_id INTEGER NOT NULL,
+  user_id VARCHAR(255) NOT NULL,
+  added_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (event_id, user_id)
+);
+

--- a/backend/middleware/participant.js
+++ b/backend/middleware/participant.js
@@ -1,0 +1,14 @@
+const logger = require('../utils/logger');
+
+function ensureSelf(req, res, next) {
+  const requested = req.params.userId;
+  const current = req.user?.username;
+  if (!requested || requested !== current) {
+    logger.error('Forbidden participant access', { current, requested });
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  next();
+}
+
+module.exports = { ensureSelf };
+

--- a/backend/models/participant.js
+++ b/backend/models/participant.js
@@ -1,0 +1,103 @@
+const { randomUUID } = require('crypto');
+
+// In-memory storage for participants keyed by `${eventId}:${userId}`
+const participants = new Map();
+// Waitlists keyed by eventId -> Set of userIds
+const waitlists = new Map();
+
+function key(eventId, userId) {
+  return `${eventId}:${userId}`;
+}
+
+function register(eventId, userId, profile) {
+  const k = key(eventId, userId);
+  if (participants.has(k)) {
+    throw new Error('User already registered for this event');
+  }
+  const participant = {
+    id: randomUUID(),
+    eventId,
+    userId,
+    profile: { ...profile },
+    preferences: {},
+    status: 'registered',
+    payment: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  participants.set(k, participant);
+  return participant;
+}
+
+function getParticipant(eventId, userId) {
+  return participants.get(key(eventId, userId)) || null;
+}
+
+function findByUser(userId) {
+  for (const participant of participants.values()) {
+    if (participant.userId === userId) return participant;
+  }
+  return null;
+}
+
+function updatePreferences(userId, preferences) {
+  const participant = findByUser(userId);
+  if (!participant) return null;
+  participant.preferences = { ...participant.preferences, ...preferences };
+  participant.updatedAt = new Date();
+  return participant;
+}
+
+function listByEvent(eventId) {
+  return Array.from(participants.values()).filter(
+    (p) => p.eventId === eventId && p.status === 'registered'
+  );
+}
+
+function addToWaitlist(eventId, userId) {
+  const list = waitlists.get(eventId) || new Set();
+  list.add(userId);
+  waitlists.set(eventId, list);
+  return { eventId, userId };
+}
+
+function processPayment(eventId, userId, payment) {
+  const participant = getParticipant(eventId, userId);
+  if (!participant) return null;
+  participant.payment = {
+    amount: payment.amount,
+    method: payment.method,
+    paidAt: new Date(),
+  };
+  participant.updatedAt = new Date();
+  return participant;
+}
+
+function updateProfile(userId, updates) {
+  const participant = findByUser(userId);
+  if (!participant) return null;
+  participant.profile = { ...participant.profile, ...updates };
+  participant.updatedAt = new Date();
+  return participant;
+}
+
+function cancelRegistration(eventId, userId) {
+  const participant = getParticipant(eventId, userId);
+  if (!participant) return null;
+  participant.status = 'cancelled';
+  participant.updatedAt = new Date();
+  return participant;
+}
+
+module.exports = {
+  register,
+  getParticipant,
+  findByUser,
+  updatePreferences,
+  listByEvent,
+  addToWaitlist,
+  processPayment,
+  updateProfile,
+  cancelRegistration,
+};
+

--- a/backend/routes/participants.js
+++ b/backend/routes/participants.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const {
+  registerParticipantHandler,
+  setPreferencesHandler,
+  getPreEventMatchesHandler,
+  joinWaitlistHandler,
+  processPaymentHandler,
+  viewProfileHandler,
+  updateProfileHandler,
+  cancelRegistrationHandler,
+} = require('../controllers/participant');
+const auth = require('../middleware/auth');
+const { ensureSelf } = require('../middleware/participant');
+const validate = require('../middleware/validate');
+const {
+  registerSchema,
+  preferencesSchema,
+  paymentSchema,
+  profileUpdateSchema,
+} = require('../validation/participant');
+
+const router = express.Router();
+
+router.post('/register/:eventId', auth, validate(registerSchema), registerParticipantHandler);
+router.put('/preferences/:userId', auth, ensureSelf, validate(preferencesSchema), setPreferencesHandler);
+router.get('/matches/pre-event/:eventId', auth, getPreEventMatchesHandler);
+router.post('/waitlist/:eventId', auth, joinWaitlistHandler);
+router.post('/payment/process/:eventId', auth, validate(paymentSchema), processPaymentHandler);
+router.get('/profile/view/:userId', auth, ensureSelf, viewProfileHandler);
+router.put('/profile/update/:userId', auth, ensureSelf, validate(profileUpdateSchema), updateProfileHandler);
+router.post('/cancel/:eventId', auth, cancelRegistrationHandler);
+
+module.exports = router;
+

--- a/backend/services/participant.js
+++ b/backend/services/participant.js
@@ -1,0 +1,79 @@
+const participantModel = require('../models/participant');
+const logger = require('../utils/logger');
+
+async function registerParticipant(eventId, userId, profile) {
+  const participant = participantModel.register(eventId, userId, profile);
+  logger.info('Participant registered', { eventId, userId });
+  return participant;
+}
+
+async function setPreferences(userId, preferences) {
+  const participant = participantModel.updatePreferences(userId, preferences);
+  if (!participant) {
+    throw new Error('Participant not found');
+  }
+  logger.info('Participant preferences updated', { userId });
+  return participant;
+}
+
+async function getPreEventMatches(eventId, userId) {
+  const participants = participantModel.listByEvent(eventId).filter(
+    (p) => p.userId !== userId
+  );
+  // simple random sample up to 5 matches
+  const shuffled = participants.sort(() => 0.5 - Math.random());
+  return shuffled.slice(0, 5);
+}
+
+async function joinWaitlist(eventId, userId) {
+  const result = participantModel.addToWaitlist(eventId, userId);
+  logger.info('User added to waitlist', { eventId, userId });
+  return result;
+}
+
+async function processRegistrationPayment(eventId, userId, payment) {
+  const participant = participantModel.processPayment(eventId, userId, payment);
+  if (!participant) {
+    throw new Error('Participant not found');
+  }
+  logger.info('Registration payment processed', { eventId, userId, amount: payment.amount });
+  return participant;
+}
+
+async function getParticipantProfile(userId) {
+  const participant = participantModel.findByUser(userId);
+  if (!participant) {
+    throw new Error('Participant not found');
+  }
+  return participant;
+}
+
+async function updateParticipantProfile(userId, updates) {
+  const participant = participantModel.updateProfile(userId, updates);
+  if (!participant) {
+    throw new Error('Participant not found');
+  }
+  logger.info('Participant profile updated', { userId });
+  return participant;
+}
+
+async function cancelRegistration(eventId, userId) {
+  const participant = participantModel.cancelRegistration(eventId, userId);
+  if (!participant) {
+    throw new Error('Participant not found');
+  }
+  logger.info('Participant registration cancelled', { eventId, userId });
+  return participant;
+}
+
+module.exports = {
+  registerParticipant,
+  setPreferences,
+  getPreEventMatches,
+  joinWaitlist,
+  processRegistrationPayment,
+  getParticipantProfile,
+  updateParticipantProfile,
+  cancelRegistration,
+};
+

--- a/backend/validation/participant.js
+++ b/backend/validation/participant.js
@@ -1,0 +1,31 @@
+const Joi = require('joi');
+
+const registerSchema = Joi.object({
+  name: Joi.string().max(100).required(),
+  email: Joi.string().email().required(),
+  bio: Joi.string().max(500).allow('', null),
+});
+
+const preferencesSchema = Joi.object({
+  topics: Joi.array().items(Joi.string()).default([]),
+  goals: Joi.string().max(500).allow('', null),
+});
+
+const paymentSchema = Joi.object({
+  amount: Joi.number().positive().required(),
+  method: Joi.string().max(50).required(),
+});
+
+const profileUpdateSchema = Joi.object({
+  name: Joi.string().max(100),
+  email: Joi.string().email(),
+  bio: Joi.string().max(500).allow('', null),
+}).min(1);
+
+module.exports = {
+  registerSchema,
+  preferencesSchema,
+  paymentSchema,
+  profileUpdateSchema,
+};
+


### PR DESCRIPTION
## Summary
- add participant model, service, controller, validation, middleware and SQL schema
- expose participant registration, preferences, matching, waitlist, payment, profile and cancellation routes
- wire participant routes into backend app

## Testing
- `npm test` *(fails: Invalid package.json JSON parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68924d9e038c8320a2f6a97c8b008798