### PR TITLE
feat: add event module

### DIFF
--- a/backend/controllers/event.js
+++ b/backend/controllers/event.js
@@ -1,0 +1,98 @@
+const eventService = require('../services/event');
+const logger = require('../utils/logger');
+
+async function createPitchEvent(req, res) {
+  try {
+    const event = await eventService.createPitchEvent(req.body, req.user.id);
+    res.status(201).json(event);
+  } catch (err) {
+    logger.error('Failed to create pitch event', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function getPitchEvent(req, res) {
+  const event = await eventService.getPitchEvent(req.params.eventId);
+  if (!event) return res.status(404).json({ error: 'Event not found' });
+  res.json(event);
+}
+
+async function attendPitchEvent(req, res) {
+  const result = await eventService.attendPitchEvent(req.params.eventId, req.user.id);
+  if (!result) return res.status(404).json({ error: 'Event not found' });
+  res.json(result);
+}
+
+async function setupPitchLivestream(req, res) {
+  const { eventId } = req.params;
+  const { streamUrl } = req.body;
+  const result = await eventService.setupPitchLivestream(eventId, streamUrl);
+  if (!result) return res.status(404).json({ error: 'Event not found' });
+  res.json(result);
+}
+
+async function getPitchLivestream(req, res) {
+  const result = await eventService.getPitchLivestream(req.params.eventId);
+  if (!result) return res.status(404).json({ error: 'Event not found' });
+  res.json(result);
+}
+
+async function createNetworkingEvent(req, res) {
+  try {
+    const event = await eventService.createNetworkingEvent(req.body, req.user.id);
+    res.status(201).json(event);
+  } catch (err) {
+    logger.error('Failed to create networking event', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function getNetworkingEvent(req, res) {
+  const event = await eventService.getNetworkingEvent(req.params.eventId);
+  if (!event) return res.status(404).json({ error: 'Event not found' });
+  res.json(event);
+}
+
+async function createWorkshop(req, res) {
+  try {
+    const event = await eventService.createWorkshopEvent(req.body, req.user.id);
+    res.status(201).json(event);
+  } catch (err) {
+    logger.error('Failed to create workshop', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function getWorkshop(req, res) {
+  const event = await eventService.getWorkshopEvent(req.params.eventId);
+  if (!event) return res.status(404).json({ error: 'Event not found' });
+  res.json(event);
+}
+
+async function submitQuestion(req, res) {
+  const { eventId } = req.params;
+  const { question } = req.body;
+  const result = await eventService.submitQuestion(eventId, req.user.id, question);
+  if (!result) return res.status(404).json({ error: 'Event not found' });
+  res.status(201).json(result);
+}
+
+async function getQuestions(req, res) {
+  const questions = await eventService.getQuestions(req.params.eventId);
+  if (!questions) return res.status(404).json({ error: 'Event not found' });
+  res.json(questions);
+}
+
+module.exports = {
+  createPitchEvent,
+  getPitchEvent,
+  attendPitchEvent,
+  setupPitchLivestream,
+  getPitchLivestream,
+  createNetworkingEvent,
+  getNetworkingEvent,
+  createWorkshop,
+  getWorkshop,
+  submitQuestion,
+  getQuestions,
+};

--- a/backend/database/event_controller.sql
+++ b/backend/database/event_controller.sql
@@ -1,0 +1,28 @@
+-- Event Controller tables for pitch, networking, and workshop events
+
+CREATE TABLE IF NOT EXISTS events_general (
+  id UUID PRIMARY KEY,
+  type VARCHAR(50) NOT NULL, -- pitch, networking, workshop
+  title VARCHAR(255) NOT NULL,
+  description TEXT,
+  event_date TIMESTAMP NOT NULL,
+  host_id UUID NOT NULL,
+  livestream_url TEXT,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS event_attendees (
+  id UUID PRIMARY KEY,
+  event_id UUID REFERENCES events_general(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL,
+  joined_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS event_questions (
+  id UUID PRIMARY KEY,
+  event_id UUID REFERENCES events_general(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL,
+  question TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);

--- a/backend/middleware/eventItemExists.js
+++ b/backend/middleware/eventItemExists.js
@@ -1,0 +1,13 @@
+const eventService = require('../services/event');
+const logger = require('../utils/logger');
+
+module.exports = async (req, res, next) => {
+  const { eventId } = req.params;
+  const event = await eventService.getEventById(eventId);
+  if (!event) {
+    logger.error('Event not found', { eventId });
+    return res.status(404).json({ error: 'Event not found' });
+  }
+  req.event = event;
+  next();
+};

--- a/backend/models/eventController.js
+++ b/backend/models/eventController.js
@@ -1,0 +1,72 @@
+const { randomUUID } = require('crypto');
+
+// In-memory store for investor events keyed by id
+const events = new Map();
+
+function createEvent({ type, title, description, date, hostId }) {
+  const id = randomUUID();
+  const timestamp = new Date();
+  const event = {
+    id,
+    type, // 'pitch', 'networking', 'workshop'
+    title,
+    description: description || null,
+    date: new Date(date),
+    hostId,
+    attendees: new Set(),
+    livestreamUrl: null,
+    questions: [],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  events.set(id, event);
+  return event;
+}
+
+function findById(id) {
+  return events.get(id);
+}
+
+function addAttendee(id, userId) {
+  const event = events.get(id);
+  if (!event) return null;
+  event.attendees.add(userId);
+  event.updatedAt = new Date();
+  return event;
+}
+
+function setLivestream(id, url) {
+  const event = events.get(id);
+  if (!event) return null;
+  event.livestreamUrl = url;
+  event.updatedAt = new Date();
+  return event.livestreamUrl;
+}
+
+function getLivestream(id) {
+  return events.get(id)?.livestreamUrl || null;
+}
+
+function addQuestion(id, userId, question) {
+  const event = events.get(id);
+  if (!event) return null;
+  const entry = { id: randomUUID(), userId, question, createdAt: new Date() };
+  event.questions.push(entry);
+  event.updatedAt = new Date();
+  return entry;
+}
+
+function getQuestions(id) {
+  const event = events.get(id);
+  return event ? event.questions : null;
+}
+
+module.exports = {
+  createEvent,
+  findById,
+  addAttendee,
+  setLivestream,
+  getLivestream,
+  addQuestion,
+  getQuestions,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,8 +15,8 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "express-validator": "^7.2.1",
-    "joi": "^17.11.0"
-    "uuid": "^9.0.0"
+      "express-validator": "^7.2.1",
+      "joi": "^17.11.0",
+      "uuid": "^9.0.0"
+    }
   }
-}

--- a/backend/routes/events.js
+++ b/backend/routes/events.js
@@ -5,6 +5,8 @@ const auth = require('../middleware/auth');
 const validate = require('../middleware/validateSchema');
 const eventExists = require('../middleware/eventExists');
 const eventController = require('../controllers/eventManagement');
+const investorEventController = require('../controllers/event');
+const eventItemExists = require('../middleware/eventItemExists');
 const {
   createEventSchema,
   updateEventSchema,
@@ -12,6 +14,13 @@ const {
   paymentSchema,
   feedbackSchema
 } = require('../validators/eventValidator');
+const {
+  pitchEventSchema,
+  networkingEventSchema,
+  workshopEventSchema,
+  livestreamSchema,
+  questionSchema,
+} = require('../validators/eventController');
 
 router.post('/create', auth, validate(createEventSchema), eventController.createEvent);
 router.get('/templates', eventController.getTemplates);
@@ -23,5 +32,21 @@ router.post('/payment/setup/:eventId', auth, eventExists, validate(paymentSchema
 router.get('/upcoming', eventController.getUpcomingEvents);
 router.post('/feedback/collect/:eventId', auth, eventExists, validate(feedbackSchema), eventController.collectFeedback);
 router.get('/history/:userId', auth, eventController.getEventHistory);
+
+// Stage 86 Event Controller routes
+router.post('/pitch/create', auth, validate(pitchEventSchema), investorEventController.createPitchEvent);
+router.get('/pitch/:eventId', eventItemExists, investorEventController.getPitchEvent);
+router.post('/pitch/attend/:eventId', auth, eventItemExists, investorEventController.attendPitchEvent);
+router.post('/pitch/livestream/:eventId', auth, eventItemExists, validate(livestreamSchema), investorEventController.setupPitchLivestream);
+router.get('/pitch/livestream/:eventId', eventItemExists, investorEventController.getPitchLivestream);
+
+router.post('/networking/create', auth, validate(networkingEventSchema), investorEventController.createNetworkingEvent);
+router.get('/networking/:eventId', eventItemExists, investorEventController.getNetworkingEvent);
+
+router.post('/workshop/create', auth, validate(workshopEventSchema), investorEventController.createWorkshop);
+router.get('/workshop/:eventId', eventItemExists, investorEventController.getWorkshop);
+
+router.post('/q&a/:eventId', auth, eventItemExists, validate(questionSchema), investorEventController.submitQuestion);
+router.get('/q&a/:eventId', eventItemExists, investorEventController.getQuestions);
 
 module.exports = router;

--- a/backend/services/event.js
+++ b/backend/services/event.js
@@ -1,0 +1,93 @@
+const eventModel = require('../models/eventController');
+const logger = require('../utils/logger');
+
+function ensureType(event, expectedType) {
+  if (!event || event.type !== expectedType) {
+    return null;
+  }
+  return event;
+}
+
+async function createPitchEvent(data, hostId) {
+  const event = eventModel.createEvent({ ...data, type: 'pitch', hostId });
+  logger.info('Pitch event created', { eventId: event.id, hostId });
+  return event;
+}
+
+async function getPitchEvent(eventId) {
+  return ensureType(eventModel.findById(eventId), 'pitch');
+}
+
+async function attendPitchEvent(eventId, userId) {
+  const event = await getPitchEvent(eventId);
+  if (!event) return null;
+  eventModel.addAttendee(eventId, userId);
+  logger.info('User attending pitch event', { eventId, userId });
+  return { success: true };
+}
+
+async function setupPitchLivestream(eventId, url) {
+  const event = await getPitchEvent(eventId);
+  if (!event) return null;
+  eventModel.setLivestream(eventId, url);
+  logger.info('Livestream set for pitch event', { eventId });
+  return { streamUrl: url };
+}
+
+async function getPitchLivestream(eventId) {
+  const event = await getPitchEvent(eventId);
+  if (!event) return null;
+  return { streamUrl: eventModel.getLivestream(eventId) };
+}
+
+async function createNetworkingEvent(data, hostId) {
+  const event = eventModel.createEvent({ ...data, type: 'networking', hostId });
+  logger.info('Networking event created', { eventId: event.id, hostId });
+  return event;
+}
+
+async function getNetworkingEvent(eventId) {
+  return ensureType(eventModel.findById(eventId), 'networking');
+}
+
+async function createWorkshopEvent(data, hostId) {
+  const event = eventModel.createEvent({ ...data, type: 'workshop', hostId });
+  logger.info('Workshop event created', { eventId: event.id, hostId });
+  return event;
+}
+
+async function getWorkshopEvent(eventId) {
+  return ensureType(eventModel.findById(eventId), 'workshop');
+}
+
+async function submitQuestion(eventId, userId, question) {
+  const event = eventModel.findById(eventId);
+  if (!event) return null;
+  const q = eventModel.addQuestion(eventId, userId, question);
+  logger.info('Question submitted for event', { eventId, userId });
+  return q;
+}
+
+async function getQuestions(eventId) {
+  const questions = eventModel.getQuestions(eventId);
+  return questions || null;
+}
+
+async function getEventById(eventId) {
+  return eventModel.findById(eventId);
+}
+
+module.exports = {
+  createPitchEvent,
+  getPitchEvent,
+  attendPitchEvent,
+  setupPitchLivestream,
+  getPitchLivestream,
+  createNetworkingEvent,
+  getNetworkingEvent,
+  createWorkshopEvent,
+  getWorkshopEvent,
+  submitQuestion,
+  getQuestions,
+  getEventById,
+};

--- a/backend/validators/eventController.js
+++ b/backend/validators/eventController.js
@@ -1,0 +1,27 @@
+const Joi = require('joi');
+
+const baseEventSchema = {
+  title: Joi.string().required(),
+  description: Joi.string().allow('', null),
+  date: Joi.date().iso().required(),
+};
+
+const pitchEventSchema = Joi.object(baseEventSchema);
+const networkingEventSchema = Joi.object(baseEventSchema);
+const workshopEventSchema = Joi.object(baseEventSchema);
+
+const livestreamSchema = Joi.object({
+  streamUrl: Joi.string().uri().required(),
+});
+
+const questionSchema = Joi.object({
+  question: Joi.string().min(1).required(),
+});
+
+module.exports = {
+  pitchEventSchema,
+  networkingEventSchema,
+  workshopEventSchema,
+  livestreamSchema,
+  questionSchema,
+};


### PR DESCRIPTION
## Summary
- add event controller for managing pitch, networking, and workshop events
- implement models, services, middleware, validation, and routes for event features
- define SQL tables for events, attendees, and questions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68925866a6dc8320bdf8c6d0e5c7d587