### PR TITLE
feat: add stage1 landing page with chakra ui

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 
+EXTERNAL_TESTIMONIAL_API=https://jsonplaceholder.typicode.com/comments

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const authRoutes = require('./routes/auth');
+const landingRoutes = require('./routes/landing');
 const dashboardRoutes = require('./routes/dashboard');
 const commissionRoutes = require('./routes/commission');
 const payoutRoutes = require('./routes/payouts');
@@ -108,6 +109,7 @@ app.use(express.json());
 // Mount routes. The parent application may prefix these with "/api"
 // when integrating the backend.
 app.use('/auth', authRoutes);
+app.use('/landing', landingRoutes);
 app.use('/affiliates', dashboardRoutes);
 app.use('/commissions', commissionRoutes);
 app.use('/payouts', payoutRoutes);

--- a/backend/controllers/landing.js
+++ b/backend/controllers/landing.js
@@ -1,0 +1,23 @@
+const { listFeatures } = require('../models/landingContent');
+const fetchExternal = require('../utils/fetchExternal');
+
+async function getLandingContent(req, res) {
+  try {
+    const features = listFeatures();
+    let testimonials = [];
+    const apiUrl = process.env.EXTERNAL_TESTIMONIAL_API;
+    if (apiUrl) {
+      const data = await fetchExternal(apiUrl);
+      testimonials = data.slice(0, 3).map(item => ({
+        id: item.id,
+        name: item.name || 'Anonymous',
+        quote: item.body || ''
+      }));
+    }
+    res.json({ features, testimonials });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load landing content' });
+  }
+}
+
+module.exports = { getLandingContent };

--- a/backend/database/landing_content.sql
+++ b/backend/database/landing_content.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS landing_content (
+  id SERIAL PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  description TEXT,
+  icon VARCHAR(255)
+);
+
+CREATE TABLE IF NOT EXISTS testimonials (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  quote TEXT NOT NULL
+);

--- a/backend/models/landingContent.js
+++ b/backend/models/landingContent.js
@@ -1,0 +1,26 @@
+const features = [
+  {
+    id: 'feature1',
+    title: 'AI-Powered Matching',
+    description: 'Connect with opportunities using intelligent algorithms.',
+    icon: 'https://img.icons8.com/ios-filled/50/artificial-intelligence.png'
+  },
+  {
+    id: 'feature2',
+    title: 'Integrated Gig Management',
+    description: 'Manage tasks, payments, and communication in one place.',
+    icon: 'https://img.icons8.com/ios-filled/50/project-management.png'
+  },
+  {
+    id: 'feature3',
+    title: 'Real-Time Analytics',
+    description: 'Track performance with live dashboards and insights.',
+    icon: 'https://img.icons8.com/ios-filled/50/combo-chart.png'
+  }
+];
+
+function listFeatures() {
+  return features;
+}
+
+module.exports = { listFeatures };

--- a/backend/routes/landing.js
+++ b/backend/routes/landing.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { getLandingContent } = require('../controllers/landing');
+
+const router = express.Router();
+
+router.get('/content', getLandingContent);
+
+module.exports = router;

--- a/backend/utils/fetchExternal.js
+++ b/backend/utils/fetchExternal.js
@@ -1,0 +1,8 @@
+async function fetchExternal(url) {
+  const res = await fetch(url, { headers: { 'User-Agent': 'Workhouse/1.0' } });
+  if (!res.ok) {
+    throw new Error(`Request failed with status ${res.status}`);
+  }
+  return res.json();
+}
+module.exports = fetchExternal;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5,6 +5,7 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<LandingPage />} />
+        <Route path="/login" element={<LoginPage />} />
         <Route path="/home" element={<HomePage />} />
         <Route path="/dashboard" element={<Protected><HomeDashboard /></Protected>} />
       </Routes>

--- a/frontend/components/FeatureCard.css
+++ b/frontend/components/FeatureCard.css
@@ -1,0 +1,6 @@
+.feature-card {
+  transition: transform 0.2s ease;
+}
+.feature-card:hover {
+  transform: translateY(-4px);
+}

--- a/frontend/components/FeatureCard.js
+++ b/frontend/components/FeatureCard.js
@@ -1,0 +1,13 @@
+const { Box, Heading, Text, Image } = ChakraUI;
+
+function FeatureCard({ title, description, icon }) {
+  return (
+    <Box className="feature-card" borderWidth="1px" borderRadius="lg" p={6} textAlign="center" bg="white">
+      {icon && <Image src={icon} alt="" boxSize="50px" mx="auto" mb={4} />}
+      <Heading size="md" mb={2}>{title}</Heading>
+      <Text fontSize="sm" color="gray.600">{description}</Text>
+    </Box>
+  );
+}
+
+window.FeatureCard = FeatureCard;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,18 +11,23 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
     />
