### PR TITLE
feat: add service calendar page

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -51,8 +51,8 @@ const podcastAnalyticsRoutes = require('./routes/podcastAnalytics');
 const workspaceAnalyticsRoutes = require('./routes/workspaceAnalytics');
 const sentimentAnalysisRoutes = require('./routes/sentimentAnalysis');
 const podcastAnalyticsRoutes = require('./routes/podcastAnalytics');
-const serviceProviderAnalyticsRoutes = require('./routes/serviceProviderAnalytics');
-const serviceProviderOrdersRoutes = require('./routes/serviceProviderOrders');
+
+const serviceProviderCalendarRoutes = require('./routes/serviceProviderCalendar');
 const userAnalyticsRoutes = require('./routes/userAnalytics');
 const webinarAnalyticsRoutes = require('./routes/webinarAnalytics');
 const workspaceAnalyticsRoutes = require('./routes/workspaceAnalytics');
@@ -173,7 +173,8 @@ app.use('/analytics/workspace', workspaceAnalyticsRoutes);
 app.use('/sentiment', sentimentAnalysisRoutes);
 app.use('/podcast-analytics', podcastAnalyticsRoutes);
 app.use('/service-providers', serviceProviderAnalyticsRoutes);
-app.use('/service-providers/orders', serviceProviderOrdersRoutes);
+
+app.use('/service-providers/calendar', serviceProviderCalendarRoutes);
 app.use('/analytics/user', userAnalyticsRoutes);
 app.use('/webinar-analytics', webinarAnalyticsRoutes);
 app.use('/analytics/workspace', workspaceAnalyticsRoutes);

--- a/backend/controllers/serviceProviderCalendar.js
+++ b/backend/controllers/serviceProviderCalendar.js
@@ -1,0 +1,28 @@
+const CalendarEvent = require('../models/calendarEvent');
+
+exports.createEvent = (req, res) => {
+  const { sellerId, buyerId, serviceId, startTime, endTime, status } = req.body;
+  if (!sellerId || !startTime || !endTime) {
+    return res.status(400).json({ error: 'sellerId, startTime, and endTime are required' });
+  }
+  const event = CalendarEvent.createEvent({ sellerId, buyerId, serviceId, startTime, endTime, status });
+  res.status(201).json(event);
+};
+
+exports.listEvents = (req, res) => {
+  const { userId } = req.query;
+  const data = userId ? CalendarEvent.getEventsByUser(userId) : CalendarEvent.events;
+  res.json(data);
+};
+
+exports.updateEvent = (req, res) => {
+  const event = CalendarEvent.updateEvent(req.params.id, req.body);
+  if (!event) return res.status(404).json({ error: 'Event not found' });
+  res.json(event);
+};
+
+exports.deleteEvent = (req, res) => {
+  const event = CalendarEvent.deleteEvent(req.params.id);
+  if (!event) return res.status(404).json({ error: 'Event not found' });
+  res.json(event);
+};

