### PR TITLE
feat: add sample integrations for free third-party APIs

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -101,6 +101,7 @@ const applicationRoutes = require('./routes/applications');
 const campaignRoutes = require('./routes/campaigns');
 const projectManagementRoutes = require('./routes/projectManagement');
 const successStoryRoutes = require('./routes/successStories');
+const thirdPartyApiRoutes = require('./routes/thirdPartyApis');
 const app = express();
 app.use(cors());
 app.use(express.json());
@@ -210,6 +211,7 @@ app.use('/applications', applicationRoutes);
 app.use('/success', successStoryRoutes);
 app.use('/affiliates/notifications', notificationRoutes);
 app.use('/workspace', projectManagementRoutes);
+app.use('/third-party', thirdPartyApiRoutes);
 
 const port = process.env.PORT || 5000;
 if (require.main === module) {

--- a/backend/controllers/thirdPartyApis.js
+++ b/backend/controllers/thirdPartyApis.js
@@ -1,0 +1,105 @@
+const {
+  getVrCapabilities,
+  verifyIdentity,
+  getVisionOsSample,
+  getCloudflareTrace,
+  fetchFromCdn,
+  fetchCached,
+  getPodcastSample,
+  getVoiceChatSample,
+} = require('../services/thirdPartyApis');
+const logger = require('../utils/logger');
+
+async function vrHandler(req, res) {
+  try {
+    const data = await getVrCapabilities();
+    res.json(data);
+  } catch (err) {
+    logger.error('VR compatibility API failed', { error: err.message });
+    res.status(500).json({ error: 'Failed to fetch VR compatibility information' });
+  }
+}
+
+async function identityHandler(req, res) {
+  try {
+    const data = await verifyIdentity();
+    res.json(data);
+  } catch (err) {
+    logger.error('Identity verification API failed', { error: err.message });
+    res.status(500).json({ error: 'Failed to verify identity' });
+  }
+}
+
+async function visionOsHandler(req, res) {
+  try {
+    const data = await getVisionOsSample();
+    res.json(data);
+  } catch (err) {
+    logger.error('Vision OS API failed', { error: err.message });
+    res.status(500).json({ error: 'Failed to fetch Vision OS data' });
+  }
+}
+
+async function cloudflareHandler(req, res) {
+  try {
+    const data = await getCloudflareTrace();
+    res.send(data);
+  } catch (err) {
+    logger.error('Cloudflare API failed', { error: err.message });
+    res.status(500).json({ error: 'Failed to reach Cloudflare' });
+  }
+}
+
+async function cdnHandler(req, res) {
+  try {
+    const pkg = req.query.package;
+    const data = await fetchFromCdn(pkg);
+    res.send(data);
+  } catch (err) {
+    logger.error('CDN API failed', { error: err.message });
+    res.status(500).json({ error: 'Failed to fetch CDN resource' });
+  }
+}
+
+async function cacheHandler(req, res) {
+  try {
+    const target = req.query.url;
+    const data = await fetchCached(target);
+    res.send(data);
+  } catch (err) {
+    logger.error('Cache API failed', { error: err.message });
+    res.status(500).json({ error: 'Failed to fetch cached content' });
+  }
+}
+
+async function podcastHandler(req, res) {
+  try {
+    const data = await getPodcastSample();
+    res.json(data);
+  } catch (err) {
+    logger.error('Podcast API failed', { error: err.message });
+    res.status(500).json({ error: 'Failed to fetch podcast data' });
+  }
+}
+
+async function voiceHandler(req, res) {
+  try {
+    const data = await getVoiceChatSample();
+    res.json(data);
+  } catch (err) {
+    logger.error('Voice chat API failed', { error: err.message });
+    res.status(500).json({ error: 'Failed to access voice chat service' });
+  }
+}
+
+module.exports = {
+  vrHandler,
+  identityHandler,
+  visionOsHandler,
+  cloudflareHandler,
+  cdnHandler,
+  cacheHandler,
+  podcastHandler,
+  voiceHandler,
+};
+

--- a/backend/routes/thirdPartyApis.js
+++ b/backend/routes/thirdPartyApis.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const {
+  vrHandler,
+  identityHandler,
+  visionOsHandler,
+  cloudflareHandler,
+  cdnHandler,
+  cacheHandler,
+  podcastHandler,
+  voiceHandler,
+} = require('../controllers/thirdPartyApis');
+
+const router = express.Router();
+
+router.get('/vr', vrHandler);
+router.get('/identity', identityHandler);
+router.get('/visionos', visionOsHandler);
+router.get('/cloudflare', cloudflareHandler);
+router.get('/cdn', cdnHandler);
+router.get('/cache', cacheHandler);
+router.get('/podcast', podcastHandler);
+router.get('/voice', voiceHandler);
+
+module.exports = router;
+

--- a/backend/services/thirdPartyApis.js
+++ b/backend/services/thirdPartyApis.js
@@ -1,0 +1,69 @@
+const axios = require('axios');
+
+// The following functions demonstrate integrations with a variety of free third-party
+// services. They act as lightweight wrappers around publicly accessible APIs so
+// the rest of the application can experiment with different platform features
+// without vendor lock-in.
+
+async function getVrCapabilities() {
+  // Placeholder for a virtual reality compatibility check. In practice this could
+  // call a WebXR or similar API. JSONPlaceholder is used purely for demonstration.
+  const { data } = await axios.get('https://jsonplaceholder.typicode.com/todos/1');
+  return data;
+}
+
+async function verifyIdentity() {
+  // Uses the free Random User API to mock identity verification.
+  const { data } = await axios.get('https://randomuser.me/api/');
+  return data;
+}
+
+async function getVisionOsSample() {
+  // Placeholder endpoint for Vision OS related data.
+  const { data } = await axios.get('https://jsonplaceholder.typicode.com/todos/2');
+  return data;
+}
+
+async function getCloudflareTrace() {
+  // Cloudflare provides a free trace endpoint useful for diagnostics.
+  const { data } = await axios.get('https://www.cloudflare.com/cdn-cgi/trace');
+  return data;
+}
+
+async function fetchFromCdn(packageName = 'axios@latest') {
+  // Retrieve a package directly from the jsDelivr free CDN.
+  const url = `https://cdn.jsdelivr.net/npm/${packageName}`;
+  const { data } = await axios.get(url);
+  return data;
+}
+
+async function fetchCached(url = 'https://example.com') {
+  // AllOrigins offers a free caching proxy for public requests.
+  const endpoint = `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`;
+  const { data } = await axios.get(endpoint);
+  return data;
+}
+
+async function getPodcastSample() {
+  // Mixcloud exposes a free API with podcast and music information.
+  const { data } = await axios.get('https://api.mixcloud.com/popular/');
+  return data;
+}
+
+async function getVoiceChatSample() {
+  // Placeholder for a voice chat API. Replace with a WebRTC service such as Jitsi.
+  const { data } = await axios.get('https://jsonplaceholder.typicode.com/todos/3');
+  return data;
+}
+
+module.exports = {
+  getVrCapabilities,
+  verifyIdentity,
+  getVisionOsSample,
+  getCloudflareTrace,
+  fetchFromCdn,
+  fetchCached,
+  getPodcastSample,
+  getVoiceChatSample,
+};
+


### PR DESCRIPTION
## Summary
- add service wrappers for several free third-party APIs (VR, identity, Vision OS, Cloudflare, CDN, caching, podcast, voice chat)
- expose endpoints under `/third-party` for accessing these integrations
- wire new routes into the Express application

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68926b7eb27c8320bab45b3c5d71b7ea