### PR TITLE
feat: add virtual interview page

### DIFF
--- a/.env
+++ b/.env
@@ -21,3 +21,4 @@ RECAPTCHA_SECRET=
 FRONTEND_API_BASE_URL=http://localhost:3000/api
 AVATAR_API=https://api.dicebear.com/6.x/initials/svg
 API_BASE_URL=http://localhost:5000
+JITSI_DOMAIN=https://meet.jit.si

--- a/backend/app.js
+++ b/backend/app.js
@@ -69,6 +69,7 @@ const aiEnhancedLearningRoutes = require('./routes/aiEnhancedLearningDevelopment
 const userFeedbackAdjustmentRoutes = require('./routes/userFeedbackAdjustment');
 const integrationRoutes = require('./routes/integration');
 const sessionRoutes = require('./routes/sessions');
+const interviewRoutes = require('./routes/interviews');
 const infrastructureOptimizationRoutes = require('./routes/infrastructureOptimization');
 const externalDataMLRoutes = require('./routes/externalDataML');
 const machineLearningRoutes = require('./routes/machineLearning');
@@ -185,6 +186,7 @@ app.use('/ml/learning', aiEnhancedLearningRoutes);
 app.use('/', userFeedbackAdjustmentRoutes);
 app.use('/integration', integrationRoutes);
 app.use('/sessions', sessionRoutes);
+app.use('/interviews', interviewRoutes);
 app.use('/ml', infrastructureOptimizationRoutes);
 app.use('/', externalDataMLRoutes);
 app.use('/ml', machineLearningRoutes);

--- a/backend/controllers/interview.js
+++ b/backend/controllers/interview.js
@@ -1,0 +1,39 @@
+const { scheduleInterview, getInterview, addNote } = require('../services/interview');
+const logger = require('../utils/logger');
+
+async function scheduleInterviewHandler(req, res) {
+  try {
+    const interview = scheduleInterview(req.body);
+    res.status(201).json(interview);
+  } catch (err) {
+    logger.error('Failed to schedule interview', err);
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function getInterviewHandler(req, res) {
+  const interview = getInterview(req.params.id);
+  if (!interview) {
+    return res.status(404).json({ error: 'Interview not found' });
+  }
+  res.json(interview);
+}
+
+async function addNoteHandler(req, res) {
+  try {
+    const interview = addNote(req.params.id, req.body.text);
+    if (!interview) {
+      return res.status(404).json({ error: 'Interview not found' });
+    }
+    res.json(interview);
+  } catch (err) {
+    logger.error('Failed to add note', err);
+    res.status(400).json({ error: err.message });
+  }
+}
+
+module.exports = {
+  scheduleInterviewHandler,
+  getInterviewHandler,
+  addNoteHandler,
+};

--- a/backend/models/interview.js
+++ b/backend/models/interview.js
@@ -1,0 +1,36 @@
+const interviews = [];
+let idCounter = 1;
+
+function createInterview({ interviewerId, candidateId, scheduledFor }) {
+  const interview = {
+    id: idCounter++,
+    interviewerId: Number(interviewerId),
+    candidateId: Number(candidateId),
+    scheduledFor: new Date(scheduledFor),
+    notes: [],
+    status: 'scheduled',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  interviews.push(interview);
+  return interview;
+}
+
+function getInterviewById(id) {
+  return interviews.find(i => i.id === Number(id));
+}
+
+function addNoteToInterview(id, text) {
+  const interview = getInterviewById(id);
+  if (!interview) return null;
+  interview.notes.push({ text, createdAt: new Date() });
+  interview.updatedAt = new Date();
+  return interview;
+}
+
+module.exports = {
+  interviews,
+  createInterview,
+  getInterviewById,
+  addNoteToInterview,
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/client-s3": "^3.859.0",
     "nodemailer": "^7.0.5",
     "pusher": "^5.2.0",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
     "dotenv": "^16.3.1"
   }
 }

--- a/backend/routes/interviews.js
+++ b/backend/routes/interviews.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const { authenticate } = require('../middleware/auth');
+const validate = require('../middleware/validate');
+const { scheduleInterviewSchema, noteSchema } = require('../validation/interview');
+const {
+  scheduleInterviewHandler,
+  getInterviewHandler,
+  addNoteHandler,
+} = require('../controllers/interview');
+
+const router = express.Router();
+
+router.post('/schedule', authenticate, validate(scheduleInterviewSchema), scheduleInterviewHandler);
+router.get('/:id', authenticate, getInterviewHandler);
+router.post('/:id/notes', authenticate, validate(noteSchema), addNoteHandler);
+
+module.exports = router;

--- a/backend/services/interview.js
+++ b/backend/services/interview.js
@@ -1,0 +1,23 @@
+const {
+  createInterview,
+  getInterviewById,
+  addNoteToInterview,
+} = require('../models/interview');
+
+function scheduleInterview(data) {
+  return createInterview(data);
+}
+
+function getInterview(id) {
+  return getInterviewById(id);
+}
+
+function addNote(id, text) {
+  return addNoteToInterview(id, text);
+}
+
+module.exports = {
+  scheduleInterview,
+  getInterview,
+  addNote,
+};

--- a/backend/validation/interview.js
+++ b/backend/validation/interview.js
@@ -1,0 +1,16 @@
+const Joi = require('joi');
+
+const scheduleInterviewSchema = Joi.object({
+  interviewerId: Joi.number().required(),
+  candidateId: Joi.number().required(),
+  scheduledFor: Joi.date().iso().required(),
+});
+
+const noteSchema = Joi.object({
+  text: Joi.string().max(1000).required(),
+});
+
+module.exports = {
+  scheduleInterviewSchema,
+  noteSchema,
+};

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,3 @@
 VITE_API_BASE_URL=http://localhost:3000/api
 VITE_AVATAR_API=https://api.dicebear.com/6.x/initials/svg
+VITE_JITSI_DOMAIN=https://meet.jit.si

--- a/frontend/api/interviews.js
+++ b/frontend/api/interviews.js
@@ -1,0 +1,17 @@
+(function(global){
+  async function getInterview(id){
+    const res = await apiFetch(`/api/interviews/${id}`);
+    if(!res.ok) throw new Error('Failed to load interview');
+    return res.json();
+  }
+  async function addNote(id, text){
+    const res = await apiFetch(`/api/interviews/${id}/notes`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text })
+    });
+    if(!res.ok) throw new Error('Failed to add note');
+    return res.json();
+  }
+  global.interviewAPI = { getInterview, addNote };
+})(window);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -26,6 +26,7 @@ function App() {
         <Route path="/feed" element={<Protected><LiveFeed /></Protected>} />
         <Route path="/profile/customize" element={<Protected><ProfileCustomization /></Protected>} />
         <Route path="/setup/financial-media" element={<Protected><FinancialMediaSetupPage /></Protected>} />
+        <Route path="/interview/:id" element={<Protected><VirtualInterviewPage /></Protected>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/env.js
+++ b/frontend/env.js
@@ -1,3 +1,4 @@
 window.env = {
-  API_BASE_URL: 'http://localhost:5000'
+  API_BASE_URL: 'http://localhost:5000',
+  JITSI_DOMAIN: 'https://meet.jit.si'
 };

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,6 +38,7 @@
     <link rel="stylesheet" href="components/FeatureCard.css" />
     <link rel="stylesheet" href="components/ProgressIndicator.css" />
     <link rel="stylesheet" href="views/financial_media_setup.css" />
+    <link rel="stylesheet" href="views/virtual_interview.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
@@ -79,9 +80,11 @@
     <script type="text/babel" data-presets="env,react" src="views/cv_cover_letter_page.js"></script>
     <script type="text/babel" data-presets="env,react" src="utils/auth.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/profile.js"></script>
+    <script type="text/babel" data-presets="env,react" src="api/interviews.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/profile_customization.js"></script>
     <script type="text/babel" data-presets="env,react" src="utils/api.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/financial_media_setup.js"></script>
+    <script type="text/babel" data-presets="env,react" src="views/virtual_interview.js"></script>
     <script type="text/babel" data-presets="env,react" src="app.js"></script>
   </body>
 </html>

--- a/frontend/nav/menu.js
+++ b/frontend/nav/menu.js
@@ -14,6 +14,7 @@ function NavMenu() {
       <Heading size="md">Workhouse</Heading>
       <Spacer />
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/dashboard')}>Dashboard</Button>
+      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/interview/1')}>Interview</Button>
       <Button variant="outline" color="white" onClick={handleLogout}>Logout</Button>
     </Flex>
   );

--- a/frontend/views/home_dashboard.js
+++ b/frontend/views/home_dashboard.js
@@ -42,12 +42,16 @@ function HomeDashboard() {
         )}
         <QuoteWidget />
       </SimpleGrid>
-    <Box className="dashboard">
-      <Heading size="lg" mb={2}>Dashboard</Heading>
-      <Text mb={4}>Hello, {user.username}!</Text>
-      <Button colorScheme="blue" onClick={() => window.location.href = '/feed'}>
-        Go to Live Feed
-      </Button>
+      <Box className="dashboard" mt={6}>
+        <Heading size="lg" mb={2}>Dashboard</Heading>
+        <Text mb={4}>Hello, {user.username}!</Text>
+        <Button colorScheme="blue" mr={2} onClick={() => window.location.href = '/feed'}>
+          Go to Live Feed
+        </Button>
+        <Button colorScheme="teal" onClick={() => window.location.href = '/interview/1'}>
+          Join Interview
+        </Button>
+      </Box>
     </Box>
   );
 }

