### PR TITLE
feat(tasks): add task management page and API

### DIFF
--- a/backend/controllers/projectManagement.js
+++ b/backend/controllers/projectManagement.js
@@ -67,6 +67,17 @@ async function getTaskHandler(req, res) {
   }
 }
 
+async function listTasksHandler(req, res) {
+  const { projectId } = req.params;
+  try {
+    const tasks = await service.listTasks(projectId);
+    res.json(tasks);
+  } catch (err) {
+    logger.error('Failed to list tasks', { error: err.message, projectId });
+    res.status(500).json({ error: err.message });
+  }
+}
+
 async function updateTaskHandler(req, res) {
   const { taskId } = req.params;
   try {
@@ -320,6 +331,7 @@ module.exports = {
   deleteProjectHandler,
   createTaskHandler,
   getTaskHandler,
+  listTasksHandler,
   updateTaskHandler,
   deleteTaskHandler,
   assignTaskHandler,

--- a/backend/models/projectManagement.js
+++ b/backend/models/projectManagement.js
@@ -69,6 +69,10 @@ function getTaskById(taskId) {
   return tasks.get(taskId);
 }
 
+function listTasksByProject(projectId) {
+  return Array.from(tasks.values()).filter((t) => t.projectId === projectId);
+}
+
 function updateTask(taskId, data) {
   const task = tasks.get(taskId);
   if (!task) return null;
@@ -195,6 +199,7 @@ module.exports = {
   deleteProject,
   createTask,
   getTaskById,
+  listTasksByProject,
   updateTask,
   deleteTask,
   assignTask,

--- a/backend/routes/projectManagement.js
+++ b/backend/routes/projectManagement.js
@@ -6,6 +6,7 @@ const {
   deleteProjectHandler,
   createTaskHandler,
   getTaskHandler,
+  listTasksHandler,
   updateTaskHandler,
   deleteTaskHandler,
   assignTaskHandler,
@@ -70,6 +71,7 @@ router.delete('/projects/delete/:projectId', auth, validate(projectIdParamSchema
 // Task routes
 router.post('/tasks/create', auth, validate(createTaskSchema), createTaskHandler);
 router.get('/tasks/:taskId', auth, validate(taskIdParamSchema, 'params'), taskExists, getTaskHandler);
+router.get('/projects/:projectId/tasks', auth, validate(projectIdParamSchema, 'params'), projectExists, listTasksHandler);
 router.put('/tasks/update/:taskId', auth, validate(taskIdParamSchema, 'params'), validate(updateTaskSchema), taskExists, updateTaskHandler);
 router.delete('/tasks/delete/:taskId', auth, validate(taskIdParamSchema, 'params'), taskExists, deleteTaskHandler);
 router.post('/tasks/assign', auth, validate(assignTaskSchema), assignTaskHandler);

--- a/backend/services/projectManagement.js
+++ b/backend/services/projectManagement.js
@@ -34,6 +34,12 @@ async function getTask(taskId) {
   return model.getTaskById(taskId);
 }
 
+async function listTasks(projectId) {
+  const list = model.listTasksByProject(projectId);
+  logger.info('Tasks retrieved', { projectId, count: list.length });
+  return list;
+}
+
 async function updateTask(taskId, data) {
   const task = model.updateTask(taskId, data);
   if (!task) throw new Error('Task not found');
@@ -177,6 +183,7 @@ module.exports = {
   deleteProject,
   createTask,
   getTask,
+  listTasks,
   updateTask,
   deleteTask,
   assignTask,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -38,21 +38,26 @@ import { ChakraProvider, Box } from '@chakra-ui/react';
 import NavBar from './components/NavBar.jsx';
 import ProfilePage from './pages/ProfilePage.jsx';
 import ProfileCustomizationPage from './pages/ProfileCustomizationPage.jsx';
+import TaskManagementPage from './pages/TaskManagementPage.jsx';
 import { ProfileProvider } from './context/ProfileContext.jsx';
+import { TaskProvider } from './context/TaskContext.jsx';
 
 function App() {
   return (
     <ChakraProvider>
       <BrowserRouter>
         <ProfileProvider>
-          <NavBar />
-          <Box p={4}>
-            <Routes>
-              <Route path="/" element={<Navigate to="/profile" replace />} />
-              <Route path="/profile" element={<ProfilePage />} />
-              <Route path="/profile/customize" element={<ProfileCustomizationPage />} />
-            </Routes>
-          </Box>
+          <TaskProvider>
+            <NavBar />
+            <Box p={4}>
+              <Routes>
+                <Route path="/" element={<Navigate to="/profile" replace />} />
+                <Route path="/profile" element={<ProfilePage />} />
+                <Route path="/profile/customize" element={<ProfileCustomizationPage />} />
+                <Route path="/tasks" element={<TaskManagementPage />} />
+              </Routes>
+            </Box>
+          </TaskProvider>
         </ProfileProvider>
       </BrowserRouter>
     </ChakraProvider>

--- a/frontend/src/api/tasks.js
+++ b/frontend/src/api/tasks.js
@@ -1,0 +1,21 @@
+import apiClient from '../utils/apiClient.js';
+
+export function createTask(data) {
+  return apiClient.post('/workspace/tasks/create', data).then(res => res.data);
+}
+
+export function listTasks(projectId) {
+  return apiClient.get(`/workspace/projects/${projectId}/tasks`).then(res => res.data);
+}
+
+export function updateTask(taskId, updates) {
+  return apiClient.put(`/workspace/tasks/update/${taskId}`, updates).then(res => res.data);
+}
+
+export function deleteTask(taskId) {
+  return apiClient.delete(`/workspace/tasks/delete/${taskId}`);
+}
+
+export function assignTask(payload) {
+  return apiClient.post('/workspace/tasks/assign', payload).then(res => res.data);
+}

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -57,8 +57,11 @@ function NavBar() {
       <Button as={RouterLink} to="/profile" variant="ghost" color="white" mr={2}>
         Profile
       </Button>
-      <Button as={RouterLink} to="/orders" variant="ghost" color="white">
+      <Button as={RouterLink} to="/orders" variant="ghost" color="white" mr={2}>
         Orders
+      </Button>
+      <Button as={RouterLink} to="/tasks" variant="ghost" color="white">
+        Tasks
       </Button>
     </Flex>
   );

--- a/frontend/src/components/TaskForm.jsx
+++ b/frontend/src/components/TaskForm.jsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import { Box, FormControl, FormLabel, Input, Textarea, Button } from '@chakra-ui/react';
+import { useTasks } from '../context/TaskContext.jsx';
+import '../styles/TaskForm.css';
+
+function TaskForm({ projectId, setProjectId, editingTask, onUpdate }) {
+  const { addTask } = useTasks();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [dueDate, setDueDate] = useState('');
+
+  useEffect(() => {
+    if (editingTask) {
+      setTitle(editingTask.title);
+      setDescription(editingTask.description || '');
+      setDueDate(editingTask.dueDate ? editingTask.dueDate.substring(0,10) : '');
+    } else {
+      setTitle('');
+      setDescription('');
+      setDueDate('');
+    }
+  }, [editingTask]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!projectId) return;
+    if (editingTask) {
+      await onUpdate({ title, description, dueDate });
+    } else {
+      await addTask({ projectId, title, description, dueDate });
+    }
+  };
+
+  return (
+    <Box as="form" className="task-form" onSubmit={handleSubmit} mb={6}>
+      <FormControl mb={3} isRequired>
+        <FormLabel>Project ID</FormLabel>
+        <Input value={projectId} onChange={(e) => setProjectId(e.target.value)} />
+      </FormControl>
+      <FormControl mb={3} isRequired>
+        <FormLabel>Title</FormLabel>
+        <Input value={title} onChange={(e) => setTitle(e.target.value)} />
+      </FormControl>
+      <FormControl mb={3}>
+        <FormLabel>Description</FormLabel>
+        <Textarea value={description} onChange={(e) => setDescription(e.target.value)} />
+      </FormControl>
+      <FormControl mb={3}>
+        <FormLabel>Due Date</FormLabel>
+        <Input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} />
+      </FormControl>
+      <Button type="submit" colorScheme="teal">
+        {editingTask ? 'Update Task' : 'Create Task'}
+      </Button>
+    </Box>
+  );
+}
+
+export default TaskForm;

--- a/frontend/src/components/TaskList.jsx
+++ b/frontend/src/components/TaskList.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Table, Thead, Tbody, Tr, Th, Td, Button } from '@chakra-ui/react';
+import { useTasks } from '../context/TaskContext.jsx';
+import '../styles/TaskList.css';
+
+function TaskList({ onEdit }) {
+  const { tasks, removeTask } = useTasks();
+
+  return (
+    <Table className="task-list" variant="striped" size="sm">
+      <Thead>
+        <Tr>
+          <Th>Title</Th>
+          <Th>Status</Th>
+          <Th>Due Date</Th>
+          <Th>Actions</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {tasks.map((task) => (
+          <Tr key={task.id}>
+            <Td>{task.title}</Td>
+            <Td>{task.status}</Td>
+            <Td>{task.dueDate ? new Date(task.dueDate).toLocaleDateString() : '-'}</Td>
+            <Td>
+              <Button size="xs" mr={2} onClick={() => onEdit(task)}>Edit</Button>
+              <Button size="xs" colorScheme="red" onClick={() => removeTask(task.id)}>
+                Delete
+              </Button>
+            </Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
+  );
+}
+
+export default TaskList;

--- a/frontend/src/context/TaskContext.jsx
+++ b/frontend/src/context/TaskContext.jsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+import { listTasks, createTask, updateTask, deleteTask } from '../api/tasks.js';
+
+const TaskContext = createContext();
+
+export function TaskProvider({ children }) {
+  const [tasks, setTasks] = useState([]);
+
+  const fetchTasks = useCallback(async (projectId) => {
+    if (!projectId) return;
+    const data = await listTasks(projectId);
+    setTasks(data);
+  }, []);
+
+  const addTask = async (task) => {
+    const created = await createTask(task);
+    setTasks((prev) => [...prev, created]);
+  };
+
+  const editTask = async (taskId, updates) => {
+    const updated = await updateTask(taskId, updates);
+    setTasks((prev) => prev.map((t) => (t.id === taskId ? updated : t)));
+  };
+
+  const removeTask = async (taskId) => {
+    await deleteTask(taskId);
+    setTasks((prev) => prev.filter((t) => t.id !== taskId));
+  };
+
+  return (
+    <TaskContext.Provider value={{ tasks, fetchTasks, addTask, editTask, removeTask }}>
+      {children}
+    </TaskContext.Provider>
+  );
+}
+
+export function useTasks() {
+  return useContext(TaskContext);
+}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -64,6 +64,9 @@ function ProfilePage() {
       <Button className="customize-btn" onClick={() => navigate('/profile/customize')} colorScheme="teal" mb={4}>
         Customize Profile
       </Button>
+      <Button onClick={() => navigate('/tasks')} colorScheme="teal" mb={4}>
+        Manage Tasks
+      </Button>
       <VStack spacing={6} align="stretch">
         <ProfileHeader profile={profile} />
         <AboutSection bio={profile.bio} />

--- a/frontend/src/pages/TaskManagementPage.jsx
+++ b/frontend/src/pages/TaskManagementPage.jsx
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+import NavBar from '../components/NavBar.jsx';
+import TaskForm from '../components/TaskForm.jsx';
+import TaskList from '../components/TaskList.jsx';
+import { useTasks } from '../context/TaskContext.jsx';
+import '../styles/TaskManagementPage.css';
+
+export default function TaskManagementPage() {
+  const { fetchTasks, editTask } = useTasks();
+  const [projectId, setProjectId] = useState('');
+  const [editingTask, setEditingTask] = useState(null);
+
+  useEffect(() => {
+    if (projectId) fetchTasks(projectId);
+  }, [projectId, fetchTasks]);
+
+  const handleUpdate = async (updates) => {
+    await editTask(editingTask.id, updates);
+    setEditingTask(null);
+  };
+
+  return (
+    <Box className="task-management-page" p={4}>
+      <NavBar />
+      <Heading mb={4}>Task Management</Heading>
+      <TaskForm
+        projectId={projectId}
+        setProjectId={setProjectId}
+        editingTask={editingTask}
+        onUpdate={handleUpdate}
+      />
+      <TaskList onEdit={setEditingTask} />
+    </Box>
+  );
+}

--- a/frontend/src/styles/TaskForm.css
+++ b/frontend/src/styles/TaskForm.css
@@ -1,0 +1,6 @@
+.task-form {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}

--- a/frontend/src/styles/TaskList.css
+++ b/frontend/src/styles/TaskList.css
@@ -1,0 +1,3 @@
+.task-list {
+  margin-top: 1rem;
+}

--- a/frontend/src/styles/TaskManagementPage.css
+++ b/frontend/src/styles/TaskManagementPage.css
@@ -1,0 +1,4 @@
+.task-management-page {
+  max-width: 900px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- add task listing capability and endpoint in workspace project management
- build task management React page with Chakra UI components
- wire up navigation with context and API helpers

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892864ab4c48320afe4c6c83240849e