### PR TITLE
Add expert access module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -49,6 +49,7 @@ const milestoneRoutes = require('./routes/milestones');
 const progressRoutes = require('./routes/progress');
 const achievementRoutes = require('./routes/achievements');
 const skillRoutes = require('./routes/skills');
+const expertAccessRoutes = require('./routes/expertAccess');
 
 const app = express();
 app.use(cors());
@@ -105,6 +106,7 @@ app.use('/achievements', achievementRoutes);
 app.use('/skills', skillRoutes);
 app.use('/goals', goalRoutes);
 app.use('/milestones', milestoneRoutes);
+app.use('/experts', expertAccessRoutes);
 
 // Commission rate adjustment notifications
 app.use('/affiliates/notifications', notificationRoutes);

--- a/backend/controllers/expertAccess.js
+++ b/backend/controllers/expertAccess.js
@@ -1,0 +1,60 @@
+const {
+  bookSession,
+  listWebinars,
+  requestAdvice,
+  requestProjectFeedback,
+} = require('../services/expertAccess');
+const logger = require('../utils/logger');
+
+async function bookSessionHandler(req, res) {
+  try {
+    const { expertId } = req.params;
+    const { sessionDate } = req.body;
+    const session = await bookSession(req.user.id, expertId, sessionDate);
+    res.status(201).json(session);
+  } catch (err) {
+    logger.error('Failed to book expert session', { error: err.message });
+    res.status(500).json({ error: 'Failed to book session' });
+  }
+}
+
+async function listWebinarsHandler(req, res) {
+  try {
+    const webinars = await listWebinars();
+    res.json(webinars);
+  } catch (err) {
+    logger.error('Failed to retrieve webinars', { error: err.message });
+    res.status(500).json({ error: 'Failed to retrieve webinars' });
+  }
+}
+
+async function requestAdviceHandler(req, res) {
+  try {
+    const { expertId } = req.params;
+    const { topic, details } = req.body;
+    const request = await requestAdvice(req.user.id, expertId, topic, details);
+    res.status(201).json(request);
+  } catch (err) {
+    logger.error('Failed to request advice', { error: err.message });
+    res.status(500).json({ error: 'Failed to request advice' });
+  }
+}
+
+async function requestProjectFeedbackHandler(req, res) {
+  try {
+    const { projectId } = req.params;
+    const { expertId, notes } = req.body;
+    const request = await requestProjectFeedback(req.user.id, projectId, expertId, notes);
+    res.status(201).json(request);
+  } catch (err) {
+    logger.error('Failed to request project feedback', { error: err.message });
+    res.status(500).json({ error: 'Failed to request feedback' });
+  }
+}
+
+module.exports = {
+  bookSessionHandler,
+  listWebinarsHandler,
+  requestAdviceHandler,
+  requestProjectFeedbackHandler,
+};

