### PR TITLE
feat: add task dashboard

### DIFF
--- a/backend/controllers/projectManagement.js
+++ b/backend/controllers/projectManagement.js
@@ -55,6 +55,16 @@ async function createTaskHandler(req, res) {
   }
 }
 
+async function listTasksHandler(req, res) {
+  try {
+    const tasks = await service.listTasks(req.query);
+    res.json(tasks);
+  } catch (err) {
+    logger.error('Failed to list tasks', { error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+}
+
 async function getTaskHandler(req, res) {
   const { taskId } = req.params;
   try {
@@ -319,6 +329,7 @@ module.exports = {
   updateProjectHandler,
   deleteProjectHandler,
   createTaskHandler,
+  listTasksHandler,
   getTaskHandler,
   updateTaskHandler,
   deleteTaskHandler,

--- a/backend/models/projectManagement.js
+++ b/backend/models/projectManagement.js
@@ -47,7 +47,7 @@ function deleteProject(projectId) {
   return projects.delete(projectId);
 }
 
-function createTask({ projectId, title, description = '', dueDate = null }) {
+function createTask({ projectId, title, description = '', dueDate = null, ownerId }) {
   const id = randomUUID();
   const now = new Date();
   const task = {
@@ -58,6 +58,7 @@ function createTask({ projectId, title, description = '', dueDate = null }) {
     dueDate,
     status: 'pending',
     assignee: null,
+    ownerId,
     createdAt: now,
     updatedAt: now,
   };
@@ -67,6 +68,14 @@ function createTask({ projectId, title, description = '', dueDate = null }) {
 
 function getTaskById(taskId) {
   return tasks.get(taskId);
+}
+
+function listTasks({ ownerId, assignee } = {}) {
+  return Array.from(tasks.values()).filter((t) => {
+    if (ownerId && t.ownerId !== ownerId) return false;
+    if (assignee && t.assignee !== assignee) return false;
+    return true;
+  });
 }
 
 function updateTask(taskId, data) {
@@ -195,6 +204,7 @@ module.exports = {
   deleteProject,
   createTask,
   getTaskById,
+  listTasks,
   updateTask,
   deleteTask,
   assignTask,

--- a/backend/routes/projectManagement.js
+++ b/backend/routes/projectManagement.js
@@ -5,6 +5,7 @@ const {
   updateProjectHandler,
   deleteProjectHandler,
   createTaskHandler,
+  listTasksHandler,
   getTaskHandler,
   updateTaskHandler,
   deleteTaskHandler,
@@ -43,6 +44,7 @@ const {
   createProjectSchema,
   updateProjectSchema,
   createTaskSchema,
+  taskListSchema,
   updateTaskSchema,
   assignTaskSchema,
   aiProjectSchema,
@@ -69,6 +71,7 @@ router.delete('/projects/delete/:projectId', auth, validate(projectIdParamSchema
 
 // Task routes
 router.post('/tasks/create', auth, validate(createTaskSchema), createTaskHandler);
+router.get('/tasks', auth, validate(taskListSchema, 'query'), listTasksHandler);
 router.get('/tasks/:taskId', auth, validate(taskIdParamSchema, 'params'), taskExists, getTaskHandler);
 router.put('/tasks/update/:taskId', auth, validate(taskIdParamSchema, 'params'), validate(updateTaskSchema), taskExists, updateTaskHandler);
 router.delete('/tasks/delete/:taskId', auth, validate(taskIdParamSchema, 'params'), taskExists, deleteTaskHandler);

--- a/backend/services/projectManagement.js
+++ b/backend/services/projectManagement.js
@@ -30,6 +30,10 @@ async function createTask(data) {
   return task;
 }
 
+async function listTasks(filter = {}) {
+  return model.listTasks(filter);
+}
+
 async function getTask(taskId) {
   return model.getTaskById(taskId);
 }
@@ -176,6 +180,7 @@ module.exports = {
   updateProject,
   deleteProject,
   createTask,
+  listTasks,
   getTask,
   updateTask,
   deleteTask,

--- a/backend/validation/projectManagement.js
+++ b/backend/validation/projectManagement.js
@@ -34,6 +34,7 @@ const updateProjectSchema = Joi.object({
 
 const createTaskSchema = Joi.object({
   projectId: Joi.string().guid({ version: 'uuidv4' }).required(),
+  ownerId: Joi.string().required(),
   title: Joi.string().min(3).max(255).required(),
   description: Joi.string().max(1000).allow('', null),
   dueDate: Joi.date().iso().optional(),
@@ -53,6 +54,11 @@ const assignTaskSchema = Joi.object({
 
 const aiProjectSchema = Joi.object({
   projectId: Joi.string().guid({ version: 'uuidv4' }).required(),
+});
+
+const taskListSchema = Joi.object({
+  ownerId: Joi.string().guid({ version: 'uuidv4' }).optional(),
+  assignee: Joi.string().optional(),
 });
 
 const hireSchema = Joi.object({
@@ -134,6 +140,7 @@ module.exports = {
   createTaskSchema,
   updateTaskSchema,
   assignTaskSchema,
+  taskListSchema,
   aiProjectSchema,
   hireSchema,
   feedPostSchema,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -38,6 +38,7 @@ import { ChakraProvider, Box } from '@chakra-ui/react';
 import NavBar from './components/NavBar.jsx';
 import ProfilePage from './pages/ProfilePage.jsx';
 import ProfileCustomizationPage from './pages/ProfileCustomizationPage.jsx';
+import TaskDashboardPage from './pages/TaskDashboardPage.jsx';
 import { ProfileProvider } from './context/ProfileContext.jsx';
 
 function App() {
@@ -51,6 +52,7 @@ function App() {
               <Route path="/" element={<Navigate to="/profile" replace />} />
               <Route path="/profile" element={<ProfilePage />} />
               <Route path="/profile/customize" element={<ProfileCustomizationPage />} />
+              <Route path="/tasks" element={<TaskDashboardPage />} />
             </Routes>
           </Box>
         </ProfileProvider>

--- a/frontend/src/api/tasks.js
+++ b/frontend/src/api/tasks.js
@@ -1,0 +1,6 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function listTasks(params = {}) {
+  const { data } = await apiClient.get('/workspace/tasks', { params });
+  return data;
+}

--- a/frontend/src/components/NavMenu.jsx
+++ b/frontend/src/components/NavMenu.jsx
@@ -17,6 +17,7 @@ function NavMenu() {
     <Flex className="nav-menu" bg="teal.500" color="white" p={4} align="center">
       <Heading size="md">Workhouse</Heading>
       <Spacer />
+      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/tasks')}>Tasks</Button>
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/profile')}>Profile</Button>
       <Button variant="outline" color="white" onClick={handleLogout}>Logout</Button>
     </Flex>

--- a/frontend/src/components/TaskTable.jsx
+++ b/frontend/src/components/TaskTable.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Table, Thead, Tbody, Tr, Th, Td } from '@chakra-ui/react';
+import '../styles/TaskTable.css';
+
+function TaskTable({ tasks }) {
+  return (
+    <Table variant="simple" className="task-table">
+      <Thead>
+        <Tr>
+          <Th>Title</Th>
+          <Th>Status</Th>
+          <Th>Due Date</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {tasks.map((task) => (
+          <Tr key={task.id}>
+            <Td>{task.title}</Td>
+            <Td>{task.status}</Td>
+            <Td>{task.dueDate ? new Date(task.dueDate).toLocaleDateString() : '-'}</Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  );
+}
+
+export default TaskTable;

--- a/frontend/src/pages/TaskDashboardPage.jsx
+++ b/frontend/src/pages/TaskDashboardPage.jsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Heading, ButtonGroup, Button, Spinner } from '@chakra-ui/react';
+import NavMenu from '../components/NavMenu.jsx';
+import TaskTable from '../components/TaskTable.jsx';
+import '../styles/TaskDashboardPage.css';
+import { listTasks } from '../api/tasks.js';
+import { useAuth } from '../context/AuthContext.jsx';
+
+function TaskDashboardPage() {
+  const { user } = useAuth();
+  const [mode, setMode] = useState('creator');
+  const [tasks, setTasks] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!user) return;
+    async function load() {
+      setLoading(true);
+      try {
+        const params = mode === 'creator' ? { ownerId: user.id } : { assignee: user.id };
+        const data = await listTasks(params);
+        setTasks(data);
+      } catch (err) {
+        console.error('Failed to load tasks', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [user, mode]);
+
+  return (
+    <Box className="task-dashboard-page" p={4}>
+      <NavMenu />
+      <Heading mb={4}>Task Dashboard</Heading>
+      <ButtonGroup mb={4}>
+        <Button colorScheme={mode === 'creator' ? 'teal' : 'gray'} onClick={() => setMode('creator')}>
+          Task Creator
+        </Button>
+        <Button colorScheme={mode === 'tasker' ? 'teal' : 'gray'} onClick={() => setMode('tasker')}>
+          Tasker
+        </Button>
+      </ButtonGroup>
+      {loading ? <Spinner /> : <TaskTable tasks={tasks} />}
+    </Box>
+  );
+}
+
+export default TaskDashboardPage;

--- a/frontend/src/styles/TaskDashboardPage.css
+++ b/frontend/src/styles/TaskDashboardPage.css
@@ -1,0 +1,4 @@
+.task-dashboard-page {
+  max-width: 1200px;
+  margin: 0 auto;
+}

--- a/frontend/src/styles/TaskTable.css
+++ b/frontend/src/styles/TaskTable.css
@@ -1,0 +1,4 @@
+.task-table {
+  width: 100%;
+  background-color: white;
+}


### PR DESCRIPTION
## Summary
- add task listing support to workspace backend and route
- implement task dashboard with creator/tasker toggle
- wire up tasks API and navigation link

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6892851158d083208c0f45895bb6e568