### PR TITLE
feat: add user progress module

### DIFF
--- a/backend/controllers/userProgress.js
+++ b/backend/controllers/userProgress.js
@@ -1,0 +1,83 @@
+const {
+  trackProgress,
+  getUserProgress,
+  getCourseProgress,
+  getDetailedProgress,
+  setLearningGoal,
+  getLearningGoals,
+} = require('../services/userProgress');
+const logger = require('../utils/logger');
+
+async function trackProgressHandler(req, res) {
+  try {
+    const record = await trackProgress(req.body);
+    res.status(201).json(record);
+  } catch (err) {
+    logger.error('Failed to track progress', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function getUserProgressHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const data = await getUserProgress(userId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch user progress', { error: err.message, userId });
+    res.status(500).json({ error: 'Failed to fetch user progress' });
+  }
+}
+
+async function getCourseProgressHandler(req, res) {
+  const { courseId, userId } = req.params;
+  try {
+    const data = await getCourseProgress(courseId, userId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch course progress', { error: err.message, courseId, userId });
+    res.status(500).json({ error: 'Failed to fetch course progress' });
+  }
+}
+
+async function getDetailedProgressHandler(req, res) {
+  const { userId, courseId } = req.params;
+  try {
+    const data = await getDetailedProgress(userId, courseId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch detailed progress', { error: err.message, courseId, userId });
+    res.status(500).json({ error: 'Failed to fetch detailed progress' });
+  }
+}
+
+async function setLearningGoalHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const goal = await setLearningGoal(userId, req.body);
+    res.status(201).json(goal);
+  } catch (err) {
+    logger.error('Failed to set learning goal', { error: err.message, userId });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function getLearningGoalsHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const goals = await getLearningGoals(userId);
+    res.json(goals);
+  } catch (err) {
+    logger.error('Failed to fetch learning goals', { error: err.message, userId });
+    res.status(500).json({ error: 'Failed to fetch learning goals' });
+  }
+}
+
+module.exports = {
+  trackProgressHandler,
+  getUserProgressHandler,
+  getCourseProgressHandler,
+  getDetailedProgressHandler,
+  setLearningGoalHandler,
+  getLearningGoalsHandler,
+};

--- a/backend/database/user_progress.sql
+++ b/backend/database/user_progress.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS user_progress (
+  id UUID PRIMARY KEY,
+  user_id VARCHAR(255) NOT NULL,
+  course_id VARCHAR(255) NOT NULL,
+  activity VARCHAR(255),
+  progress DECIMAL(5,2) NOT NULL,
+  details TEXT,
+  tracked_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS learning_goals (
+  id UUID PRIMARY KEY,
+  user_id VARCHAR(255) NOT NULL,
+  goal TEXT NOT NULL,
+  target_date DATE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/middleware/userProgress.js
+++ b/backend/middleware/userProgress.js
@@ -1,0 +1,13 @@
+// Middleware to ensure a user can only access their own user progress data unless admin
+module.exports = function ensureUserProgressAccess(req, res, next) {
+  const targetUserId = req.params.userId || req.body.userId;
+  if (!targetUserId) {
+    return res.status(400).json({ error: 'User identifier required' });
+  }
+  const user = req.user || {};
+  const isAdmin = user.role === 'admin' || (Array.isArray(user.roles) && user.roles.includes('admin'));
+  if (isAdmin || user.username === targetUserId) {
+    return next();
+  }
+  return res.status(403).json({ error: 'Forbidden' });
+};

--- a/backend/models/userProgress.js
+++ b/backend/models/userProgress.js
@@ -1,0 +1,53 @@
+const { randomUUID } = require('crypto');
+
+// In-memory store for user progress and learning goals
+const progressRecords = [];
+const learningGoals = [];
+
+function addProgress({ userId, courseId, activity, progress, details, trackedAt = new Date() }) {
+  const record = {
+    id: randomUUID(),
+    userId,
+    courseId,
+    activity: activity || null,
+    progress,
+    details: details || null,
+    trackedAt,
+    updatedAt: new Date(),
+  };
+  progressRecords.push(record);
+  return record;
+}
+
+function listProgressByUser(userId) {
+  return progressRecords.filter((p) => p.userId === userId);
+}
+
+function listProgressByCourseForUser(courseId, userId) {
+  return progressRecords.filter((p) => p.userId === userId && p.courseId === courseId);
+}
+
+function addLearningGoal(userId, { goal, targetDate }) {
+  const record = {
+    id: randomUUID(),
+    userId,
+    goal,
+    targetDate: targetDate ? new Date(targetDate) : null,
+    createdAt: new Date(),
+  };
+  learningGoals.push(record);
+  return record;
+}
+
+function listLearningGoals(userId) {
+  return learningGoals.filter((g) => g.userId === userId);
+}
+
+module.exports = {
+  addProgress,
+  listProgressByUser,
+  listProgressByCourseForUser,
+  addLearningGoal,
+  listLearningGoals,
+};
+

--- a/backend/routes/progress.js
+++ b/backend/routes/progress.js
@@ -5,16 +5,40 @@ const {
   createCustomAlertHandler,
   getTimelineHandler,
 } = require('../controllers/progressTracking');
+const {
+  trackProgressHandler,
+  getUserProgressHandler,
+  getCourseProgressHandler,
+  getDetailedProgressHandler,
+  setLearningGoalHandler,
+  getLearningGoalsHandler,
+} = require('../controllers/userProgress');
 const auth = require('../middleware/auth');
 const validate = require('../middleware/validate');
 const ensureProgressAccess = require('../middleware/progress');
-const { userIdParamSchema, customAlertSchema } = require('../validation/progressTracking');
+const ensureUserProgressAccess = require('../middleware/userProgress');
+const { userIdParamSchema: trackingUserIdParamSchema, customAlertSchema } = require('../validation/progressTracking');
+const {
+  trackProgressSchema,
+  userIdParamSchema,
+  courseUserParamSchema,
+  learningGoalSchema,
+} = require('../validation/userProgress');
 
 const router = express.Router();
 
-router.get('/dashboard/:userId', auth, validate(userIdParamSchema, 'params'), ensureProgressAccess, getDashboardHandler);
-router.get('/alerts/:userId', auth, validate(userIdParamSchema, 'params'), ensureProgressAccess, getAlertsHandler);
+// Progress tracking routes
+router.get('/dashboard/:userId', auth, validate(trackingUserIdParamSchema, 'params'), ensureProgressAccess, getDashboardHandler);
+router.get('/alerts/:userId', auth, validate(trackingUserIdParamSchema, 'params'), ensureProgressAccess, getAlertsHandler);
 router.post('/custom-alerts/create', auth, validate(customAlertSchema), ensureProgressAccess, createCustomAlertHandler);
-router.get('/timeline/:userId', auth, validate(userIdParamSchema, 'params'), ensureProgressAccess, getTimelineHandler);
+router.get('/timeline/:userId', auth, validate(trackingUserIdParamSchema, 'params'), ensureProgressAccess, getTimelineHandler);
+
+// User progress routes
+router.post('/track', auth, validate(trackProgressSchema), ensureUserProgressAccess, trackProgressHandler);
+router.get('/:userId', auth, validate(userIdParamSchema, 'params'), ensureUserProgressAccess, getUserProgressHandler);
+router.get('/course/:courseId/user/:userId', auth, validate(courseUserParamSchema, 'params'), ensureUserProgressAccess, getCourseProgressHandler);
+router.get('/detail/:userId/course/:courseId', auth, validate(courseUserParamSchema, 'params'), ensureUserProgressAccess, getDetailedProgressHandler);
+router.post('/goals/:userId', auth, validate(userIdParamSchema, 'params'), ensureUserProgressAccess, validate(learningGoalSchema), setLearningGoalHandler);
+router.get('/goals/:userId', auth, validate(userIdParamSchema, 'params'), ensureUserProgressAccess, getLearningGoalsHandler);
 
 module.exports = router;

--- a/backend/services/userProgress.js
+++ b/backend/services/userProgress.js
@@ -1,0 +1,53 @@
+const logger = require('../utils/logger');
+const progressModel = require('../models/userProgress');
+
+async function trackProgress(data) {
+  const record = progressModel.addProgress(data);
+  logger.info('Progress tracked', { userId: data.userId, courseId: data.courseId, progressId: record.id });
+  return record;
+}
+
+async function getUserProgress(userId) {
+  const entries = progressModel.listProgressByUser(userId);
+  const summary = {};
+  for (const entry of entries) {
+    if (!summary[entry.courseId]) {
+      summary[entry.courseId] = [];
+    }
+    summary[entry.courseId].push(entry.progress);
+  }
+  const courses = Object.keys(summary).map((courseId) => ({
+    courseId,
+    averageProgress: summary[courseId].reduce((a, b) => a + b, 0) / summary[courseId].length,
+  }));
+  return { userId, courses };
+}
+
+async function getCourseProgress(courseId, userId) {
+  const entries = progressModel.listProgressByCourseForUser(courseId, userId);
+  const average = entries.reduce((acc, e) => acc + e.progress, 0) / (entries.length || 1);
+  return { userId, courseId, averageProgress: entries.length ? average : 0 };
+}
+
+async function getDetailedProgress(userId, courseId) {
+  return progressModel.listProgressByCourseForUser(courseId, userId);
+}
+
+async function setLearningGoal(userId, data) {
+  const goal = progressModel.addLearningGoal(userId, data);
+  logger.info('Learning goal set', { userId, goalId: goal.id });
+  return goal;
+}
+
+async function getLearningGoals(userId) {
+  return progressModel.listLearningGoals(userId);
+}
+
+module.exports = {
+  trackProgress,
+  getUserProgress,
+  getCourseProgress,
+  getDetailedProgress,
+  setLearningGoal,
+  getLearningGoals,
+};

--- a/backend/validation/userProgress.js
+++ b/backend/validation/userProgress.js
@@ -1,0 +1,30 @@
+const Joi = require('joi');
+
+const trackProgressSchema = Joi.object({
+  userId: Joi.string().required(),
+  courseId: Joi.string().required(),
+  activity: Joi.string().allow('', null),
+  progress: Joi.number().min(0).max(100).required(),
+  details: Joi.string().allow('', null),
+});
+
+const userIdParamSchema = Joi.object({
+  userId: Joi.string().required(),
+});
+
+const courseUserParamSchema = Joi.object({
+  courseId: Joi.string().required(),
+  userId: Joi.string().required(),
+});
+
+const learningGoalSchema = Joi.object({
+  goal: Joi.string().max(500).required(),
+  targetDate: Joi.date().optional(),
+});
+
+module.exports = {
+  trackProgressSchema,
+  userIdParamSchema,
+  courseUserParamSchema,
+  learningGoalSchema,
+};


### PR DESCRIPTION
## Summary
- add user progress controller, service, model, middleware, validation, and SQL schema
- extend progress routes with endpoints for tracking progress and managing learning goals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689253d135b4832095eafbb099b88193