--- a/backend/database/expert_access.sql
+++ b/backend/database/expert_access.sql
@@ -1,0 +1,37 @@
+CREATE TABLE IF NOT EXISTS expert_sessions (
+  id UUID PRIMARY KEY,
+  expert_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+  session_date TIMESTAMP NOT NULL,
+  status VARCHAR(50) DEFAULT 'scheduled',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS expert_webinars (
+  id UUID PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  scheduled_at TIMESTAMP NOT NULL,
+  description TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS expert_advice_requests (
+  id UUID PRIMARY KEY,
+  expert_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+  topic VARCHAR(255) NOT NULL,
+  details TEXT,
+  status VARCHAR(50) DEFAULT 'pending',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS expert_project_feedback (
+  id UUID PRIMARY KEY,
+  project_id UUID NOT NULL,
+  expert_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+  notes TEXT,
+  status VARCHAR(50) DEFAULT 'pending',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/backend/middleware/expertAccess.js
+++ b/backend/middleware/expertAccess.js
@@ -1,0 +1,16 @@
+const logger = require('../utils/logger');
+
+/**
+ * Ensures the authenticated user has access to expert features.
+ * Allowed roles: user, learner, admin.
+ */
+module.exports = function expertAccess(req, res, next) {
+  const roles = req.user?.roles || [req.user?.role];
+  const roleList = Array.isArray(roles) ? roles : [];
+  const allowed = roleList.some(r => ['user', 'learner', 'admin'].includes(r));
+  if (!allowed) {
+    logger.error('Expert access denied', { userId: req.user?.id });
+    return res.status(403).json({ error: 'Expert access required' });
+  }
+  next();
+};

--- a/backend/models/expertAccess.js
+++ b/backend/models/expertAccess.js
@@ -1,0 +1,83 @@
+const { randomUUID } = require('crypto');
+
+const sessions = new Map();
+const webinars = new Map();
+const adviceRequests = new Map();
+const projectFeedbackRequests = new Map();
+
+function createSession({ userId, expertId, sessionDate }) {
+  const id = randomUUID();
+  const session = {
+    id,
+    userId,
+    expertId,
+    sessionDate: new Date(sessionDate),
+    status: 'scheduled',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  sessions.set(id, session);
+  return session;
+}
+
+function getWebinars() {
+  return Array.from(webinars.values());
+}
+
+function seedWebinar({ title, scheduledAt, description }) {
+  const id = randomUUID();
+  const webinar = {
+    id,
+    title,
+    scheduledAt: new Date(scheduledAt),
+    description: description || '',
+    createdAt: new Date(),
+  };
+  webinars.set(id, webinar);
+  return webinar;
+}
+
+function createAdviceRequest({ userId, expertId, topic, details }) {
+  const id = randomUUID();
+  const request = {
+    id,
+    userId,
+    expertId,
+    topic,
+    details: details || '',
+    status: 'pending',
+    createdAt: new Date(),
+  };
+  adviceRequests.set(id, request);
+  return request;
+}
+
+function createProjectFeedbackRequest({ userId, projectId, expertId, notes }) {
+  const id = randomUUID();
+  const request = {
+    id,
+    userId,
+    projectId,
+    expertId,
+    notes: notes || '',
+    status: 'pending',
+    createdAt: new Date(),
+  };
+  projectFeedbackRequests.set(id, request);
+  return request;
+}
+
+module.exports = {
+  createSession,
+  getWebinars,
+  seedWebinar,
+  createAdviceRequest,
+  createProjectFeedbackRequest,
+};
+
+// Seed a sample webinar for demonstration purposes
+seedWebinar({
+  title: 'Industry Trends Webinar',
+  scheduledAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+  description: 'Overview of upcoming industry trends and insights.',
+});

--- a/backend/routes/expertAccess.js
+++ b/backend/routes/expertAccess.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const {
+  bookSessionHandler,
+  listWebinarsHandler,
+  requestAdviceHandler,
+  requestProjectFeedbackHandler,
+} = require('../controllers/expertAccess');
+const auth = require('../middleware/auth');
+const expertAccess = require('../middleware/expertAccess');
+const validate = require('../middleware/validate');
+const {
+  bookSessionSchema,
+  adviceRequestSchema,
+  projectFeedbackSchema,
+} = require('../validation/expertAccess');
+
+const router = express.Router();
+
+router.post('/session/book/:expertId', auth, expertAccess, validate(bookSessionSchema), bookSessionHandler);
+router.get('/webinars', auth, expertAccess, listWebinarsHandler);
+router.post('/advice/request/:expertId', auth, expertAccess, validate(adviceRequestSchema), requestAdviceHandler);
+router.post('/project/feedback/:projectId', auth, expertAccess, validate(projectFeedbackSchema), requestProjectFeedbackHandler);
+
+module.exports = router;

--- a/backend/services/expertAccess.js
+++ b/backend/services/expertAccess.js
@@ -1,0 +1,33 @@
+const expertAccessModel = require('../models/expertAccess');
+const logger = require('../utils/logger');
+
+function bookSession(userId, expertId, sessionDate) {
+  const session = expertAccessModel.createSession({ userId, expertId, sessionDate });
+  logger.info('Expert session booked', { sessionId: session.id, userId, expertId });
+  return session;
+}
+
+function listWebinars() {
+  const webinars = expertAccessModel.getWebinars();
+  logger.info('Retrieved expert webinars', { count: webinars.length });
+  return webinars;
+}
+
+function requestAdvice(userId, expertId, topic, details) {
+  const request = expertAccessModel.createAdviceRequest({ userId, expertId, topic, details });
+  logger.info('Expert advice requested', { requestId: request.id, userId, expertId });
+  return request;
+}
+
+function requestProjectFeedback(userId, projectId, expertId, notes) {
+  const request = expertAccessModel.createProjectFeedbackRequest({ userId, projectId, expertId, notes });
+  logger.info('Project feedback requested', { requestId: request.id, userId, projectId, expertId });
+  return request;
+}
+
+module.exports = {
+  bookSession,
+  listWebinars,
+  requestAdvice,
+  requestProjectFeedback,
+};

--- a/backend/validation/expertAccess.js
+++ b/backend/validation/expertAccess.js
@@ -1,0 +1,21 @@
+const Joi = require('joi');
+
+const bookSessionSchema = Joi.object({
+  sessionDate: Joi.date().iso().required(),
+});
+
+const adviceRequestSchema = Joi.object({
+  topic: Joi.string().min(3).max(255).required(),
+  details: Joi.string().max(2000).allow('').optional(),
+});
+
+const projectFeedbackSchema = Joi.object({
+  expertId: Joi.string().guid({ version: 'uuidv4' }).required(),
+  notes: Joi.string().max(2000).allow('').optional(),
+});
+
+module.exports = {
+  bookSessionSchema,
+  adviceRequestSchema,
+  projectFeedbackSchema,
+};


### PR DESCRIPTION
## Summary
- add Expert Access module with booking, webinars, advice, and project feedback endpoints
- include in-memory models, service layer, controller, validation schemas, and role-based middleware
- define SQL schema and integrate routes into app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689254221544832094b701ad1fe0c520