### PR TITLE
feat: add service creation page

### DIFF
--- a/backend/controllers/serviceProviderAnalytics.js
+++ b/backend/controllers/serviceProviderAnalytics.js
@@ -12,6 +12,30 @@ exports.getAnalytics = (req, res) => {
   }
 };
 
+exports.createService = (req, res) => {
+  try {
+    const created = service.createService(req.user.id, req.validatedBody);
+    res.status(201).json(created);
+  } catch (err) {
+    logger.error('Failed to create service', err);
+    res.status(500).json({ error: 'Unable to create service' });
+  }
+};
+
+exports.updateService = (req, res) => {
+  try {
+    const { serviceId } = req.params;
+    const updated = service.updateService(req.user.id, serviceId, req.validatedBody);
+    if (!updated) {
+      return res.status(404).json({ error: 'Service not found or unauthorized' });
+    }
+    res.json(updated);
+  } catch (err) {
+    logger.error('Failed to update service', err);
+    res.status(500).json({ error: 'Unable to update service' });
+  }
+};
+
 exports.updatePricing = (req, res) => {
   try {
     const { serviceId } = req.params;

--- a/backend/models/serviceProviderAnalytics.js
+++ b/backend/models/serviceProviderAnalytics.js
@@ -12,6 +12,30 @@ function findServiceById(id) {
   return services.find(s => s.id === id);
 }
 
+function createService(providerId, { title, description, tags = [], category, price }) {
+  const now = new Date();
+  const service = {
+    id: randomUUID(),
+    providerId,
+    title,
+    description,
+    tags,
+    category,
+    price,
+    createdAt: now,
+    updatedAt: now,
+  };
+  services.push(service);
+  return service;
+}
+
+function updateService(providerId, serviceId, data) {
+  const service = services.find(s => s.id === serviceId && s.providerId === providerId);
+  if (!service) return null;
+  Object.assign(service, data, { updatedAt: new Date() });
+  return service;
+}
+
 function updateServicePricing(providerId, serviceId, price) {
   const service = services.find(s => s.id === serviceId && s.providerId === providerId);
   if (!service) return null;
@@ -116,6 +140,8 @@ module.exports = {
   testimonials,
   customizationRequests,
   chatSessions,
+  createService,
+  updateService,
   findServiceById,
   updateServicePricing,
   addAvailability,

--- a/backend/routes/serviceProviderAnalytics.js
+++ b/backend/routes/serviceProviderAnalytics.js
@@ -8,6 +8,8 @@ const schemas = require('../validation/serviceProviderAnalytics');
 const router = express.Router();
 
 router.get('/analytics', authenticate, requireRole('service_provider'), controller.getAnalytics);
+router.post('/services', authenticate, requireRole('service_provider'), validate(schemas.serviceCreationSchema), controller.createService);
+router.put('/services/:serviceId', authenticate, requireRole('service_provider'), validate(schemas.serviceUpdateSchema), controller.updateService);
 router.put('/services/:serviceId/pricing', authenticate, requireRole('service_provider'), validate(schemas.pricingUpdateSchema), controller.updatePricing);
 router.post('/calendar/availability', authenticate, requireRole('service_provider'), validate(schemas.availabilitySchema), controller.setAvailability);
 router.post('/bookings', authenticate, requireRole('client'), validate(schemas.bookingSchema), controller.createBooking);

--- a/backend/services/serviceProviderAnalytics.js
+++ b/backend/services/serviceProviderAnalytics.js
@@ -6,6 +6,16 @@ function getAnalytics(providerId) {
   return model.computeAnalytics(providerId);
 }
 
+function createService(providerId, data) {
+  logger.info('Creating service', { providerId });
+  return model.createService(providerId, data);
+}
+
+function updateService(providerId, serviceId, data) {
+  logger.info('Updating service', { providerId, serviceId });
+  return model.updateService(providerId, serviceId, data);
+}
+
 function updatePricing(providerId, serviceId, price) {
   logger.info('Updating pricing', { providerId, serviceId, price });
   return model.updateServicePricing(providerId, serviceId, price);
@@ -53,6 +63,8 @@ function initiateChat(clientId, data) {
 
 module.exports = {
   getAnalytics,
+  createService,
+  updateService,
   updatePricing,
   setAvailability,
   createBooking,

--- a/backend/validation/serviceProviderAnalytics.js
+++ b/backend/validation/serviceProviderAnalytics.js
@@ -39,6 +39,22 @@ const chatInitSchema = Joi.object({
   message: Joi.string().max(1024).required(),
 });
 
+const serviceCreationSchema = Joi.object({
+  title: Joi.string().max(255).required(),
+  description: Joi.string().max(2048).required(),
+  price: Joi.number().positive().required(),
+  tags: Joi.array().items(Joi.string()).default([]),
+  category: Joi.string().max(255).optional(),
+});
+
+const serviceUpdateSchema = Joi.object({
+  title: Joi.string().max(255).optional(),
+  description: Joi.string().max(2048).optional(),
+  price: Joi.number().positive().optional(),
+  tags: Joi.array().items(Joi.string()).optional(),
+  category: Joi.string().max(255).optional(),
+});
+
 module.exports = {
   pricingUpdateSchema,
   availabilitySchema,
@@ -47,4 +63,6 @@ module.exports = {
   testimonialSchema,
   customizationSchema,
   chatInitSchema,
+  serviceCreationSchema,
+  serviceUpdateSchema,
 };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,62 +1,66 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { AuthProvider, useAuth } from './context/AuthContext.jsx';
+import { ChakraProvider, Box } from '@chakra-ui/react';
+import NavBar from './components/NavBar.jsx';
+import NavMenu from './components/NavMenu.jsx';
 import LoginPage from './pages/LoginPage.jsx';
 import SignupPage from './pages/SignupPage.jsx';
 import ProfilePage from './pages/ProfilePage.jsx';
+import ProfileCustomizationPage from './pages/ProfileCustomizationPage.jsx';
+import ServiceCreationPage from './pages/ServiceCreationPage.jsx';
+import { AuthProvider, useAuth } from './context/AuthContext.jsx';
+import { ProfileProvider } from './context/ProfileContext.jsx';
 
 function Protected({ children }) {
   const { user } = useAuth();
   if (!user) {
-    return <Navigate to="/login" />;
+    return <Navigate to="/login" replace />;
   }
   return children;
 }
 
 export default function App() {
   return (
-    <AuthProvider>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/signup" element={<SignupPage />} />
-          <Route
-            path="/profile"
-            element={
-              <Protected>
-                <ProfilePage />
-              </Protected>
-            }
-          />
-          <Route path="*" element={<Navigate to="/login" />} />
-        </Routes>
-      </BrowserRouter>
-    </AuthProvider>
-  );
-}
-import { ChakraProvider, Box } from '@chakra-ui/react';
-import NavBar from './components/NavBar.jsx';
-import ProfilePage from './pages/ProfilePage.jsx';
-import ProfileCustomizationPage from './pages/ProfileCustomizationPage.jsx';
-import { ProfileProvider } from './context/ProfileContext.jsx';
-
-function App() {
-  return (
     <ChakraProvider>
-      <BrowserRouter>
-        <ProfileProvider>
-          <NavBar />
-          <Box p={4}>
-            <Routes>
-              <Route path="/" element={<Navigate to="/profile" replace />} />
-              <Route path="/profile" element={<ProfilePage />} />
-              <Route path="/profile/customize" element={<ProfileCustomizationPage />} />
-            </Routes>
-          </Box>
-        </ProfileProvider>
-      </BrowserRouter>
+      <AuthProvider>
+        <BrowserRouter>
+          <ProfileProvider>
+            <NavBar />
+            <NavMenu />
+            <Box p={4}>
+              <Routes>
+                <Route path="/login" element={<LoginPage />} />
+                <Route path="/signup" element={<SignupPage />} />
+                <Route
+                  path="/profile"
+                  element={
+                    <Protected>
+                      <ProfilePage />
+                    </Protected>
+                  }
+                />
+                <Route
+                  path="/profile/customize"
+                  element={
+                    <Protected>
+                      <ProfileCustomizationPage />
+                    </Protected>
+                  }
+                />
+                <Route
+                  path="/services/new"
+                  element={
+                    <Protected>
+                      <ServiceCreationPage />
+                    </Protected>
+                  }
+                />
+                <Route path="*" element={<Navigate to="/login" replace />} />
+              </Routes>
+            </Box>
+          </ProfileProvider>
+        </BrowserRouter>
+      </AuthProvider>
     </ChakraProvider>
   );
 }
-
-export default App;

--- a/frontend/src/api/services.js
+++ b/frontend/src/api/services.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const BASE_URL = window.env.API_BASE_URL;
+
+export async function createService(data) {
+  const token = localStorage.getItem('token');
+  const res = await axios.post(`${BASE_URL}/service-providers/services`, data, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+}
+
+export async function updateService(serviceId, data) {
+  const token = localStorage.getItem('token');
+  const res = await axios.put(`${BASE_URL}/service-providers/services/${serviceId}`, data, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  return res.data;
+}

--- a/frontend/src/components/NavMenu.jsx
+++ b/frontend/src/components/NavMenu.jsx
@@ -17,8 +17,15 @@ function NavMenu() {
     <Flex className="nav-menu" bg="teal.500" color="white" p={4} align="center">
       <Heading size="md">Workhouse</Heading>
       <Spacer />
-      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/profile')}>Profile</Button>
-      <Button variant="outline" color="white" onClick={handleLogout}>Logout</Button>
+      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/profile')}>
+        Profile
+      </Button>
+      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/services/new')}>
+        New Service
+      </Button>
+      <Button variant="outline" color="white" onClick={handleLogout}>
+        Logout
+      </Button>
     </Flex>
   );
 }

--- a/frontend/src/pages/ServiceCreationPage.jsx
+++ b/frontend/src/pages/ServiceCreationPage.jsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Heading,
+  VStack,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  Button,
+  useToast,
+} from '@chakra-ui/react';
+import { createService } from '../api/services.js';
+import '../styles/ServiceCreationPage.css';
+import { useNavigate } from 'react-router-dom';
+
+export default function ServiceCreationPage() {
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    price: '',
+    tags: '',
+    category: '',
+  });
+  const toast = useToast();
+  const navigate = useNavigate();
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const payload = {
+        title: form.title,
+        description: form.description,
+        price: Number(form.price),
+        category: form.category || undefined,
+        tags: form.tags
+          .split(',')
+          .map((t) => t.trim())
+          .filter(Boolean),
+      };
+      await createService(payload);
+      toast({ title: 'Service created', status: 'success' });
+      navigate('/profile');
+    } catch (err) {
+      console.error(err);
+      toast({ title: 'Failed to create service', status: 'error' });
+    }
+  };
+
+  return (
+    <Box className="service-creation-page" maxW="600px" mx="auto">
+      <Heading mb={6}>Create Service</Heading>
+      <form onSubmit={handleSubmit}>
+        <VStack spacing={4} align="stretch">
+          <FormControl isRequired>
+            <FormLabel>Title</FormLabel>
+            <Input name="title" value={form.title} onChange={handleChange} />
+          </FormControl>
+          <FormControl isRequired>
+            <FormLabel>Description</FormLabel>
+            <Textarea name="description" value={form.description} onChange={handleChange} />
+          </FormControl>
+          <FormControl isRequired>
+            <FormLabel>Price</FormLabel>
+            <Input
+              name="price"
+              type="number"
+              min="0"
+              step="0.01"
+              value={form.price}
+              onChange={handleChange}
+            />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Category</FormLabel>
+            <Input name="category" value={form.category} onChange={handleChange} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Tags (comma separated)</FormLabel>
+            <Input name="tags" value={form.tags} onChange={handleChange} />
+          </FormControl>
+          <Button colorScheme="teal" type="submit">
+            Save Service
+          </Button>
+        </VStack>
+      </form>
+    </Box>
+  );
+}

--- a/frontend/src/styles/ServiceCreationPage.css
+++ b/frontend/src/styles/ServiceCreationPage.css
@@ -1,0 +1,6 @@
+.service-creation-page {
+  background-color: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}


### PR DESCRIPTION
## Summary
- add backend endpoints and validation for service creation and update
- introduce seller service creation page using Chakra UI
- wire new page into navigation and app routing

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689284e4d5d88320a506a346aa96c4ff