### PR TITLE
Add user table and clean up auth service

### DIFF
--- a/backend/database/database.sql
+++ b/backend/database/database.sql
@@ -1,5 +1,6 @@
 -- Central database schema for Workhouse
 -- Run individual module schemas as needed
+\i users.sql
 \i payouts.sql
 -- Main database schema initialization
 \i referrals.sql

--- a/backend/database/users.sql
+++ b/backend/database/users.sql
@@ -1,0 +1,10 @@
+-- SQL schema for core user accounts
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY,
+  username VARCHAR(255) UNIQUE NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  role VARCHAR(50) DEFAULT 'user',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -1,19 +1,36 @@
 const { randomUUID } = require('crypto');
 
+// In-memory user store. In a real application this would be persisted
+// to a database table. Each user has a UUID identifier, username,
+// hashed password and role.
 const users = [];
 
+/**
+ * Find a user by username.
+ * @param {string} username
+ * @returns {object|undefined}
+ */
 function findUser(username) {
   return users.find(u => u.username === username);
 }
 
-function addUser({ username, password, role }) {
+/**
+ * Add a new user to the store.
+ * @param {{username: string, password: string, role?: string}} param0
+ * @returns {object} The created user record
+ */
+function addUser({ username, password, role = 'user' }) {
   const user = { id: randomUUID(), username, password, role };
   users.push(user);
   return user;
-function addUser({ username, password, role = 'user' }) {
-  users.push({ username, password, role });
 }
 
+/**
+ * Update an existing user's password.
+ * @param {string} username
+ * @param {string} password
+ * @returns {boolean} True if the user was found and updated
+ */
 function updatePassword(username, password) {
   const user = findUser(username);
   if (!user) return false;
@@ -22,3 +39,4 @@ function updatePassword(username, password) {
 }
 
 module.exports = { users, findUser, addUser, updatePassword };
+

--- a/backend/services/auth.js
+++ b/backend/services/auth.js
@@ -4,24 +4,29 @@ const { findUser, addUser } = require('../models/user');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
 
-async function register(username, password, roles = ['user']) {
+/**
+ * Register a new user.
+ * @param {string} username
+ * @param {string} password Plain text password
+ * @param {string} [role='user'] Role assigned to the user
+ * @returns {Promise<{id: string, username: string, role: string}>}
+ */
 async function register(username, password, role = 'user') {
   const existing = findUser(username);
   if (existing) {
     throw new Error('User already exists');
   }
   const hashed = await bcrypt.hash(password, 10);
-  const user = { username, password: hashed, roles };
-  addUser(user);
-  return { username, roles };
-  const user = { username, password: hashed, role };
-  addUser(user);
   const user = addUser({ username, password: hashed, role });
   return { id: user.id, username: user.username, role: user.role };
-  addUser({ username, password: hashed, role });
-  return { username, role };
 }
 
+/**
+ * Authenticate a user and return a JWT token.
+ * @param {string} username
+ * @param {string} password
+ * @returns {Promise<{token: string}>}
+ */
 async function login(username, password) {
   const user = findUser(username);
   if (!user) {
@@ -31,23 +36,19 @@ async function login(username, password) {
   if (!match) {
     throw new Error('Invalid credentials');
   }
-  const token = jwt.sign({ username, roles: user.roles }, JWT_SECRET, { expiresIn: '1h' });
-  const token = jwt.sign({ username, role: user.role }, JWT_SECRET, {
-    expiresIn: '1h',
-  });
   const token = jwt.sign(
     { id: user.id, username: user.username, role: user.role },
     JWT_SECRET,
     { expiresIn: '1h' }
   );
-
-  const token = jwt.sign({ username, role: user.role }, JWT_SECRET, {
-    expiresIn: '1h',
-  });
-  const token = jwt.sign({ username, role: user.role }, JWT_SECRET, { expiresIn: '1h' });
   return { token };
 }
 
+/**
+ * Verify a JWT token.
+ * @param {string} token
+ * @returns {object|null} Decoded token or null if invalid
+ */
 function verifyToken(token) {
   try {
     return jwt.verify(token, JWT_SECRET);
@@ -57,3 +58,4 @@ function verifyToken(token) {
 }
 
 module.exports = { register, login, verifyToken };
+


### PR DESCRIPTION
## Summary
- add missing `users` SQL schema and include in main database
- implement in-memory user model with UUID ids
- simplify auth service to register users and issue JWT tokens

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892667ccd7c832080551b403f84f312