### PR TITLE
Rename duplicate route paths

### DIFF
--- a/backend/routes/dataProtection.js
+++ b/backend/routes/dataProtection.js
@@ -15,7 +15,13 @@ const {
 const router = express.Router();
 
 router.post('/protection-policy-update', auth, requireAdmin, validate(policyUpdateSchema), protectionPolicyUpdateHandler);
-router.get('/privacy-settings', auth, getPrivacySettingsHandler);
-router.put('/privacy-settings', auth, validate(privacySettingsSchema), updatePrivacySettingsHandler);
+// Split privacy settings routes to avoid duplicate path names
+router.get('/privacy-settings/view', auth, getPrivacySettingsHandler);
+router.put(
+  '/privacy-settings/update',
+  auth,
+  validate(privacySettingsSchema),
+  updatePrivacySettingsHandler
+);
 
 module.exports = router;

--- a/backend/routes/employee.js
+++ b/backend/routes/employee.js
@@ -41,8 +41,14 @@ router.get('/benefits', auth, controller.listBenefits);
 router.post('/benefits/enroll', auth, requireFields('employeeId', 'benefitId'), controller.enrollBenefits);
 
 // Employee Relations
-router.post('/feedback', auth, requireFields('employeeId', 'message'), controller.submitFeedback);
-router.get('/feedback', auth, controller.listFeedback);
+// Separate feedback routes to avoid duplicate path names
+router.post(
+  '/feedback/submit',
+  auth,
+  requireFields('employeeId', 'message'),
+  controller.submitFeedback
+);
+router.get('/feedback/list', auth, controller.listFeedback);
 router.post('/issues/report', auth, requireFields('employeeId', 'issue'), controller.reportIssue);
 router.get('/issues', auth, controller.listIssues);
 

--- a/backend/routes/security.js
+++ b/backend/routes/security.js
@@ -92,8 +92,14 @@ router.post('/intrusion/report-incident', auth, validate(incidentReportSchema), 
 router.post('/intrusion/resolve-incident', auth, validate(incidentResolveSchema), incidentResolveHandler);
 
 router.post('/data/protection-policy-update', auth, validate(policyUpdateSchema), policyUpdateHandler);
-router.get('/data/privacy-settings', auth, privacySettingsGetHandler);
-router.put('/data/privacy-settings', auth, validate(privacyUpdateSchema), privacySettingsUpdateHandler);
+// Separate privacy settings routes to avoid duplicate paths
+router.get('/data/privacy-settings/view', auth, privacySettingsGetHandler);
+router.put(
+  '/data/privacy-settings/update',
+  auth,
+  validate(privacyUpdateSchema),
+  privacySettingsUpdateHandler
+);
 
 router.post('/api/rate-limiting', auth, validate(rateLimitSchema), rateLimitConfigHandler);
 router.post('/api/endpoint-encryption', auth, validate(endpointEncryptionSchema), endpointEncryptionConfigHandler);


### PR DESCRIPTION
## Summary
- clarify data privacy endpoints in dataProtection and security modules
- split employee feedback routes to unique submit/list paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892645463908320a6a7445250a5229a