--- a/frontend/views/virtual_interview.css
+++ b/frontend/views/virtual_interview.css
@@ -1,0 +1,10 @@
+.virtual-interview {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.video-container {
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  overflow: hidden;
+}

--- a/frontend/views/virtual_interview.js
+++ b/frontend/views/virtual_interview.js
@@ -1,0 +1,61 @@
+const { Box, Heading, Button, Text, Textarea } = ChakraUI;
+const { useState, useEffect } = React;
+const { useParams } = ReactRouterDOM;
+
+function VirtualInterviewPage() {
+  const { id } = useParams();
+  const [interview, setInterview] = useState(null);
+  const [inSession, setInSession] = useState(false);
+  const [note, setNote] = useState('');
+  const domain = (window.env && window.env.JITSI_DOMAIN) || 'https://meet.jit.si';
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await window.interviewAPI.getInterview(id);
+        setInterview(data);
+      } catch (err) {
+        console.error('Failed to load interview', err);
+      }
+    }
+    load();
+  }, [id]);
+
+  async function handleSaveNote() {
+    try {
+      await window.interviewAPI.addNote(id, note);
+      setNote('');
+    } catch (err) {
+      console.error('Failed to save note', err);
+    }
+  }
+
+  return (
+    <Box className="virtual-interview" p={4}>
+      <NavMenu />
+      <Heading mb={4}>Virtual Interview</Heading>
+      {interview && (
+        <Text mb={4}>Scheduled for: {new Date(interview.scheduledFor).toLocaleString()}</Text>
+      )}
+      {!inSession ? (
+        <Button colorScheme="blue" onClick={() => setInSession(true)}>Join Interview</Button>
+      ) : (
+        <Box className="video-container" mb={4}>
+          <iframe
+            title="Interview"
+            src={`${domain}/${'workhouse-interview-'+id}`}
+            allow="camera; microphone; fullscreen; display-capture"
+            style={{ width: '100%', height: '500px', border: 0 }}
+          ></iframe>
+        </Box>
+      )}
+      <Box mt={4}>
+        <Heading size="md" mb={2}>Notes</Heading>
+        <Textarea value={note} onChange={(e) => setNote(e.target.value)} placeholder="Enter notes" />
+        <Button mt={2} colorScheme="teal" onClick={handleSaveNote}>Save Note</Button>
+      </Box>
+    </Box>
+  );
+}
+
+window.VirtualInterviewPage = VirtualInterviewPage;


### PR DESCRIPTION
## Summary
- build backend interview model, service, controller and routes
- add React Virtual Interview page with Jitsi integration
- wire new page into navigation, dashboard, and environment configuration

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_689277d1700483208533ffa23baecaa1