### PR TITLE
feat: add learning analytics module

### DIFF
--- a/backend/controllers/analytics.js
+++ b/backend/controllers/analytics.js
@@ -1,6 +1,23 @@
-const { getAgencyEarnings, getAgencyPerformance } = require('../services/analytics');
+const {
+  getAgencyEarnings,
+  getAgencyPerformance,
+  getContentPerformance,
+  getContentPerformanceById,
+  detectPerformanceAnomalies,
+  getContentTrends,
+  getPopularContent,
+  getContentRecommendations,
+  submitContentFeedback,
+  getPathAnalytics,
+  getUserAnalytics,
+  getSkillsAnalytics,
+  getLearningPredictions,
+} = require('../services/analytics');
 const logger = require('../utils/logger');
 
+// -----------------------------
+// Agency analytics handlers
+// -----------------------------
 async function getAgencyEarningsHandler(req, res) {
   const { agencyId } = req.params;
   const { startDate, endDate } = req.query;
@@ -27,17 +44,13 @@ async function getAgencyPerformanceHandler(req, res) {
     res.json(data);
   } catch (err) {
     logger.error('Failed to fetch agency performance analytics', { agencyId, error: err.message });
-const {
-  getContentPerformance,
-  getContentPerformanceById,
-  detectPerformanceAnomalies,
-  getContentTrends,
-  getPopularContent,
-  getContentRecommendations,
-  submitContentFeedback,
-} = require('../services/analytics');
-const logger = require('../utils/logger');
+    res.status(404).json({ error: err.message });
+  }
+}
 