+    <link rel="stylesheet" href="views/landing_page.css" />
+    <link rel="stylesheet" href="views/login_page.css" />
+    <link rel="stylesheet" href="components/FeatureCard.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
     <script crossorigin src="https://unpkg.com/@emotion/react@11/umd/emotion-react.umd.min.js"></script>
     <script crossorigin src="https://unpkg.com/@emotion/styled@11/umd/emotion-styled.umd.min.js"></script>
-    <script crossorigin src="https://unpkg.com/@mui/material@5/umd/material-ui.development.js"></script>
+    <script crossorigin src="https://unpkg.com/@chakra-ui/react@1.8.8/dist/chakra-ui-react.umd.min.js"></script>
     <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
   </head>
   <body>
     <div id="root"></div>
     <script type="text/babel" data-presets="env,react" src="views/home_page.js"></script>
+    <script type="text/babel" data-presets="env,react" src="components/FeatureCard.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/landing_page.js"></script>
+    <script type="text/babel" data-presets="env,react" src="views/login_page.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/home_dashboard.js"></script>
     <script type="text/babel" data-presets="env,react" src="app.js"></script>
   </body>

--- a/frontend/views/landing_page.css
+++ b/frontend/views/landing_page.css
@@ -1,0 +1,16 @@
+.landing-header a {
+  text-decoration: none;
+}
+.hero {
+  background-image: url('https://images.unsplash.com/photo-1521791055366-0d553872125f?auto=format&fit=crop&w=1350&q=80');
+  background-size: cover;
+  background-position: center;
+  color: white;
+  min-height: 60vh;
+}
+.testimonial {
+  max-width: 600px;
+}
+.landing-footer a {
+  color: #ffffff;
+}

--- a/frontend/views/landing_page.js
+++ b/frontend/views/landing_page.js
@@ -1,77 +1,72 @@
-const { Container, TextField, Button, Typography, Box, AppBar, Toolbar } = MaterialUI;
-const { useState } = React;
+const { ChakraProvider, Box, Flex, Heading, Text, Button, Grid, Stack, Image } = ChakraUI;
+const { useEffect, useState } = React;
 const { useNavigate } = ReactRouterDOM;
 
 function LandingPage() {
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
+  const [features, setFeatures] = useState([]);
+  const [testimonials, setTestimonials] = useState([]);
   const navigate = useNavigate();
 
-  async function handle(action) {
-    setError('');
-    const url = `/api/auth/${action}`;
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password })
-    });
-    const data = await res.json();
-    if (!res.ok) {
-      setError(data.error || 'Error');
-      return;
-    }
-    if (action === 'login') {
-      localStorage.setItem('token', data.token);
-      navigate('/dashboard');
-    } else {
-      alert('Registered! You can now log in.');
-    }
-  }
+  useEffect(() => {
+    fetch('/api/landing/content')
+      .then((res) => res.json())
+      .then((data) => {
+        setFeatures(data.features || []);
+        setTestimonials(data.testimonials || []);
+      })
+      .catch(() => {});
+  }, []);
 
   return (
-    <Box sx={{ flexGrow: 1 }}>
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6" sx={{ flexGrow: 1 }}>
-            Workhouse
-          </Typography>
-        </Toolbar>
-      </AppBar>
-      <Container maxWidth="sm" sx={{ mt: 4 }}>
-        <Typography variant="h4" gutterBottom>
-          Welcome to Workhouse
-        </Typography>
-        <TextField
-          label="Username"
-          fullWidth
-          margin="normal"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        />
-        <TextField
-          label="Password"
-          type="password"
-          fullWidth
-          margin="normal"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        {error && (
-          <Typography color="error" sx={{ mt: 1 }}>
-            {error}
-          </Typography>
-        )}
-        <Box sx={{ mt: 2, display: 'flex', gap: 2 }}>
-          <Button variant="contained" onClick={() => handle('login')}>
-            Login
-          </Button>
-          <Button variant="outlined" onClick={() => handle('register')}>
-            Register
-          </Button>
+    <ChakraProvider>
+      <Flex as="header" className="landing-header" justify="space-between" align="center" p={4} boxShadow="sm" position="sticky" top="0" bg="white" zIndex="1000">
+        <Heading size="md">Workhouse</Heading>
+        <Stack direction="row" spacing={4}>
+          <Button variant="ghost" onClick={() => navigate('/login')}>Login</Button>
+          <Button colorScheme="blue" onClick={() => navigate('/login')}>Sign Up</Button>
+        </Stack>
+      </Flex>
+      <Box as="main">
+        <Flex className="hero" direction="column" align="center" justify="center" textAlign="center" p={8}>
+          <Heading mb={4}>Revolutionize Your Recruitment &amp; Gig Management</Heading>
+          <Text mb={6}>AI-powered platform connecting talent, employers, and service providers.</Text>
+          <Button colorScheme="blue" size="lg" onClick={() => navigate('/login')}>Get Started</Button>
+        </Flex>
+        <Box className="features" py={16} px={8}>
+          <Grid templateColumns="repeat(auto-fit, minmax(200px,1fr))" gap={6}>
+            {features.map((f) => (
+              <FeatureCard key={f.id} title={f.title} description={f.description} icon={f.icon} />
+            ))}
+          </Grid>
         </Box>
-      </Container>
-    </Box>
+        <Box className="testimonials" bg="gray.50" py={16} px={8}>
+          <Heading size="lg" textAlign="center" mb={8}>What People Say</Heading>
+          <Stack spacing={6}>
+            {testimonials.map((t) => (
+              <Box key={t.id} className="testimonial" maxW="xl" mx="auto" textAlign="center">
+                <Text fontStyle="italic">"{t.quote}"</Text>
+                <Text mt={2} fontWeight="bold">- {t.name}</Text>
+              </Box>
+            ))}
+          </Stack>
+        </Box>
+        <Box className="secondary-cta" py={16} px={8} textAlign="center">
+          <Heading mb={4}>Ready to Join?</Heading>
+          <Text mb={6}>Start your journey with Workhouse today.</Text>
+          <Button colorScheme="blue" size="lg" onClick={() => navigate('/login')}>Create Account</Button>
+        </Box>
+      </Box>
+      <Box as="footer" className="landing-footer" py={8} textAlign="center" bg="gray.800" color="white">
+        <Stack spacing={2} align="center">
+          <Stack direction="row" spacing={4}>
+            <a href="#">Privacy Policy</a>
+            <a href="#">Terms of Service</a>
+            <a href="#">Help Center</a>
+          </Stack>
+          <Text>&copy; {new Date().getFullYear()} Workhouse</Text>
+        </Stack>
+      </Box>
+    </ChakraProvider>
   );
 }
 

