### PR TITLE
feat(gamification): add gamification module

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -64,6 +64,7 @@ const milestoneRoutes = require('./routes/milestones');
 const progressRoutes = require('./routes/progress');
 const achievementRoutes = require('./routes/achievements');
 const skillRoutes = require('./routes/skills');
+const gamificationRoutes = require('./routes/gamification');
 
 const app = express();
 app.use(cors());
@@ -135,6 +136,7 @@ app.use('/achievements', achievementRoutes);
 app.use('/skills', skillRoutes);
 app.use('/goals', goalRoutes);
 app.use('/milestones', milestoneRoutes);
+app.use('/gamification', gamificationRoutes);
 
 // Commission rate adjustment notifications
 app.use('/affiliates/notifications', notificationRoutes);

--- a/backend/controllers/gamification.js
+++ b/backend/controllers/gamification.js
@@ -1,0 +1,58 @@
+const {
+  getLeaderboard,
+  claimReward,
+  awardBadge,
+  listBadges,
+} = require('../services/gamification');
+const logger = require('../utils/logger');
+
+async function getLeaderboardHandler(req, res) {
+  const { courseId } = req.params;
+  try {
+    const data = await getLeaderboard(courseId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch leaderboard', { error: err.message, courseId });
+    res.status(err.status || 500).json({ error: 'Failed to fetch leaderboard' });
+  }
+}
+
+async function claimRewardHandler(req, res) {
+  try {
+    const claim = await claimReward(req.body);
+    res.status(201).json(claim);
+  } catch (err) {
+    logger.error('Failed to claim reward', { error: err.message });
+    res.status(err.status || 400).json({ error: err.message });
+  }
+}
+
+async function earnBadgeHandler(req, res) {
+  const { userId } = req.params;
+  const { badgeId } = req.body;
+  try {
+    const record = await awardBadge(userId, badgeId);
+    res.status(201).json(record);
+  } catch (err) {
+    logger.error('Failed to award badge', { error: err.message, userId });
+    res.status(err.status || 400).json({ error: err.message });
+  }
+}
+
+async function listBadgesHandler(req, res) {
+  const { userId } = req.params;
+  try {
+    const data = await listBadges(userId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to list badges', { error: err.message, userId });
+    res.status(500).json({ error: 'Failed to list badges' });
+  }
+}
+
+module.exports = {
+  getLeaderboardHandler,
+  claimRewardHandler,
+  earnBadgeHandler,
+  listBadgesHandler,
+};

--- a/backend/database/gamification.sql
+++ b/backend/database/gamification.sql
@@ -1,0 +1,39 @@
+-- Table for badges
+CREATE TABLE IF NOT EXISTS badges (
+  id UUID PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  description TEXT
+);
+
+-- Junction table for user badges
+CREATE TABLE IF NOT EXISTS user_badges (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL,
+  badge_id UUID NOT NULL REFERENCES badges(id),
+  earned_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Leaderboard entries per course
+CREATE TABLE IF NOT EXISTS course_leaderboard (
+  id UUID PRIMARY KEY,
+  course_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+  points INT NOT NULL DEFAULT 0,
+  rank INT
+);
+
+-- Available rewards
+CREATE TABLE IF NOT EXISTS rewards (
+  id UUID PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  description TEXT,
+  points_required INT NOT NULL
+);
+
+-- Claimed rewards
+CREATE TABLE IF NOT EXISTS reward_claims (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL,
+  reward_id UUID NOT NULL REFERENCES rewards(id),
+  claimed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/middleware/gamification.js
+++ b/backend/middleware/gamification.js
@@ -1,0 +1,22 @@
+const { getReward, getBadge } = require('../services/gamification');
+const logger = require('../utils/logger');
+
+function ensureRewardExists(req, res, next) {
+  const { rewardId } = req.body;
+  if (!getReward(rewardId)) {
+    logger.error('Reward not found', { rewardId });
+    return res.status(404).json({ error: 'Reward not found' });
+  }
+  next();
+}
+
+function ensureBadgeExists(req, res, next) {
+  const { badgeId } = req.body;
+  if (!getBadge(badgeId)) {
+    logger.error('Badge not found', { badgeId });
+    return res.status(404).json({ error: 'Badge not found' });
+  }
+  next();
+}
+
+module.exports = { ensureRewardExists, ensureBadgeExists };

--- a/backend/models/gamification.js
+++ b/backend/models/gamification.js
@@ -1,0 +1,66 @@
+const { randomUUID } = require('crypto');
+
+// In-memory data stores
+const leaderboardEntries = [];
+const badges = [
+  { id: 'badge-1', name: 'First Course', description: 'Completed first course' },
+];
+const userBadges = [];
+const rewards = [
+  { id: 'reward-1', name: 'Free Course', description: 'Access to a free course', pointsRequired: 100 },
+];
+const rewardClaims = [];
+
+function getLeaderboardEntries(courseId) {
+  return leaderboardEntries
+    .filter((e) => e.courseId === courseId)
+    .sort((a, b) => b.points - a.points);
+}
+
+function addRewardClaim({ userId, rewardId }) {
+  const claim = { id: randomUUID(), userId, rewardId, claimedAt: new Date() };
+  rewardClaims.push(claim);
+  return claim;
+}
+
+function findRewardById(rewardId) {
+  return rewards.find((r) => r.id === rewardId);
+}
+
+function hasClaimedReward(userId, rewardId) {
+  return rewardClaims.some((c) => c.userId === userId && c.rewardId === rewardId);
+}
+
+function addUserBadge({ userId, badgeId }) {
+  const record = { id: randomUUID(), userId, badgeId, earnedAt: new Date() };
+  userBadges.push(record);
+  return record;
+}
+
+function listUserBadges(userId) {
+  return userBadges
+    .filter((b) => b.userId === userId)
+    .map((b) => ({
+      ...b,
+      badge: badges.find((bd) => bd.id === b.badgeId) || null,
+    }));
+}
+
+function findBadgeById(badgeId) {
+  return badges.find((b) => b.id === badgeId);
+}
+
+function hasUserBadge(userId, badgeId) {
+  return userBadges.some((b) => b.userId === userId && b.badgeId === badgeId);
+}
+
+module.exports = {
+  getLeaderboardEntries,
+  addRewardClaim,
+  findRewardById,
+  hasClaimedReward,
+  addUserBadge,
+  listUserBadges,
+  findBadgeById,
+  hasUserBadge,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,7 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "express-validator": "^7.2.1",
-    "joi": "^17.11.0"
+    "joi": "^17.11.0",
     "uuid": "^9.0.0"
   }
 }

--- a/backend/routes/gamification.js
+++ b/backend/routes/gamification.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const {
+  getLeaderboardHandler,
+  claimRewardHandler,
+  earnBadgeHandler,
+  listBadgesHandler,
+} = require('../controllers/gamification');
+const auth = require('../middleware/auth');
+const requireAdmin = require('../middleware/requireAdmin');
+const validate = require('../middleware/validate');
+const {
+  courseIdParamSchema,
+  claimRewardSchema,
+  userIdParamSchema,
+  earnBadgeSchema,
+} = require('../validation/gamification');
+const {
+  ensureRewardExists,
+  ensureBadgeExists,
+} = require('../middleware/gamification');
+
+const router = express.Router();
+
+router.get(
+  '/leaderboards/:courseId',
+  auth,
+  validate(courseIdParamSchema, 'params'),
+  getLeaderboardHandler
+);
+
+router.post(
+  '/rewards/claim',
+  auth,
+  validate(claimRewardSchema),
+  ensureRewardExists,
+  claimRewardHandler
+);
+
+router.post(
+  '/badges/earn/:userId',
+  auth,
+  requireAdmin,
+  validate(userIdParamSchema, 'params'),
+  validate(earnBadgeSchema),
+  ensureBadgeExists,
+  earnBadgeHandler
+);
+
+router.get(
+  '/badges/:userId',
+  auth,
+  validate(userIdParamSchema, 'params'),
+  listBadgesHandler
+);
+
+module.exports = router;

--- a/backend/services/gamification.js
+++ b/backend/services/gamification.js
@@ -1,0 +1,70 @@
+const {
+  getLeaderboardEntries,
+  addRewardClaim,
+  findRewardById,
+  hasClaimedReward,
+  addUserBadge,
+  listUserBadges,
+  findBadgeById,
+  hasUserBadge,
+} = require('../models/gamification');
+const logger = require('../utils/logger');
+
+async function getLeaderboard(courseId) {
+  return getLeaderboardEntries(courseId);
+}
+
+async function claimReward({ userId, rewardId }) {
+  const reward = findRewardById(rewardId);
+  if (!reward) {
+    const err = new Error('Reward not found');
+    err.status = 404;
+    throw err;
+  }
+  if (hasClaimedReward(userId, rewardId)) {
+    const err = new Error('Reward already claimed');
+    err.status = 409;
+    throw err;
+  }
+  const claim = addRewardClaim({ userId, rewardId });
+  logger.info('Reward claimed', { userId, rewardId });
+  return claim;
+}
+
+async function awardBadge(userId, badgeId) {
+  const badge = findBadgeById(badgeId);
+  if (!badge) {
+    const err = new Error('Badge not found');
+    err.status = 404;
+    throw err;
+  }
+  if (hasUserBadge(userId, badgeId)) {
+    const err = new Error('Badge already awarded');
+    err.status = 409;
+    throw err;
+  }
+  const record = addUserBadge({ userId, badgeId });
+  logger.info('Badge awarded', { userId, badgeId });
+  return record;
+}
+
+async function listBadges(userId) {
+  return listUserBadges(userId);
+}
+
+function getReward(rewardId) {
+  return findRewardById(rewardId);
+}
+
+function getBadge(badgeId) {
+  return findBadgeById(badgeId);
+}
+
+module.exports = {
+  getLeaderboard,
+  claimReward,
+  awardBadge,
+  listBadges,
+  getReward,
+  getBadge,
+};

--- a/backend/validation/gamification.js
+++ b/backend/validation/gamification.js
@@ -1,0 +1,25 @@
+const Joi = require('joi');
+
+const courseIdParamSchema = Joi.object({
+  courseId: Joi.string().required(),
+});
+
+const claimRewardSchema = Joi.object({
+  userId: Joi.string().required(),
+  rewardId: Joi.string().required(),
+});
+
+const userIdParamSchema = Joi.object({
+  userId: Joi.string().required(),
+});
+
+const earnBadgeSchema = Joi.object({
+  badgeId: Joi.string().required(),
+});
+
+module.exports = {
+  courseIdParamSchema,
+  claimRewardSchema,
+  userIdParamSchema,
+  earnBadgeSchema,
+};


### PR DESCRIPTION
## Summary
- add gamification routes for leaderboards, rewards, and badges
- implement controllers, services, models, validation, middleware, and SQL schema
- register gamification endpoints in app

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892581434048320b40b16fb36064fd1