+// -----------------------------
+// Content analytics handlers
+// -----------------------------
 async function getContentPerformanceHandler(req, res) {
   try {
     const data = await getContentPerformance();
@@ -54,14 +67,11 @@ async function getContentPerformanceByIdHandler(req, res) {
     const data = await getContentPerformanceById(contentId);
     res.json(data);
   } catch (err) {
-    logger.error('Failed to fetch content performance by id', { error: err.message });
+    logger.error('Failed to fetch content performance by id', { contentId, error: err.message });
     res.status(404).json({ error: err.message });
   }
 }
 
-module.exports = {
-  getAgencyEarningsHandler,
-  getAgencyPerformanceHandler,
 async function detectAnomaliesHandler(req, res) {
   const { metrics, threshold } = req.body;
   try {
@@ -115,7 +125,56 @@ async function submitContentFeedbackHandler(req, res) {
   }
 }
 
+// -----------------------------
+// Learning analytics handlers
+// -----------------------------
+async function getPathAnalyticsHandler(req, res) {
+  const { pathId } = req.params;
+  try {
+    const data = await getPathAnalytics(pathId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch path analytics', { pathId, error: err.message });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getUserAnalyticsHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const data = await getUserAnalytics(userId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch user analytics', { userId, error: err.message });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getSkillsAnalyticsHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const data = await getSkillsAnalytics(userId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch skills analytics', { userId, error: err.message });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getPredictionsHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const data = await getLearningPredictions(userId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch learning predictions', { userId, error: err.message });
+    res.status(404).json({ error: err.message });
+  }
+}
+
 module.exports = {
+  getAgencyEarningsHandler,
+  getAgencyPerformanceHandler,
   getContentPerformanceHandler,
   getContentPerformanceByIdHandler,
   detectAnomaliesHandler,
@@ -123,4 +182,9 @@ module.exports = {
   getPopularContentHandler,
   getContentRecommendationsHandler,
   submitContentFeedbackHandler,
+  getPathAnalyticsHandler,
+  getUserAnalyticsHandler,
+  getSkillsAnalyticsHandler,
+  getPredictionsHandler,
 };
+

--- a/backend/database/analytics.sql
+++ b/backend/database/analytics.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS path_analytics (
+  id UUID PRIMARY KEY,
+  path_id VARCHAR(255) NOT NULL,
+  views INT DEFAULT 0,
+  enrollments INT DEFAULT 0,
+  completions INT DEFAULT 0,
+  average_score DECIMAL(5,2) DEFAULT 0,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS user_analytics (
+  id UUID PRIMARY KEY,
+  user_id VARCHAR(255) NOT NULL,
+  paths_enrolled INT DEFAULT 0,
+  paths_completed INT DEFAULT 0,
+  average_score DECIMAL(5,2) DEFAULT 0,
+  learning_hours INT DEFAULT 0,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS skill_analytics (
+  id UUID PRIMARY KEY,
+  user_id VARCHAR(255) NOT NULL,
+  skill VARCHAR(255) NOT NULL,
+  level VARCHAR(50) NOT NULL,
+  progress INT DEFAULT 0,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS learning_predictions (
+  id UUID PRIMARY KEY,
+  user_id VARCHAR(255) NOT NULL,
+  prediction TEXT NOT NULL,
+  confidence DECIMAL(3,2) DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/backend/middleware/analytics.js
+++ b/backend/middleware/analytics.js
@@ -1,0 +1,27 @@
+const analyticsModel = require('../models/analytics');
+const logger = require('../utils/logger');
+
+function ensurePathAnalytics(req, res, next) {
+  const { pathId } = req.params;
+  const data = analyticsModel.getPathAnalytics(pathId);
+  if (!data) {
+    logger.error('Path analytics not found', { pathId });
+    return res.status(404).json({ error: 'Path analytics not found' });
+  }
+  req.pathAnalytics = data;
+  next();
+}
+
+function ensureUserAnalytics(req, res, next) {
+  const { userId } = req.params;
+  const data = analyticsModel.getUserAnalytics(userId);
+  if (!data) {
+    logger.error('User analytics not found', { userId });
+    return res.status(404).json({ error: 'User analytics not found' });
+  }
+  req.userAnalytics = data;
+  next();
+}
+
+module.exports = { ensurePathAnalytics, ensureUserAnalytics };
+

--- a/backend/models/analytics.js
+++ b/backend/models/analytics.js
@@ -1,7 +1,10 @@
 const { randomUUID } = require('crypto');
 
-const earnings = new Map(); // agencyId => [{ id, date, amount }]
-const performance = new Map(); // agencyId => [{ id, employeeId, tasksCompleted, rating, periodStart, periodEnd }]
+// -----------------------------
+// Agency-level analytics stores
+// -----------------------------
+const earnings = new Map(); // agencyId => [ { id, date, amount } ]
+const performance = new Map(); // agencyId => [ { id, employeeId, tasksCompleted, rating, periodStart, periodEnd } ]
 
 function addEarning(agencyId, amount, date = new Date()) {
   const record = {
@@ -45,12 +48,9 @@ function getPerformanceByAgency(agencyId) {
   return performance.get(agencyId) || [];
 }
 
-module.exports = {
-  addEarning,
-  getEarningsByAgency,
-  addPerformance,
-  getPerformanceByAgency,
-// In-memory stores
+// -----------------------------
+// Content analytics stores
+// -----------------------------
 const contentAnalytics = new Map(); // contentId -> metrics
 const contentFeedback = []; // list of feedback entries
 
@@ -105,11 +105,104 @@ function updateFeedbackScore(contentId) {
   return score;
 }
 
+// -----------------------------
+// Learning analytics stores
+// -----------------------------
+const pathAnalytics = new Map(); // pathId -> analytics
+const userAnalytics = new Map(); // userId -> analytics
+const skillAnalytics = new Map(); // userId -> [ { skill, level, progress, updatedAt } ]
+const learningPredictions = new Map(); // userId -> { prediction, confidence, createdAt }
+
+function setPathAnalytics(pathId, data) {
+  const record = Object.assign({
+    id: randomUUID(),
+    pathId,
+    views: 0,
+    enrollments: 0,
+    completions: 0,
+    averageScore: 0,
+    updatedAt: new Date(),
+  }, data, { updatedAt: new Date() });
+  pathAnalytics.set(pathId, record);
+  return record;
+}
+
+function getPathAnalytics(pathId) {
+  return pathAnalytics.get(pathId) || null;
+}
+
+function setUserAnalytics(userId, data) {
+  const record = Object.assign({
+    id: randomUUID(),
+    userId,
+    pathsEnrolled: 0,
+    pathsCompleted: 0,
+    averageScore: 0,
+    learningHours: 0,
+    updatedAt: new Date(),
+  }, data, { updatedAt: new Date() });
+  userAnalytics.set(userId, record);
+  return record;
+}
+
+function getUserAnalytics(userId) {
+  return userAnalytics.get(userId) || null;
+}
+
+function setUserSkills(userId, skills) {
+  const records = skills.map(s => ({
+    id: randomUUID(),
+    userId,
+    skill: s.skill,
+    level: s.level,
+    progress: s.progress || 0,
+    updatedAt: new Date(),
+  }));
+  skillAnalytics.set(userId, records);
+  return records;
+}
+
+function getUserSkills(userId) {
+  return skillAnalytics.get(userId) || [];
+}
+
+function setPrediction(userId, prediction, confidence = 0) {
+  const record = {
+    id: randomUUID(),
+    userId,
+    prediction,
+    confidence: Number(confidence),
+    createdAt: new Date(),
+  };
+  learningPredictions.set(userId, record);
+  return record;
+}
+
+function getPrediction(userId) {
+  return learningPredictions.get(userId) || null;
+}
+
 module.exports = {
+  // Agency analytics
+  addEarning,
+  getEarningsByAgency,
+  addPerformance,
+  getPerformanceByAgency,
+  // Content analytics
   getAllContentAnalytics,
   getContentAnalytics,
   upsertContentAnalytics,
   addFeedback,
   getFeedbackByContent,
   updateFeedbackScore,
+  // Learning analytics
+  setPathAnalytics,
+  getPathAnalytics,
+  setUserAnalytics,
+  getUserAnalytics,
+  setUserSkills,
+  getUserSkills,
+  setPrediction,
+  getPrediction,
 };
+

--- a/backend/routes/analytics.js
+++ b/backend/routes/analytics.js
@@ -1,22 +1,19 @@
 const express = require('express');
-const {
-  getAgencyEarningsHandler,
-  getAgencyPerformanceHandler,
-} = require('../controllers/analytics');
-const auth = require('../middleware/auth');
-const validate = require('../middleware/validate');
-const {
-  agencyIdParamSchema,
-  analyticsQuerySchema,
-} = require('../validation/analytics');
 const auth = require('../middleware/auth');
 const authorize = require('../middleware/authorize');
 const validate = require('../middleware/validate');
+const analyticsMiddleware = require('../middleware/analytics');
 const {
+  agencyIdParamSchema,
+  analyticsQuerySchema,
   anomalySchema,
   feedbackSchema,
+  pathIdParamSchema,
+  userIdParamSchema,
 } = require('../validation/analytics');
 const {
+  getAgencyEarningsHandler,
+  getAgencyPerformanceHandler,
   getContentPerformanceHandler,
   getContentPerformanceByIdHandler,
   detectAnomaliesHandler,
@@ -24,10 +21,15 @@ const {
   getPopularContentHandler,
   getContentRecommendationsHandler,
   submitContentFeedbackHandler,
+  getPathAnalyticsHandler,
+  getUserAnalyticsHandler,
+  getSkillsAnalyticsHandler,
+  getPredictionsHandler,
 } = require('../controllers/analytics');
 
 const router = express.Router();
 
+// Agency analytics routes
 router.get(
   '/:agencyId/analytics/earnings',
   auth,
@@ -42,6 +44,10 @@ router.get(
   validate(agencyIdParamSchema, 'params'),
   validate(analyticsQuerySchema, 'query'),
   getAgencyPerformanceHandler
+);
+
+// Content analytics routes
+router.get(
   '/content/performance',
   auth,
   authorize('admin', 'content-manager'),
@@ -92,4 +98,38 @@ router.post(
   submitContentFeedbackHandler
 );
 
+// Learning analytics routes
+router.get(
+  '/paths/:pathId',
+  auth,
+  validate(pathIdParamSchema, 'params'),
+  analyticsMiddleware.ensurePathAnalytics,
+  getPathAnalyticsHandler
+);
+
+router.get(
+  '/user/:userId',
+  auth,
+  validate(userIdParamSchema, 'params'),
+  analyticsMiddleware.ensureUserAnalytics,
+  getUserAnalyticsHandler
+);
+
+router.get(
+  '/skills/:userId',
+  auth,
+  validate(userIdParamSchema, 'params'),
+  analyticsMiddleware.ensureUserAnalytics,
+  getSkillsAnalyticsHandler
+);
+
+router.get(
+  '/predictions/:userId',
+  auth,
+  validate(userIdParamSchema, 'params'),
+  analyticsMiddleware.ensureUserAnalytics,
+  getPredictionsHandler
+);
+
 module.exports = router;
+

--- a/backend/validation/analytics.js
+++ b/backend/validation/analytics.js
@@ -9,9 +9,6 @@ const analyticsQuerySchema = Joi.object({
   endDate: Joi.date().iso(),
 }).with('startDate', 'endDate').with('endDate', 'startDate');
 
-module.exports = {
-  agencyIdParamSchema,
-  analyticsQuerySchema,
 const anomalySchema = Joi.object({
   metrics: Joi.array().items(Joi.number()).min(1).required(),
   threshold: Joi.number().positive().default(2),
@@ -23,7 +20,20 @@ const feedbackSchema = Joi.object({
   comment: Joi.string().allow('').max(1000),
 });
 
+const pathIdParamSchema = Joi.object({
+  pathId: Joi.string().required(),
+});
+
+const userIdParamSchema = Joi.object({
+  userId: Joi.string().required(),
+});
+
 module.exports = {
+  agencyIdParamSchema,
+  analyticsQuerySchema,
   anomalySchema,
   feedbackSchema,
+  pathIdParamSchema,
+  userIdParamSchema,
 };
+


### PR DESCRIPTION
## Summary
- build comprehensive analytics module for learning paths and users
- add validation, middleware, and SQL schema for analytics data
- expose endpoints for path stats, user analytics, skill tracking, and predictions

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_689253ffb0c08320bca9ccbc94f4e8ba