### PR TITLE
Add employment dashboard and analytics route

### DIFF
--- a/backend/controllers/employmentAnalytics.js
+++ b/backend/controllers/employmentAnalytics.js
@@ -2,6 +2,7 @@ const {
   getEmploymentOverview,
   getJobAnalytics,
   getApplicationAnalytics,
+  listJobs,
 } = require('../services/employmentAnalytics');
 const logger = require('../utils/logger');
 
@@ -36,8 +37,19 @@ async function applicationAnalyticsHandler(req, res) {
   }
 }
 
+async function jobsListHandler(req, res) {
+  try {
+    const jobs = await listJobs();
+    res.json(jobs);
+  } catch (err) {
+    logger.error('Failed to list jobs', { error: err.message });
+    res.status(500).json({ error: 'Failed to list jobs' });
+  }
+}
+
 module.exports = {
   overviewHandler,
   jobAnalyticsHandler,
   applicationAnalyticsHandler,
+  jobsListHandler,
 };

--- a/backend/models/employmentAnalytics.js
+++ b/backend/models/employmentAnalytics.js
@@ -51,6 +51,10 @@ function getJobStats(jobId) {
   return jobs.get(jobId) || null;
 }
 
+function listJobs() {
+  return Array.from(jobs.values());
+}
+
 function getApplicationStats() {
   const byStatus = applications.reduce((acc, curr) => {
     acc[curr.status] = (acc[curr.status] || 0) + 1;
@@ -76,5 +80,6 @@ module.exports = {
   recordApplication,
   getOverview,
   getJobStats,
+  listJobs,
   getApplicationStats,
 };

--- a/backend/routes/employmentAnalytics.js
+++ b/backend/routes/employmentAnalytics.js
@@ -3,6 +3,7 @@ const {
   overviewHandler,
   jobAnalyticsHandler,
   applicationAnalyticsHandler,
+  jobsListHandler,
 } = require('../controllers/employmentAnalytics');
 const auth = require('../middleware/auth');
 const authorize = require('../middleware/authorize');
@@ -12,6 +13,7 @@ const { jobParamSchema } = require('../validation/employmentAnalytics');
 const router = express.Router({ mergeParams: true });
 
 router.get('/overview', auth, authorize('admin', 'hr-manager'), overviewHandler);
+router.get('/jobs', auth, authorize('admin', 'hr-manager'), jobsListHandler);
 router.get('/jobs/:jobId', auth, authorize('admin', 'hr-manager'), validate(jobParamSchema, 'params'), jobAnalyticsHandler);
 router.get('/applications', auth, authorize('admin', 'hr-manager'), applicationAnalyticsHandler);
 

--- a/backend/services/employmentAnalytics.js
+++ b/backend/services/employmentAnalytics.js
@@ -20,8 +20,14 @@ async function getApplicationAnalytics() {
   return model.getApplicationStats();
 }
 
+async function listJobs() {
+  logger.info('Listing employment jobs');
+  return model.listJobs();
+}
+
 module.exports = {
   getEmploymentOverview,
   getJobAnalytics,
   getApplicationAnalytics,
+  listJobs,
 };

--- a/frontend/api/employment.js
+++ b/frontend/api/employment.js
@@ -1,0 +1,23 @@
+(function(global){
+  async function getOverview(){
+    const res = await apiFetch('/api/analytics/employment/overview');
+    if(!res.ok) throw new Error('Failed to load employment overview');
+    return res.json();
+  }
+  async function getApplications(){
+    const res = await apiFetch('/api/analytics/employment/applications');
+    if(!res.ok) throw new Error('Failed to load application analytics');
+    return res.json();
+  }
+  async function getJobs(){
+    const res = await apiFetch('/api/analytics/employment/jobs');
+    if(!res.ok) throw new Error('Failed to load jobs');
+    return res.json();
+  }
+  async function getJob(jobId){
+    const res = await apiFetch(`/api/analytics/employment/jobs/${jobId}`);
+    if(!res.ok) throw new Error('Failed to load job analytics');
+    return res.json();
+  }
+  global.employmentAPI = { getOverview, getApplications, getJobs, getJob };
+})(window);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -11,6 +11,7 @@ function App() {
             <Route path="/login" element={<LoginPage />} />
             <Route path="/home" element={<HomePage />} />
             <Route path="/dashboard" element={<Protected><HomeDashboard /></Protected>} />
+            <Route path="/employment" element={<Protected><EmploymentDashboard /></Protected>} />
           </Routes>
         </BrowserRouter>
       </AuthProvider>
@@ -22,6 +23,7 @@ function App() {
         <Route path="/signup" element={<SignUpPage />} />
         <Route path="/home" element={<HomePage />} />
         <Route path="/dashboard" element={<Protected><HomeDashboard /></Protected>} />
+        <Route path="/employment" element={<Protected><EmploymentDashboard /></Protected>} />
         <Route path="/onboarding/documents" element={<Protected><CvCoverLetterPage /></Protected>} />
         <Route path="/feed" element={<Protected><LiveFeed /></Protected>} />
         <Route path="/profile/customize" element={<Protected><ProfileCustomization /></Protected>} />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,6 +38,7 @@
     <link rel="stylesheet" href="components/FeatureCard.css" />
     <link rel="stylesheet" href="components/ProgressIndicator.css" />
     <link rel="stylesheet" href="views/financial_media_setup.css" />
+    <link rel="stylesheet" href="views/employment_dashboard.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
@@ -79,9 +80,11 @@
     <script type="text/babel" data-presets="env,react" src="views/cv_cover_letter_page.js"></script>
     <script type="text/babel" data-presets="env,react" src="utils/auth.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/profile.js"></script>
+    <script type="text/babel" data-presets="env,react" src="api/employment.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/profile_customization.js"></script>
     <script type="text/babel" data-presets="env,react" src="utils/api.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/financial_media_setup.js"></script>
+    <script type="text/babel" data-presets="env,react" src="views/employment_dashboard.js"></script>
     <script type="text/babel" data-presets="env,react" src="app.js"></script>
   </body>
 </html>

--- a/frontend/nav/menu.js
+++ b/frontend/nav/menu.js
@@ -14,6 +14,7 @@ function NavMenu() {
       <Heading size="md">Workhouse</Heading>
       <Spacer />
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/dashboard')}>Dashboard</Button>
+      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/employment')}>Employment</Button>
       <Button variant="outline" color="white" onClick={handleLogout}>Logout</Button>
     </Flex>
   );

--- a/frontend/views/employment_dashboard.css
+++ b/frontend/views/employment_dashboard.css
@@ -1,0 +1,11 @@
+.employment-dashboard {
+  background-color: #f7fafc;
+}
+
+.employment-dashboard .stat-box {
+  background-color: #fff;
+}
+
+.employment-dashboard .job-card {
+  background-color: #fff;
+}

--- a/frontend/views/employment_dashboard.js
+++ b/frontend/views/employment_dashboard.js
@@ -1,0 +1,85 @@
+const { Box, Heading, SimpleGrid, Text, Spinner } = ChakraUI;
+const { useEffect, useState } = React;
+
+function EmploymentDashboard() {
+  const [overview, setOverview] = useState(null);
+  const [jobs, setJobs] = useState([]);
+  const [appStats, setAppStats] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [ov, jobList, apps] = await Promise.all([
+          employmentAPI.getOverview(),
+          employmentAPI.getJobs(),
+          employmentAPI.getApplications(),
+        ]);
+        setOverview(ov);
+        setJobs(jobList);
+        setAppStats(apps);
+      } catch (err) {
+        console.error('Failed to load employment dashboard', err);
+      }
+    }
+    load();
+  }, []);
+
+  if (!overview) {
+    return (
+      <Box className="employment-dashboard" p={4}>
+        <NavMenu />
+        <Spinner />
+      </Box>
+    );
+  }
+
+  return (
+    <Box className="employment-dashboard" p={4}>
+      <NavMenu />
+      <Heading size="lg" mb={4}>Employment Overview</Heading>
+      <SimpleGrid columns={[1,2,3]} spacing={4} mb={8}>
+        <Box className="stat-box" p={4} borderWidth="1px" borderRadius="md">
+          <Text>Total Jobs: {overview.totalJobs}</Text>
+        </Box>
+        <Box className="stat-box" p={4} borderWidth="1px" borderRadius="md">
+          <Text>Open Jobs: {overview.openJobs}</Text>
+        </Box>
+        <Box className="stat-box" p={4} borderWidth="1px" borderRadius="md">
+          <Text>Closed Jobs: {overview.closedJobs}</Text>
+        </Box>
+        <Box className="stat-box" p={4} borderWidth="1px" borderRadius="md">
+          <Text>Total Applications: {overview.totalApplications}</Text>
+        </Box>
+        <Box className="stat-box" p={4} borderWidth="1px" borderRadius="md">
+          <Text>Hired Applications: {overview.hiredApplications}</Text>
+        </Box>
+      </SimpleGrid>
+      {appStats && (
+        <Box mb={8}>
+          <Heading size="md" mb={2}>Applications by Status</Heading>
+          <SimpleGrid columns={[1,2,3]} spacing={4}>
+            {Object.entries(appStats.byStatus).map(([status, count]) => (
+              <Box key={status} p={4} borderWidth="1px" borderRadius="md">
+                <Text>{status}: {count}</Text>
+              </Box>
+            ))}
+          </SimpleGrid>
+        </Box>
+      )}
+      <Heading size="md" mb={2}>Jobs</Heading>
+      <SimpleGrid columns={[1,2]} spacing={4}>
+        {jobs.map(job => (
+          <Box key={job.id} className="job-card" p={4} borderWidth="1px" borderRadius="md" bg="white">
+            <Heading size="sm" mb={2}>{job.title}</Heading>
+            <Text>Status: {job.status}</Text>
+            <Text>Views: {job.views}</Text>
+            <Text>Applications: {job.applications}</Text>
+            <Text>Hires: {job.hires}</Text>
+          </Box>
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}
+
+window.EmploymentDashboard = EmploymentDashboard;

--- a/frontend/views/home_dashboard.js
+++ b/frontend/views/home_dashboard.js
@@ -1,7 +1,5 @@
-const { Box, Heading, SimpleGrid, Text } = ChakraUI;
+const { Box, Heading, SimpleGrid, Text, Button } = ChakraUI;
 const { useState, useEffect } = React;
-const { useEffect, useState } = React;
-const { Box, Heading, Text, Button } = ChakraUI;
 
 function HomeDashboard() {
   const { user } = useAuth();
@@ -42,12 +40,16 @@ function HomeDashboard() {
         )}
         <QuoteWidget />
       </SimpleGrid>
-    <Box className="dashboard">
-      <Heading size="lg" mb={2}>Dashboard</Heading>
-      <Text mb={4}>Hello, {user.username}!</Text>
-      <Button colorScheme="blue" onClick={() => window.location.href = '/feed'}>
-        Go to Live Feed
-      </Button>
+      <Box className="dashboard">
+        <Heading size="lg" mb={2}>Dashboard</Heading>
+        <Text mb={4}>Hello, {user.username}!</Text>
+        <Button colorScheme="blue" onClick={() => window.location.href = '/feed'}>
+          Go to Live Feed
+        </Button>
+        <Button colorScheme="green" mt={2} onClick={() => window.location.href = '/employment'}>
+          Employment Dashboard
+        </Button>
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- add job listing support and route to employment analytics backend
- build employment dashboard page and API module using Chakra UI
- integrate navigation and routing for employment dashboard

## Testing
- `npm test` (fails: Could not read package.json)
- `cd backend && npm test` (fails: Invalid package.json)
- `cd ../frontend && npm test` (passes: no tests)


------
https://chatgpt.com/codex/tasks/task_e_68927664f998832090cd763c58a5135a