### PR TITLE
feat: add investor profile module

### DIFF
--- a/backend/controllers/profile.js
+++ b/backend/controllers/profile.js
@@ -7,6 +7,16 @@ const {
   getPreferences,
   addOrUpdateSkills,
   calculateMatchPotential,
+  // Stage 82 services
+  createProfile,
+  updateProfileById,
+  getProfileById,
+  uploadPortfolioItemById,
+  getProfileAnalytics,
+  submitProfileForVerification,
+  getVerificationStatus,
+  enableContinuousVerification,
+  setGeographicPreferences,
 } = require('../services/profile');
 const logger = require('../utils/logger');
 
@@ -97,6 +107,106 @@ async function getMatchPotentialHandler(req, res) {
   }
 }
 
+// Stage 82 Handlers
+async function createProfileHandler(req, res) {
+  try {
+    const profile = await createProfile(req.user.id, req.body);
+    res.status(201).json(profile);
+  } catch (err) {
+    logger.error('Failed to create profile', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function updateProfileByIdHandler(req, res) {
+  const { profileId } = req.params;
+  try {
+    const profile = await updateProfileById(profileId, req.body);
+    res.json(profile);
+  } catch (err) {
+    logger.error('Failed to update profile', { error: err.message, profileId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getProfileByIdHandler(req, res) {
+  const { profileId } = req.params;
+  try {
+    const profile = await getProfileById(profileId);
+    res.json(profile);
+  } catch (err) {
+    logger.error('Failed to retrieve profile', { error: err.message, profileId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function uploadPortfolioItemByIdHandler(req, res) {
+  const { profileId } = req.params;
+  try {
+    const item = await uploadPortfolioItemById(profileId, req.body);
+    res.status(201).json(item);
+  } catch (err) {
+    logger.error('Failed to upload portfolio item', { error: err.message, profileId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getProfileAnalyticsHandler(req, res) {
+  const { profileId } = req.params;
+  try {
+    const analytics = await getProfileAnalytics(profileId);
+    res.json(analytics);
+  } catch (err) {
+    logger.error('Failed to get profile analytics', { error: err.message, profileId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function submitProfileForVerificationHandler(req, res) {
+  const { profileId } = req.params;
+  try {
+    const profile = await submitProfileForVerification(profileId);
+    res.json({ verificationStatus: profile.verificationStatus });
+  } catch (err) {
+    logger.error('Failed to submit profile for verification', { error: err.message, profileId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function getVerificationStatusHandler(req, res) {
+  const { profileId } = req.params;
+  try {
+    const status = await getVerificationStatus(profileId);
+    res.json(status);
+  } catch (err) {
+    logger.error('Failed to get verification status', { error: err.message, profileId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function enableContinuousVerificationHandler(req, res) {
+  const { profileId } = req.params;
+  const { enabled } = req.body;
+  try {
+    const profile = await enableContinuousVerification(profileId, enabled);
+    res.json({ continuousVerification: profile.continuousVerification });
+  } catch (err) {
+    logger.error('Failed to update continuous verification', { error: err.message, profileId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
+async function setGeographicPreferencesHandler(req, res) {
+  const { profileId } = req.params;
+  try {
+    const prefs = await setGeographicPreferences(profileId, req.body);
+    res.json({ geographicPreferences: prefs });
+  } catch (err) {
+    logger.error('Failed to set geographic preferences', { error: err.message, profileId });
+    res.status(404).json({ error: err.message });
+  }
+}
+
 module.exports = {
   createMentorProfileHandler,
   createMenteeProfileHandler,
@@ -106,4 +216,14 @@ module.exports = {
   getPreferencesHandler,
   addOrUpdateSkillsHandler,
   getMatchPotentialHandler,
+  // Stage 82 exports
+  createProfileHandler,
+  updateProfileByIdHandler,
+  getProfileByIdHandler,
+  uploadPortfolioItemByIdHandler,
+  getProfileAnalyticsHandler,
+  submitProfileForVerificationHandler,
+  getVerificationStatusHandler,
+  enableContinuousVerificationHandler,
+  setGeographicPreferencesHandler,
 };

--- a/backend/database/investor_profiles.sql
+++ b/backend/database/investor_profiles.sql
@@ -1,0 +1,12 @@
+CREATE TABLE investor_profiles (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL UNIQUE,
+  bio TEXT,
+  portfolio JSONB,
+  analytics JSONB,
+  verification_status VARCHAR(20) DEFAULT 'unverified',
+  continuous_verification BOOLEAN DEFAULT FALSE,
+  geographic_preferences JSONB,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/middleware/profileIdOwnership.js
+++ b/backend/middleware/profileIdOwnership.js
@@ -1,0 +1,20 @@
+const profileModel = require('../models/profile');
+const logger = require('../utils/logger');
+
+module.exports = (req, res, next) => {
+  const { profileId } = req.params;
+  const profile = profileModel.findById(profileId);
+  if (!profile) {
+    logger.error('Profile not found', { profileId });
+    return res.status(404).json({ error: 'Profile not found' });
+  }
+  if (profile.userId !== req.user?.id) {
+    logger.error('Unauthorized profile access', {
+      profileId,
+      requester: req.user?.id,
+    });
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  req.profile = profile;
+  next();
+};

--- a/backend/models/profile.js
+++ b/backend/models/profile.js
@@ -1,17 +1,28 @@
 const { randomUUID } = require('crypto');
 
-// In-memory storage for mentor and mentee profiles
+// In-memory storage for all profiles
 const profiles = [];
 
-function createProfile({ userId, role, bio = '', preferences = {}, skills = [] }) {
+function createProfile({
+  userId,
+  role = 'general',
+  bio = '',
+  preferences = {},
+  skills = [],
+  geographicPreferences = {},
+}) {
   const profile = {
     id: randomUUID(),
     userId,
-    role, // 'mentor' or 'mentee'
+    role,
     bio,
     preferences,
     skills,
     portfolio: [],
+    analytics: { views: 0 },
+    verificationStatus: 'unverified',
+    continuousVerification: false,
+    geographicPreferences,
     createdAt: new Date(),
     updatedAt: new Date(),
   };
@@ -23,6 +34,10 @@ function findByUserId(userId) {
   return profiles.find((p) => p.userId === userId);
 }
 
+function findById(id) {
+  return profiles.find((p) => p.id === id);
+}
+
 function updateProfile(userId, updates) {
   const profile = findByUserId(userId);
   if (!profile) return null;
@@ -32,6 +47,15 @@ function updateProfile(userId, updates) {
 
 function addPortfolioItem(userId, item) {
   const profile = findByUserId(userId);
+  if (!profile) return null;
+  const portfolioItem = { id: randomUUID(), ...item, createdAt: new Date() };
+  profile.portfolio.push(portfolioItem);
+  profile.updatedAt = new Date();
+  return portfolioItem;
+}
+
+function addPortfolioItemById(profileId, item) {
+  const profile = findById(profileId);
   if (!profile) return null;
   const portfolioItem = { id: randomUUID(), ...item, createdAt: new Date() };
   profile.portfolio.push(portfolioItem);
@@ -53,12 +77,53 @@ function addOrUpdateSkills(userId, skills = []) {
   return profile.skills;
 }
 
+function getAnalytics(profileId) {
+  const profile = findById(profileId);
+  return profile ? profile.analytics : null;
+}
+
+function submitForVerification(profileId) {
+  const profile = findById(profileId);
+  if (!profile) return null;
+  profile.verificationStatus = 'pending';
+  profile.updatedAt = new Date();
+  return profile;
+}
+
+function getVerificationStatus(profileId) {
+  const profile = findById(profileId);
+  return profile ? profile.verificationStatus : null;
+}
+
+function enableContinuousVerification(profileId, enabled) {
+  const profile = findById(profileId);
+  if (!profile) return null;
+  profile.continuousVerification = enabled;
+  profile.updatedAt = new Date();
+  return profile;
+}
+
+function setGeographicPreferences(profileId, prefs) {
+  const profile = findById(profileId);
+  if (!profile) return null;
+  profile.geographicPreferences = prefs;
+  profile.updatedAt = new Date();
+  return profile;
+}
+
 module.exports = {
   profiles,
   createProfile,
   findByUserId,
+  findById,
   updateProfile,
   addPortfolioItem,
+  addPortfolioItemById,
   getPreferences,
   addOrUpdateSkills,
+  getAnalytics,
+  submitForVerification,
+  getVerificationStatus,
+  enableContinuousVerification,
+  setGeographicPreferences,
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,7 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "express-validator": "^7.2.1",
-    "joi": "^17.11.0"
+    "joi": "^17.11.0",
     "uuid": "^9.0.0"
   }
 }

--- a/backend/routes/profiles.js
+++ b/backend/routes/profiles.js
@@ -8,10 +8,21 @@ const {
   getPreferencesHandler,
   addOrUpdateSkillsHandler,
   getMatchPotentialHandler,
+  // Stage 82 handlers
+  createProfileHandler,
+  updateProfileByIdHandler,
+  getProfileByIdHandler,
+  uploadPortfolioItemByIdHandler,
+  getProfileAnalyticsHandler,
+  submitProfileForVerificationHandler,
+  getVerificationStatusHandler,
+  enableContinuousVerificationHandler,
+  setGeographicPreferencesHandler,
 } = require('../controllers/profile');
 const auth = require('../middleware/auth');
 const validate = require('../middleware/validate');
 const profileOwnership = require('../middleware/profileOwnership');
+const profileIdOwnership = require('../middleware/profileIdOwnership');
 const {
   userIdParamSchema,
   mentorProfileSchema,
@@ -19,17 +30,34 @@ const {
   updateProfileSchema,
   portfolioItemSchema,
   skillsSchema,
+  profileIdParamSchema,
+  createProfileSchema,
+  updateInvestorProfileSchema,
+  continuousVerificationSchema,
+  geographicPreferenceSchema,
 } = require('../validation/profile');
 
 const router = express.Router();
 
+// Stage 82 routes
+router.post('/create', auth, validate(createProfileSchema), createProfileHandler);
+router.put('/update/:profileId', auth, validate(profileIdParamSchema, 'params'), profileIdOwnership, validate(updateInvestorProfileSchema), updateProfileByIdHandler);
+router.get('/verification/status/:profileId', auth, validate(profileIdParamSchema, 'params'), profileIdOwnership, getVerificationStatusHandler);
+router.get('/:profileId/analytics', auth, validate(profileIdParamSchema, 'params'), profileIdOwnership, getProfileAnalyticsHandler);
+router.post('/verify/:profileId', auth, validate(profileIdParamSchema, 'params'), profileIdOwnership, submitProfileForVerificationHandler);
+router.put('/verify/continuous/:profileId', auth, validate(profileIdParamSchema, 'params'), profileIdOwnership, validate(continuousVerificationSchema), enableContinuousVerificationHandler);
+router.post('/:profileId/preferences/geographic', auth, validate(profileIdParamSchema, 'params'), profileIdOwnership, validate(geographicPreferenceSchema), setGeographicPreferencesHandler);
+router.post('/:profileId/portfolio/upload', auth, validate(profileIdParamSchema, 'params'), profileIdOwnership, validate(portfolioItemSchema), uploadPortfolioItemByIdHandler);
+router.get('/:profileId', auth, validate(profileIdParamSchema, 'params'), getProfileByIdHandler);
+
+// Existing mentorship routes (prefixed with /user to avoid conflicts)
 router.post('/mentor/create', auth, validate(mentorProfileSchema), createMentorProfileHandler);
 router.post('/mentee/create', auth, validate(menteeProfileSchema), createMenteeProfileHandler);
-router.put('/update/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, validate(updateProfileSchema), updateProfileHandler);
-router.get('/:userId', auth, validate(userIdParamSchema, 'params'), getProfileHandler);
-router.post('/portfolio/upload/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, validate(portfolioItemSchema), uploadPortfolioItemHandler);
-router.get('/preferences/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, getPreferencesHandler);
-router.post('/skills/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, validate(skillsSchema), addOrUpdateSkillsHandler);
-router.get('/match-potential/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, getMatchPotentialHandler);
+router.put('/user/update/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, validate(updateProfileSchema), updateProfileHandler);
+router.get('/user/:userId', auth, validate(userIdParamSchema, 'params'), getProfileHandler);
+router.post('/user/portfolio/upload/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, validate(portfolioItemSchema), uploadPortfolioItemHandler);
+router.get('/user/preferences/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, getPreferencesHandler);
+router.post('/user/skills/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, validate(skillsSchema), addOrUpdateSkillsHandler);
+router.get('/user/match-potential/:userId', auth, validate(userIdParamSchema, 'params'), profileOwnership, getMatchPotentialHandler);
 
 module.exports = router;

--- a/backend/services/profile.js
+++ b/backend/services/profile.js
@@ -75,6 +75,91 @@ async function calculateMatchPotential(userId) {
   return { userId, score };
 }
 
+// Stage 82 Investor-Entrepreneur Profile Services
+async function createProfile(userId, data = {}) {
+  const profile = profileModel.createProfile({ userId, ...data });
+  logger.info('Profile created', { userId, profileId: profile.id });
+  return profile;
+}
+
+async function updateProfileById(profileId, updates) {
+  const profile = profileModel.findById(profileId);
+  if (!profile) {
+    logger.error('Profile not found for update', { profileId });
+    throw new Error('Profile not found');
+  }
+  Object.assign(profile, updates, { updatedAt: new Date() });
+  logger.info('Profile updated', { profileId });
+  return profile;
+}
+
+async function getProfileById(profileId) {
+  const profile = profileModel.findById(profileId);
+  if (!profile) {
+    logger.error('Profile not found', { profileId });
+    throw new Error('Profile not found');
+  }
+  return profile;
+}
+
+async function uploadPortfolioItemById(profileId, item) {
+  const result = profileModel.addPortfolioItemById(profileId, item);
+  if (!result) {
+    logger.error('Profile not found for portfolio upload', { profileId });
+    throw new Error('Profile not found');
+  }
+  logger.info('Portfolio item added', { profileId, itemId: result.id });
+  return result;
+}
+
+async function getProfileAnalytics(profileId) {
+  const analytics = profileModel.getAnalytics(profileId);
+  if (!analytics) {
+    logger.error('Profile analytics not found', { profileId });
+    throw new Error('Profile not found');
+  }
+  return analytics;
+}
+
+async function submitProfileForVerification(profileId) {
+  const profile = profileModel.submitForVerification(profileId);
+  if (!profile) {
+    logger.error('Profile not found for verification', { profileId });
+    throw new Error('Profile not found');
+  }
+  logger.info('Profile submitted for verification', { profileId });
+  return profile;
+}
+
+async function getVerificationStatus(profileId) {
+  const status = profileModel.getVerificationStatus(profileId);
+  if (!status) {
+    logger.error('Profile not found for verification status', { profileId });
+    throw new Error('Profile not found');
+  }
+  return { status };
+}
+
+async function enableContinuousVerification(profileId, enabled) {
+  const profile = profileModel.enableContinuousVerification(profileId, enabled);
+  if (!profile) {
+    logger.error('Profile not found for continuous verification', { profileId });
+    throw new Error('Profile not found');
+  }
+  logger.info('Continuous verification updated', { profileId, enabled });
+  return profile;
+}
+
+async function setGeographicPreferences(profileId, prefs) {
+  const profile = profileModel.setGeographicPreferences(profileId, prefs);
+  if (!profile) {
+    logger.error('Profile not found for geographic preferences', { profileId });
+    throw new Error('Profile not found');
+  }
+  logger.info('Geographic preferences updated', { profileId });
+  return profile.geographicPreferences;
+}
+
 module.exports = {
   createMentorProfile,
   createMenteeProfile,
@@ -84,4 +169,14 @@ module.exports = {
   getPreferences,
   addOrUpdateSkills,
   calculateMatchPotential,
+  // Stage 82 exports
+  createProfile,
+  updateProfileById,
+  getProfileById,
+  uploadPortfolioItemById,
+  getProfileAnalytics,
+  submitProfileForVerification,
+  getVerificationStatus,
+  enableContinuousVerification,
+  setGeographicPreferences,
 };

--- a/backend/validation/profile.js
+++ b/backend/validation/profile.js
@@ -38,6 +38,36 @@ const skillsSchema = Joi.object({
   skills: Joi.array().items(Joi.string().min(1)).min(1).required(),
 });
 
+// Stage 82 Investor-Entrepreneur Profile Schemas
+const profileIdParamSchema = Joi.object({
+  profileId: Joi.string().uuid().required(),
+});
+
+const createProfileSchema = Joi.object({
+  bio: Joi.string().allow('').optional(),
+  geographicPreferences: Joi.object({
+    country: Joi.string().required(),
+    city: Joi.string().optional(),
+  }).optional(),
+});
+
+const updateInvestorProfileSchema = Joi.object({
+  bio: Joi.string().optional(),
+  geographicPreferences: Joi.object({
+    country: Joi.string().required(),
+    city: Joi.string().optional(),
+  }).optional(),
+}).min(1);
+
+const continuousVerificationSchema = Joi.object({
+  enabled: Joi.boolean().required(),
+});
+
+const geographicPreferenceSchema = Joi.object({
+  country: Joi.string().required(),
+  city: Joi.string().optional(),
+});
+
 module.exports = {
   userIdParamSchema,
   mentorProfileSchema,
@@ -45,4 +75,9 @@ module.exports = {
   updateProfileSchema,
   portfolioItemSchema,
   skillsSchema,
+  profileIdParamSchema,
+  createProfileSchema,
+  updateInvestorProfileSchema,
+  continuousVerificationSchema,
+  geographicPreferenceSchema,
 };


### PR DESCRIPTION
## Summary
- add investor/entrepreneur profile routes for creation, updates, verification, analytics, and geographic preferences
- implement profile services, model enhancements, ownership middleware and validation schemas
- define SQL schema for investor profiles

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892582d3b2883208c01692faf370e44