--- a/backend/models/calendarEvent.js
+++ b/backend/models/calendarEvent.js
@@ -1,0 +1,51 @@
+const { randomUUID } = require('crypto');
+
+const events = [];
+
+function createEvent({ sellerId, buyerId = null, serviceId = null, startTime, endTime, status = 'available' }) {
+  const event = {
+    id: randomUUID(),
+    sellerId,
+    buyerId,
+    serviceId,
+    startTime: new Date(startTime),
+    endTime: new Date(endTime),
+    status,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  events.push(event);
+  return event;
+}
+
+function getEventsByUser(userId) {
+  return events.filter((e) => e.sellerId === userId || e.buyerId === userId);
+}
+
+function getEventById(id) {
+  return events.find((e) => e.id === id);
+}
+
+function updateEvent(id, updates) {
+  const event = getEventById(id);
+  if (!event) return null;
+  Object.assign(event, updates, { updatedAt: new Date() });
+  return event;
+}
+
+function deleteEvent(id) {
+  const index = events.findIndex((e) => e.id === id);
+  if (index !== -1) {
+    return events.splice(index, 1)[0];
+  }
+  return null;
+}
+
+module.exports = {
+  events,
+  createEvent,
+  getEventsByUser,
+  getEventById,
+  updateEvent,
+  deleteEvent,
+};

--- a/backend/routes/serviceProviderCalendar.js
+++ b/backend/routes/serviceProviderCalendar.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/serviceProviderCalendar');
+
+router.post('/', controller.createEvent);
+router.get('/', controller.listEvents);
+router.put('/:id', controller.updateEvent);
+router.delete('/:id', controller.deleteEvent);
+
+module.exports = router;

--- a/frontend/api/calendar.js
+++ b/frontend/api/calendar.js
@@ -1,0 +1,35 @@
+(function(global){
+  async function listEvents(userId){
+    const res = await apiFetch(`/api/service-providers/calendar?userId=${userId}`);
+    if(!res.ok) throw new Error('Failed to fetch events');
+    return res.json();
+  }
+
+  async function createEvent(data){
+    const res = await apiFetch('/api/service-providers/calendar', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    if(!res.ok) throw new Error('Failed to create event');
+    return res.json();
+  }
+
+  async function updateEvent(id, data){
+    const res = await apiFetch(`/api/service-providers/calendar/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    if(!res.ok) throw new Error('Failed to update event');
+    return res.json();
+  }
+
+  async function deleteEvent(id){
+    const res = await apiFetch(`/api/service-providers/calendar/${id}`, { method: 'DELETE' });
+    if(!res.ok) throw new Error('Failed to delete event');
+    return res.json();
+  }
+
+  global.calendarAPI = { listEvents, createEvent, updateEvent, deleteEvent };
+})(window);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -39,6 +39,7 @@ function App() {
         <Route path="/interview/:id" element={<Protected><VirtualInterviewPage /></Protected>} />
         <Route path="/gigs/manage" element={<Protected><GigManagementPage /></Protected>} />
         <Route path="/gigs" element={<Protected><GigsDashboard /></Protected>} />
+        <Route path="/calendar" element={<Protected><CalendarPage /></Protected>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -53,7 +53,7 @@
     <link rel="stylesheet" href="views/application_interview_management.css" />
     <link rel="stylesheet" href="views/virtual_interview.css" />
     <link rel="stylesheet" href="views/gig_creation.css" />
-    <link rel="stylesheet" href="views/gigs_dashboard.css" />
+        <link rel="stylesheet" href="views/calendar_page.css" />
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
@@ -130,13 +130,13 @@
     <script type="text/babel" data-presets="env,react" src="views/chat_inbox.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/application_interview_management.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/virtual_interview.js"></script>
-    <script type="text/babel" data-presets="env,react" src="api/gigs.js"></script>
+    <script type="text/babel" data-presets="env,react" src="api/calendar.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/profile_customization.js"></script>
     <script type="text/babel" data-presets="env,react" src="utils/api.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/financial_media_setup.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/gigs.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/gig_creation.js"></script>
-    <script type="text/babel" data-presets="env,react" src="views/gigs_dashboard.js"></script>
+    <script type="text/babel" data-presets="env,react" src="views/calendar_page.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/jobs.js"></script>
     <script type="text/babel" data-presets="env,react" src="components/JobCard.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/job_listings.js"></script>

--- a/frontend/nav/menu.js
+++ b/frontend/nav/menu.js
@@ -46,8 +46,8 @@ function NavMenu() {
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/interview/1')}>Interview</Button>
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/gigs/manage')}>Gigs</Button>
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/gigs')}>Gigs</Button>
-      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/jobs')}>Jobs</Button>
-      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/orders')}>Orders</Button>
+      <
+      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/calendar')}>Calendar</Button>
       <Button variant="outline" color="white" onClick={handleLogout}>Logout</Button>
     </Flex>
   );

--- a/frontend/pages/Dashboard.jsx
+++ b/frontend/pages/Dashboard.jsx
@@ -1,4 +1,4 @@
-import { ChakraProvider, Box, Heading } from '@chakra-ui/react';
+import { ChakraProvider, Box, Heading, Button } from '@chakra-ui/react';
 import NavMenu from '../components/NavMenu';
 import '../styles/Dashboard.css';
 
@@ -8,6 +8,7 @@ export default function Dashboard() {
       <NavMenu />
       <Box p={4} className="dashboard">
         <Heading>Dashboard</Heading>
+        <Button mt={4} colorScheme="teal" onClick={() => window.location.href = '/calendar'}>Calendar</Button>
       </Box>
     </ChakraProvider>
   );

--- a/frontend/views/calendar_page.css
+++ b/frontend/views/calendar_page.css
@@ -1,0 +1,4 @@
+.calendar-page {
+  max-width: 900px;
+  margin: 0 auto;
+}

--- a/frontend/views/calendar_page.js
+++ b/frontend/views/calendar_page.js
@@ -1,0 +1,104 @@
+const { Box, Heading, Flex, Select, Button, Table, Text, Thead, Tbody, Tr, Th, Td, FormControl, FormLabel, Input, Modal, ModalOverlay, ModalContent, ModalHeader, ModalBody, ModalFooter, useDisclosure, useToast } = ChakraUI;
+const { useState, useEffect } = React;
+
+function CalendarPage(){
+  const { user } = useAuth();
+  const [events, setEvents] = useState([]);
+  const [currentTime, setCurrentTime] = useState('');
+  const [view, setView] = useState('month');
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [form, setForm] = useState({ startTime:'', endTime:'' });
+  const toast = useToast();
+
+  useEffect(()=>{ if(user) loadEvents(); },[user]);
+
+  useEffect(()=>{
+    async function fetchTime(){
+      try{
+        const res = await fetch(`${window.env.WORLD_TIME_API}/timezone/Etc/UTC`);
+        const data = await res.json();
+        setCurrentTime(data.datetime);
+      }catch(e){}
+    }
+    fetchTime();
+  },[]);
+
+
+  async function loadEvents(){
+    try{
+      const data = await calendarAPI.listEvents(user.id);
+      setEvents(data);
+    }catch(err){ console.error('Failed to load events', err); }
+  }
+
+  async function handleCreate(){
+    try{
+      await calendarAPI.createEvent({ sellerId: user.id, startTime: form.startTime, endTime: form.endTime });
+      toast({ status:'success', title:'Availability added' });
+      setForm({ startTime:'', endTime:'' });
+      onClose();
+      loadEvents();
+    }catch(err){ toast({ status:'error', title:'Failed to add availability' }); }
+  }
+
+  if(!user) return <p>Loading...</p>;
+
+  return (
+    <Box className="calendar-page" p={4}>
+      <NavMenu />
+      <Heading size="lg" mb={4}>Service Calendar</Heading>
+      {currentTime && <Text mb={4}>Current UTC Time: {new Date(currentTime).toLocaleString()}</Text>}
+      <Flex mb={4} justify="space-between" align="center">
+        <Select value={view} onChange={e=>setView(e.target.value)} width="150px">
+          <option value="day">Day</option>
+          <option value="week">Week</option>
+          <option value="month">Month</option>
+        </Select>
+        <Button colorScheme="teal" onClick={onOpen}>Add Availability</Button>
+      </Flex>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Date</Th>
+            <Th>Start</Th>
+            <Th>End</Th>
+            <Th>Status</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {events.map(ev => (
+            <Tr key={ev.id}>
+              <Td>{new Date(ev.startTime).toLocaleDateString()}</Td>
+              <Td>{new Date(ev.startTime).toLocaleTimeString()}</Td>
+              <Td>{new Date(ev.endTime).toLocaleTimeString()}</Td>
+              <Td>{ev.status}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Add Availability</ModalHeader>
+          <ModalBody>
+            <FormControl mb={3}>
+              <FormLabel>Start Time</FormLabel>
+              <Input type="datetime-local" value={form.startTime} onChange={e=>setForm({ ...form, startTime: e.target.value })} />
+            </FormControl>
+            <FormControl>
+              <FormLabel>End Time</FormLabel>
+              <Input type="datetime-local" value={form.endTime} onChange={e=>setForm({ ...form, endTime: e.target.value })} />
+            </FormControl>
+          </ModalBody>
+          <ModalFooter>
+            <Button colorScheme="teal" mr={3} onClick={handleCreate}>Save</Button>
+            <Button onClick={onClose}>Cancel</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </Box>
+  );
+}
+
+window.CalendarPage = CalendarPage;

--- a/frontend/views/home_dashboard.js
+++ b/frontend/views/home_dashboard.js
@@ -103,8 +103,9 @@ function HomeDashboard() {
         Manage Gigs
       <Button ml={2} colorScheme="teal" onClick={() => window.location.href = '/gigs'}>
         Gigs Dashboard
-      <Button colorScheme="teal" ml={2} onClick={() => window.location.href = '/jobs'}>
-        Browse Jobs
+      <
+      <Button colorScheme="teal" ml={2} onClick={() => window.location.href = '/calendar'}>
+        Calendar
       </Button>
     </Box>
     <ChatWidget />


### PR DESCRIPTION
## Summary
- add in-memory calendar event model and CRUD API
- expose calendar API to frontend and route calendar page
- build Chakra UI calendar view with availability modal and navigation links

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892850407a883209b5e679f79ab5cd7