### PR TITLE
feat: add volunteer communication module

### DIFF
--- a/backend/controllers/communication.js
+++ b/backend/controllers/communication.js
@@ -7,6 +7,7 @@ const {
   getMeeting,
   scheduleCall,
   getCall,
+  listConversations,
 } = require('../services/communication');
 const logger = require('../utils/logger');
 
@@ -32,6 +33,18 @@ async function getConversationMessagesHandler(req, res) {
       conversationId,
     });
     res.status(404).json({ error: err.message });
+  }
+}
+
+async function listConversationsHandler(req, res) {
+  const userId = req.user?.id || req.user?.username;
+  const { category } = req.query;
+  try {
+    const conversations = await listConversations(userId, category);
+    res.json(conversations);
+  } catch (err) {
+    logger.error('Failed to list conversations', { error: err.message, userId });
+    res.status(500).json({ error: err.message });
   }
 }
 
@@ -109,4 +122,5 @@ module.exports = {
   getMeetingHandler,
   scheduleCallHandler,
   getCallHandler,
+  listConversationsHandler,
 };

--- a/backend/database/communication.sql
+++ b/backend/database/communication.sql
@@ -1,6 +1,7 @@
 CREATE TABLE conversations (
   id UUID PRIMARY KEY,
   participants TEXT[] NOT NULL,
+  category VARCHAR(50) DEFAULT 'general',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -10,6 +11,13 @@ CREATE TABLE messages (
   sender_id VARCHAR(255) NOT NULL,
   content TEXT NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE message_attachments (
+  id UUID PRIMARY KEY,
+  message_id UUID REFERENCES messages(id) ON DELETE CASCADE,
+  type VARCHAR(50),
+  url TEXT NOT NULL
 );
 
 CREATE TABLE message_templates (

--- a/backend/middleware/communication.js
+++ b/backend/middleware/communication.js
@@ -6,6 +6,10 @@ function requireConversation(req, res, next) {
   if (!conversation) {
     return res.status(404).json({ error: 'Conversation not found' });
   }
+  const userId = req.user?.id || req.user?.username;
+  if (userId && !conversation.participants.includes(userId)) {
+    return res.status(403).json({ error: 'Access to conversation denied' });
+  }
   req.conversation = conversation;
   next();
 }

--- a/backend/routes/communications.js
+++ b/backend/routes/communications.js
@@ -15,6 +15,7 @@ const {
   getMeetingHandler,
   scheduleCallHandler,
   getCallHandler,
+  listConversationsHandler,
 } = require('../controllers/communication');
 const {
   messageSchema,
@@ -24,17 +25,24 @@ const {
   meetingIdParamSchema,
   scheduleCallSchema,
   callIdParamSchema,
+  conversationsListSchema,
 } = require('../validation/communication');
 
 const router = express.Router();
 
-router.post('/messages/send', auth, validate(messageSchema), sendMessageHandler);
+router.post('/messages', auth, validate(messageSchema), sendMessageHandler);
 router.get(
   '/messages/conversation/:conversationId',
   auth,
   validate(conversationIdParamSchema, 'params'),
   requireConversation,
   getConversationMessagesHandler
+);
+router.get(
+  '/messages/conversations',
+  auth,
+  validate(conversationsListSchema, 'query'),
+  listConversationsHandler
 );
 router.get('/messages/templates', auth, listTemplatesHandler);
 router.post(

--- a/backend/services/communication.js
+++ b/backend/services/communication.js
@@ -1,7 +1,10 @@
 const communicationModel = require('../models/communication');
 const logger = require('../utils/logger');
 
-async function sendMessage(userId, { conversationId, recipientId, content }) {
+async function sendMessage(
+  userId,
+  { conversationId, recipientId, content, attachments = [], category }
+) {
   let conversation;
   if (conversationId) {
     conversation = communicationModel.getConversation(conversationId);
@@ -12,12 +15,29 @@ async function sendMessage(userId, { conversationId, recipientId, content }) {
     if (!recipientId) {
       throw new Error('recipientId is required to start a conversation');
     }
-    conversation = communicationModel.createConversation([userId, recipientId]);
+    conversation = communicationModel.createConversation(
+      [userId, recipientId],
+      category
+    );
     conversationId = conversation.id;
-    logger.info('Conversation created', { conversationId, participants: conversation.participants });
+    logger.info('Conversation created', {
+      conversationId,
+      participants: conversation.participants,
+      category: conversation.category,
+    });
   }
-  const message = communicationModel.addMessage(conversationId, userId, content);
-  logger.info('Message sent', { messageId: message.id, conversationId, senderId: userId });
+  const message = communicationModel.addMessage(
+    conversationId,
+    userId,
+    content,
+    attachments
+  );
+  logger.info('Message sent', {
+    messageId: message.id,
+    conversationId,
+    senderId: userId,
+    attachments: attachments.length,
+  });
   return { conversationId, message };
 }
 
@@ -85,6 +105,10 @@ function getConversation(conversationId) {
   return communicationModel.getConversation(conversationId);
 }
 
+async function listConversations(userId, category) {
+  return communicationModel.listConversationsByUser(userId, category);
+}
+
 module.exports = {
   sendMessage,
   getConversationMessages,
@@ -95,4 +119,5 @@ module.exports = {
   scheduleCall,
   getCall,
   getConversation,
+  listConversations,
 };

--- a/backend/validation/communication.js
+++ b/backend/validation/communication.js
@@ -1,5 +1,10 @@
 const Joi = require('joi');
 
+const attachmentSchema = Joi.object({
+  type: Joi.string().max(50).required(),
+  url: Joi.string().uri().required(),
+});
+
 const messageSchema = Joi.object({
   conversationId: Joi.string().guid({ version: 'uuidv4' }).optional(),
   recipientId: Joi.string().when('conversationId', {
@@ -8,6 +13,8 @@ const messageSchema = Joi.object({
     otherwise: Joi.string().required(),
   }),
   content: Joi.string().max(1000).required(),
+  attachments: Joi.array().items(attachmentSchema).optional(),
+  category: Joi.string().max(50).optional(),
 });
 
 const conversationIdParamSchema = Joi.object({
@@ -39,6 +46,10 @@ const callIdParamSchema = Joi.object({
   callId: Joi.string().guid({ version: 'uuidv4' }).required(),
 });
 
+const conversationsListSchema = Joi.object({
+  category: Joi.string().max(50).optional(),
+});
+
 module.exports = {
   messageSchema,
   conversationIdParamSchema,
@@ -47,4 +58,5 @@ module.exports = {
   meetingIdParamSchema,
   scheduleCallSchema,
   callIdParamSchema,
+  conversationsListSchema,
 };


### PR DESCRIPTION
## Summary
- extend communication model and service for attachments, categories, and conversation listing
- add middleware, validation, routes, and controller handler for volunteer messaging workflows
- update SQL schema with conversation category and attachment table

## Testing
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68925f89eac08320835e0e606efd22e1