--- a/frontend/views/login_page.css
+++ b/frontend/views/login_page.css
@@ -1,0 +1,3 @@
+.login-container {
+  background-color: #f7fafc;
+}

--- a/frontend/views/login_page.js
+++ b/frontend/views/login_page.js
@@ -1,0 +1,59 @@
+const { ChakraProvider, Box, Flex, Heading, Input, Button, FormControl, FormLabel, Text, useToast } = ChakraUI;
+const { useState } = React;
+const { useNavigate } = ReactRouterDOM;
+
+function LoginPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const toast = useToast();
+  const navigate = useNavigate();
+
+  async function handle(action) {
+    setError('');
+    try {
+      const res = await fetch(`/api/auth/${action}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Error');
+      if (action === 'login') {
+        localStorage.setItem('token', data.token);
+        navigate('/dashboard');
+      } else {
+        toast({ title: 'Registered! You can now log in.', status: 'success', duration: 3000, isClosable: true });
+      }
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  return (
+    <ChakraProvider>
+      <Flex className="login-container" minH="100vh" align="center" justify="center" direction="column" bg="gray.50" p={4}>
+        <Heading mb={6}>Workhouse</Heading>
+        <Box w="sm" p={6} bg="white" boxShadow="md" borderRadius="md">
+          <FormControl id="username" mb={4}>
+            <FormLabel>Username</FormLabel>
+            <Input value={username} onChange={(e) => setUsername(e.target.value)} />
+          </FormControl>
+          <FormControl id="password" mb={4}>
+            <FormLabel>Password</FormLabel>
+            <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+          </FormControl>
+          {error && (
+            <Text color="red.500" mb={2}>{error}</Text>
+          )}
+          <Flex gap={3} mt={4}>
+            <Button colorScheme="blue" flex="1" onClick={() => handle('login')}>Login</Button>
+            <Button variant="outline" flex="1" onClick={() => handle('register')}>Register</Button>
+          </Flex>
+        </Box>
+      </Flex>
+    </ChakraProvider>
+  );
+}
+
+window.LoginPage = LoginPage;


### PR DESCRIPTION
## Summary
- add landing content endpoint backed by external testimonial API
- build Chakra UI landing page with feature grid and testimonials
- create login page using Chakra UI

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689269cdc9d4832086fa4029f168bb23