### PR TITLE
feat: add contract creation editing page

### DIFF
--- a/backend/models/contract.js
+++ b/backend/models/contract.js
@@ -4,16 +4,42 @@ const contracts = new Map();
 const contractProposals = new Map();
 const workSubmissions = new Map();
 
-function createContract({ clientId, title, description, budget, timeline }) {
+function createContract({
+  clientId,
+  title,
+  description,
+  paymentType,
+  budget,
+  hourlyRate,
+  expectedHours,
+  milestones = [],
+  deliverables = [],
+  timeline,
+}) {
   const id = randomUUID();
   const timestamp = new Date();
+  const mappedMilestones = milestones.map((m) => ({
+    id: randomUUID(),
+    title: m.title,
+    dueDate: m.dueDate ? new Date(m.dueDate) : null,
+    amount: m.amount ?? null,
+  }));
+  const mappedDeliverables = deliverables.map((d) => ({
+    id: randomUUID(),
+    description: d.description,
+  }));
   const contract = {
     id,
     clientId,
     freelancerId: null,
     title,
     description: description || null,
+    paymentType: paymentType || 'fixed',
     budget: budget ?? null,
+    hourlyRate: hourlyRate ?? null,
+    expectedHours: expectedHours ?? null,
+    milestones: mappedMilestones,
+    deliverables: mappedDeliverables,
     timeline: timeline || null,
     status: 'open',
     createdAt: timestamp,
@@ -33,6 +59,20 @@ function updateContract(id, updates) {
   const contract = contracts.get(id);
   if (!contract || ['terminated', 'completed'].includes(contract.status)) {
     return null;
+  }
+  if (updates.milestones) {
+    updates.milestones = updates.milestones.map((m) => ({
+      id: m.id || randomUUID(),
+      title: m.title,
+      dueDate: m.dueDate ? new Date(m.dueDate) : null,
+      amount: m.amount ?? null,
+    }));
+  }
+  if (updates.deliverables) {
+    updates.deliverables = updates.deliverables.map((d) => ({
+      id: d.id || randomUUID(),
+      description: d.description,
+    }));
   }
   Object.assign(contract, updates, { updatedAt: new Date() });
   contracts.set(id, contract);

--- a/backend/validation/contract.js
+++ b/backend/validation/contract.js
@@ -1,18 +1,38 @@
 const Joi = require('joi');
 
+const milestoneSchema = Joi.object({
+  title: Joi.string().min(1).max(255).required(),
+  dueDate: Joi.date().iso().required(),
+  amount: Joi.number().precision(2).positive().required(),
+});
+
+const deliverableSchema = Joi.object({
+  description: Joi.string().max(1000).required(),
+});
+
 const createContractSchema = Joi.object({
   clientId: Joi.string().required(),
   title: Joi.string().min(3).max(255).required(),
   description: Joi.string().max(1000).optional(),
+  paymentType: Joi.string().valid('fixed', 'hourly').required(),
   budget: Joi.number().precision(2).positive().optional(),
+  hourlyRate: Joi.number().precision(2).positive().optional(),
+  expectedHours: Joi.number().precision(2).positive().optional(),
   timeline: Joi.string().max(255).optional(),
+  milestones: Joi.array().items(milestoneSchema).optional(),
+  deliverables: Joi.array().items(deliverableSchema).optional(),
 });
 
 const updateContractSchema = Joi.object({
   title: Joi.string().min(3).max(255),
   description: Joi.string().max(1000),
+  paymentType: Joi.string().valid('fixed', 'hourly'),
   budget: Joi.number().precision(2).positive(),
+  hourlyRate: Joi.number().precision(2).positive(),
+  expectedHours: Joi.number().precision(2).positive(),
   timeline: Joi.string().max(255),
+  milestones: Joi.array().items(milestoneSchema),
+  deliverables: Joi.array().items(deliverableSchema),
   status: Joi.string().valid('open', 'active', 'terminated', 'completed'),
 }).min(1);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,62 +1,74 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { AuthProvider, useAuth } from './context/AuthContext.jsx';
+import { ChakraProvider, Box } from '@chakra-ui/react';
+import NavMenu from './components/NavMenu.jsx';
 import LoginPage from './pages/LoginPage.jsx';
 import SignupPage from './pages/SignupPage.jsx';
 import ProfilePage from './pages/ProfilePage.jsx';
+import ProfileCustomizationPage from './pages/ProfileCustomizationPage.jsx';
+import ContractFormPage from './pages/ContractFormPage.jsx';
+import { AuthProvider, useAuth } from './context/AuthContext.jsx';
+import { ProfileProvider } from './context/ProfileContext.jsx';
 
 function Protected({ children }) {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
+  if (loading) return null;
   if (!user) {
-    return <Navigate to="/login" />;
+    return <Navigate to="/login" replace />;
   }
   return children;
 }
 
 export default function App() {
   return (
-    <AuthProvider>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/signup" element={<SignupPage />} />
-          <Route
-            path="/profile"
-            element={
-              <Protected>
-                <ProfilePage />
-              </Protected>
-            }
-          />
-          <Route path="*" element={<Navigate to="/login" />} />
-        </Routes>
-      </BrowserRouter>
-    </AuthProvider>
-  );
-}
-import { ChakraProvider, Box } from '@chakra-ui/react';
-import NavBar from './components/NavBar.jsx';
-import ProfilePage from './pages/ProfilePage.jsx';
-import ProfileCustomizationPage from './pages/ProfileCustomizationPage.jsx';
-import { ProfileProvider } from './context/ProfileContext.jsx';
-
-function App() {
-  return (
     <ChakraProvider>
-      <BrowserRouter>
-        <ProfileProvider>
-          <NavBar />
-          <Box p={4}>
-            <Routes>
-              <Route path="/" element={<Navigate to="/profile" replace />} />
-              <Route path="/profile" element={<ProfilePage />} />
-              <Route path="/profile/customize" element={<ProfileCustomizationPage />} />
-            </Routes>
-          </Box>
-        </ProfileProvider>
-      </BrowserRouter>
+      <AuthProvider>
+        <BrowserRouter>
+          <ProfileProvider>
+            <NavMenu />
+            <Box p={4}>
+              <Routes>
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/signup" element={<SignupPage />} />
+                <Route
+                  path="/profile"
+                  element={
+                    <Protected>
+                      <ProfilePage />
+                    </Protected>
+                  }
+                />
+                <Route
+                  path="/profile/customize"
+                  element={
+                    <Protected>
+                      <ProfileCustomizationPage />
+                    </Protected>
+                  }
+                />
+                <Route
+                  path="/contracts/new"
+                  element={
+                    <Protected>
+                      <ContractFormPage />
+                    </Protected>
+                  }
+                />
+                <Route
+                  path="/contracts/:contractId/edit"
+                  element={
+                    <Protected>
+                      <ContractFormPage />
+                    </Protected>
+                  }
+                />
+                <Route path="/" element={<Navigate to="/profile" replace />} />
+                <Route path="*" element={<Navigate to="/profile" replace />} />
+              </Routes>
+            </Box>
+          </ProfileProvider>
+        </BrowserRouter>
+      </AuthProvider>
     </ChakraProvider>
   );
 }
-
-export default App;

--- a/frontend/src/api/contracts.js
+++ b/frontend/src/api/contracts.js
@@ -1,0 +1,16 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function createContract(data) {
+  const { data: contract } = await apiClient.post('/contracts/create', data);
+  return contract;
+}
+
+export async function getContract(contractId) {
+  const { data: contract } = await apiClient.get(`/contracts/${contractId}`);
+  return contract;
+}
+
+export async function updateContract(contractId, data) {
+  const { data: contract } = await apiClient.put(`/contracts/${contractId}`, data);
+  return contract;
+}

--- a/frontend/src/components/NavMenu.jsx
+++ b/frontend/src/components/NavMenu.jsx
@@ -17,8 +17,25 @@ function NavMenu() {
     <Flex className="nav-menu" bg="teal.500" color="white" p={4} align="center">
       <Heading size="md">Workhouse</Heading>
       <Spacer />
-      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/profile')}>Profile</Button>
-      <Button variant="outline" color="white" onClick={handleLogout}>Logout</Button>
+      <Button
+        variant="ghost"
+        color="white"
+        mr={2}
+        onClick={() => navigate('/profile')}
+      >
+        Profile
+      </Button>
+      <Button
+        variant="ghost"
+        color="white"
+        mr={2}
+        onClick={() => navigate('/contracts/new')}
+      >
+        New Contract
+      </Button>
+      <Button variant="outline" color="white" onClick={handleLogout}>
+        Logout
+      </Button>
     </Flex>
   );
 }

--- a/frontend/src/pages/ContractFormPage.jsx
+++ b/frontend/src/pages/ContractFormPage.jsx
@@ -1,0 +1,224 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  Select,
+  Button,
+  VStack,
+  HStack,
+  IconButton,
+} from '@chakra-ui/react';
+import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
+import { useNavigate, useParams } from 'react-router-dom';
+import { createContract, getContract, updateContract } from '../api/contracts.js';
+import { useAuth } from '../context/AuthContext.jsx';
+import '../styles/ContractFormPage.css';
+
+function ContractFormPage() {
+  const { contractId } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    paymentType: 'fixed',
+    budget: '',
+    hourlyRate: '',
+    expectedHours: '',
+    milestones: [],
+    deliverables: [],
+  });
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (contractId) {
+      async function load() {
+        try {
+          const data = await getContract(contractId);
+          setForm({
+            title: data.title || '',
+            description: data.description || '',
+            paymentType: data.paymentType || 'fixed',
+            budget: data.budget || '',
+            hourlyRate: data.hourlyRate || '',
+            expectedHours: data.expectedHours || '',
+            milestones: data.milestones || [],
+            deliverables: data.deliverables || [],
+          });
+        } catch (err) {
+          console.error(err);
+        }
+      }
+      load();
+    }
+  }, [contractId]);
+
+  function handleChange(e) {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  }
+
+  const addDeliverable = () => {
+    setForm((f) => ({ ...f, deliverables: [...f.deliverables, { description: '' }] }));
+  };
+
+  const updateDeliverable = (index, value) => {
+    const deliverables = [...form.deliverables];
+    deliverables[index].description = value;
+    setForm({ ...form, deliverables });
+  };
+
+  const removeDeliverable = (index) => {
+    const deliverables = form.deliverables.filter((_, i) => i !== index);
+    setForm({ ...form, deliverables });
+  };
+
+  const addMilestone = () => {
+    setForm((f) => ({
+      ...f,
+      milestones: [...f.milestones, { title: '', dueDate: '', amount: '' }],
+    }));
+  };
+
+  const updateMilestone = (index, field, value) => {
+    const milestones = [...form.milestones];
+    milestones[index][field] = value;
+    setForm({ ...form, milestones });
+  };
+
+  const removeMilestone = (index) => {
+    const milestones = form.milestones.filter((_, i) => i !== index);
+    setForm({ ...form, milestones });
+  };
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const payload = {
+        clientId: user?.id || 'client',
+        title: form.title,
+        description: form.description,
+        paymentType: form.paymentType,
+        budget: form.paymentType === 'fixed' ? Number(form.budget) || undefined : undefined,
+        hourlyRate: form.paymentType === 'hourly' ? Number(form.hourlyRate) || undefined : undefined,
+        expectedHours: form.paymentType === 'hourly' ? Number(form.expectedHours) || undefined : undefined,
+        milestones: form.milestones,
+        deliverables: form.deliverables,
+      };
+      if (contractId) {
+        await updateContract(contractId, payload);
+      } else {
+        const created = await createContract(payload);
+        navigate(`/contracts/${created.id}/edit`);
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Box className="contract-form" maxW="800px" mx="auto">
+      <Heading mb={6}>{contractId ? 'Edit Contract' : 'Create Contract'}</Heading>
+      <form onSubmit={handleSubmit}>
+        <VStack spacing={4} align="stretch">
+          <FormControl isRequired>
+            <FormLabel>Title</FormLabel>
+            <Input name="title" value={form.title} onChange={handleChange} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Description</FormLabel>
+            <Textarea name="description" value={form.description} onChange={handleChange} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Payment Type</FormLabel>
+            <Select name="paymentType" value={form.paymentType} onChange={handleChange}>
+              <option value="fixed">Fixed</option>
+              <option value="hourly">Hourly</option>
+            </Select>
+          </FormControl>
+          {form.paymentType === 'fixed' && (
+            <FormControl>
+              <FormLabel>Total Budget</FormLabel>
+              <Input type="number" name="budget" value={form.budget} onChange={handleChange} />
+            </FormControl>
+          )}
+          {form.paymentType === 'hourly' && (
+            <HStack spacing={4}>
+              <FormControl>
+                <FormLabel>Hourly Rate</FormLabel>
+                <Input type="number" name="hourlyRate" value={form.hourlyRate} onChange={handleChange} />
+              </FormControl>
+              <FormControl>
+                <FormLabel>Expected Hours</FormLabel>
+                <Input type="number" name="expectedHours" value={form.expectedHours} onChange={handleChange} />
+              </FormControl>
+            </HStack>
+          )}
+          <Box>
+            <FormLabel>Deliverables</FormLabel>
+            <VStack spacing={2} align="stretch">
+              {form.deliverables.map((d, idx) => (
+                <HStack key={idx}>
+                  <Input
+                    value={d.description}
+                    onChange={(e) => updateDeliverable(idx, e.target.value)}
+                    placeholder={`Deliverable ${idx + 1}`}
+                  />
+                  <IconButton
+                    aria-label="Remove"
+                    icon={<DeleteIcon />}
+                    onClick={() => removeDeliverable(idx)}
+                  />
+                </HStack>
+              ))}
+              <Button leftIcon={<AddIcon />} onClick={addDeliverable} variant="outline">
+                Add Deliverable
+              </Button>
+            </VStack>
+          </Box>
+          <Box>
+            <FormLabel>Milestones</FormLabel>
+            <VStack spacing={2} align="stretch">
+              {form.milestones.map((m, idx) => (
+                <HStack key={idx} align="start">
+                  <Input
+                    placeholder="Title"
+                    value={m.title}
+                    onChange={(e) => updateMilestone(idx, 'title', e.target.value)}
+                  />
+                  <Input
+                    type="date"
+                    value={m.dueDate}
+                    onChange={(e) => updateMilestone(idx, 'dueDate', e.target.value)}
+                  />
+                  <Input
+                    type="number"
+                    placeholder="Amount"
+                    value={m.amount}
+                    onChange={(e) => updateMilestone(idx, 'amount', e.target.value)}
+                  />
+                  <IconButton aria-label="Remove" icon={<DeleteIcon />} onClick={() => removeMilestone(idx)} />
+                </HStack>
+              ))}
+              <Button leftIcon={<AddIcon />} onClick={addMilestone} variant="outline">
+                Add Milestone
+              </Button>
+            </VStack>
+          </Box>
+          <Button colorScheme="teal" type="submit" isLoading={loading} alignSelf="flex-start">
+            {contractId ? 'Update Contract' : 'Create Contract'}
+          </Button>
+        </VStack>
+      </form>
+    </Box>
+  );
+}
+
+export default ContractFormPage;

--- a/frontend/src/styles/ContractFormPage.css
+++ b/frontend/src/styles/ContractFormPage.css
@@ -1,0 +1,7 @@
+.contract-form {
+  padding: 1rem;
+}
+
+.contract-form .chakra-form-control {
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- implement contract creation/editing form with milestones and deliverables
- add contracts API client and navigation entry
- extend contract backend model and validation for payment, milestones and deliverables

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689284874e788320b4dc28bf621752d8