### PR TITLE
feat: add opportunity management page

### DIFF
--- a/frontend/api/applications.js
+++ b/frontend/api/applications.js
@@ -1,0 +1,28 @@
+const API_BASE_URL = window.API_BASE_URL || '/api';
+
+async function request(path, options = {}) {
+  const token = localStorage.getItem('token');
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...options.headers,
+  };
+  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message || 'Request failed');
+  }
+  if (res.status === 204) return {};
+  return res.json();
+}
+
+export function applyToOpportunity(opportunityId, message = '') {
+  return request('/applications', {
+    method: 'POST',
+    body: JSON.stringify({ opportunityId, message }),
+  });
+}
+
+export function getUserApplications() {
+  return request('/applications/user');
+}

--- a/frontend/api/opportunities.js
+++ b/frontend/api/opportunities.js
@@ -1,0 +1,44 @@
+const API_BASE_URL = window.API_BASE_URL || '/api';
+
+async function request(path, options = {}) {
+  const token = localStorage.getItem('token');
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...options.headers,
+  };
+  const res = await fetch(`${API_BASE_URL}/opportunities${path}`, { ...options, headers });
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message || 'Request failed');
+  }
+  if (res.status === 204) return {};
+  return res.json();
+}
+
+export function fetchOpportunities(query = '') {
+  const q = query ? `?${query}` : '';
+  return request(q);
+}
+
+export function createOpportunity(data) {
+  return request('', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export function updateOpportunity(id, data) {
+  return request(`/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteOpportunity(id) {
+  return request(`/${id}`, { method: 'DELETE' });
+}
+
+export function fetchOpportunityDashboard() {
+  return request('/dashboard');
+}

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,3 +1,4 @@
+import OpportunityManagement from './pages/OpportunityManagement.jsx';
 const { BrowserRouter, Routes, Route, Navigate } = ReactRouterDOM;
 const { ChakraProvider } = ChakraUI;
 
@@ -39,6 +40,7 @@ function App() {
         <Route path="/interview/:id" element={<Protected><VirtualInterviewPage /></Protected>} />
         <Route path="/gigs/manage" element={<Protected><GigManagementPage /></Protected>} />
         <Route path="/gigs" element={<Protected><GigsDashboard /></Protected>} />
+        <Route path="/opportunities" element={<Protected><OpportunityManagement /></Protected>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/components/NavMenu.jsx
+++ b/frontend/components/NavMenu.jsx
@@ -8,6 +8,7 @@ export default function NavMenu() {
       <HStack spacing={4}>
         <Link as={RouterLink} to="/">Dashboard</Link>
         <Link as={RouterLink} to="/jobs">Job Posts</Link>
+        <Link as={RouterLink} to="/opportunities">Opportunities</Link>
       </HStack>
     </Box>
   );

--- a/frontend/components/OpportunityForm.jsx
+++ b/frontend/components/OpportunityForm.jsx
@@ -1,0 +1,66 @@
+import { Box, Button, Checkbox, FormControl, FormLabel, Input, Select, Stack, Textarea } from '@chakra-ui/react';
+import { useState } from 'react';
+import '../styles/OpportunityForm.css';
+
+export default function OpportunityForm({ onSubmit }) {
+  const [form, setForm] = useState({
+    title: '',
+    description: '',
+    location: '',
+    remote: false,
+    commitmentTime: '',
+    urgency: 'normal',
+    requirements: '',
+  });
+
+  const handleChange = (e) => {
+    const { name, value, type, checked } = e.target;
+    setForm((prev) => ({ ...prev, [name]: type === 'checkbox' ? checked : value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit(form);
+    setForm({ title: '', description: '', location: '', remote: false, commitmentTime: '', urgency: 'normal', requirements: '' });
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit} className="opportunity-form">
+      <Stack spacing={3}>
+        <FormControl isRequired>
+          <FormLabel>Title</FormLabel>
+          <Input name="title" value={form.title} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Description</FormLabel>
+          <Textarea name="description" value={form.description} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Location</FormLabel>
+          <Input name="location" value={form.location} onChange={handleChange} />
+        </FormControl>
+        <FormControl display="flex" alignItems="center">
+          <Checkbox name="remote" isChecked={form.remote} onChange={handleChange} mr={2} />
+          <FormLabel m={0}>Remote</FormLabel>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Commitment Time</FormLabel>
+          <Input name="commitmentTime" value={form.commitmentTime} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Urgency</FormLabel>
+          <Select name="urgency" value={form.urgency} onChange={handleChange}>
+            <option value="low">Low</option>
+            <option value="normal">Normal</option>
+            <option value="high">High</option>
+          </Select>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Requirements</FormLabel>
+          <Textarea name="requirements" value={form.requirements} onChange={handleChange} />
+        </FormControl>
+        <Button colorScheme="teal" type="submit">Create Opportunity</Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/components/OpportunityList.jsx
+++ b/frontend/components/OpportunityList.jsx
@@ -1,0 +1,36 @@
+import { List, ListItem, HStack, Heading, Text, Button, Box } from '@chakra-ui/react';
+import '../styles/OpportunityList.css';
+
+export default function OpportunityList({ opportunities, onDelete, onApply }) {
+  if (!opportunities || opportunities.length === 0) {
+    return <Text className="opportunity-list-empty">No opportunities available.</Text>;
+  }
+
+  return (
+    <List spacing={3} className="opportunity-list">
+      {opportunities.map((op) => (
+        <ListItem key={op.id} className="opportunity-list-item">
+          <HStack justify="space-between" align="flex-start">
+            <Box>
+              <Heading size="sm">{op.title}</Heading>
+              <Text fontSize="sm">{op.location}{op.remote ? ' (Remote)' : ''}</Text>
+              <Text fontSize="sm">Urgency: {op.urgency}</Text>
+            </Box>
+            <HStack>
+              {onApply && (
+                <Button size="sm" colorScheme="green" onClick={() => onApply(op.id)}>
+                  Apply
+                </Button>
+              )}
+              {onDelete && (
+                <Button size="sm" colorScheme="red" onClick={() => onDelete(op.id)}>
+                  Delete
+                </Button>
+              )}
+            </HStack>
+          </HStack>
+        </ListItem>
+      ))}
+    </List>
+  );
+}

--- a/frontend/pages/Dashboard.jsx
+++ b/frontend/pages/Dashboard.jsx
@@ -1,4 +1,5 @@
-import { ChakraProvider, Box, Heading } from '@chakra-ui/react';
+import { ChakraProvider, Box, Heading, Button } from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router-dom';
 import NavMenu from '../components/NavMenu';
 import '../styles/Dashboard.css';
 
@@ -7,7 +8,10 @@ export default function Dashboard() {
     <ChakraProvider>
       <NavMenu />
       <Box p={4} className="dashboard">
-        <Heading>Dashboard</Heading>
+        <Heading mb={4}>Dashboard</Heading>
+        <Button as={RouterLink} to="/opportunities" colorScheme="teal">
+          Manage Opportunities
+        </Button>
       </Box>
     </ChakraProvider>
   );

--- a/frontend/pages/OpportunityManagement.jsx
+++ b/frontend/pages/OpportunityManagement.jsx
@@ -1,0 +1,85 @@
+import { ChakraProvider, Box, Heading, SimpleGrid, Stat, StatLabel, StatNumber, useToast } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import NavMenu from '../components/NavMenu';
+import OpportunityForm from '../components/OpportunityForm';
+import OpportunityList from '../components/OpportunityList';
+import { fetchOpportunities, createOpportunity, deleteOpportunity, fetchOpportunityDashboard } from '../api/opportunities';
+import { applyToOpportunity } from '../api/applications';
+import '../styles/OpportunityManagement.css';
+
+export default function OpportunityManagement() {
+  const [opportunities, setOpportunities] = useState([]);
+  const [stats, setStats] = useState({ totalViews: 0, totalApplications: 0, totalMatches: 0 });
+  const toast = useToast();
+
+  const loadData = async () => {
+    try {
+      const [opsData, dash] = await Promise.all([
+        fetchOpportunities(),
+        fetchOpportunityDashboard(),
+      ]);
+      setOpportunities(opsData.opportunities || opsData); // API may return {opportunities:[]}
+      setStats(dash.stats || stats);
+    } catch (err) {
+      toast({ title: 'Failed to load opportunities', status: 'error' });
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const handleCreate = async (form) => {
+    try {
+      await createOpportunity(form);
+      toast({ title: 'Opportunity created', status: 'success' });
+      loadData();
+    } catch (err) {
+      toast({ title: 'Creation failed', status: 'error' });
+    }
+  };
+
+  const handleDelete = async (id) => {
+    try {
+      await deleteOpportunity(id);
+      toast({ title: 'Opportunity deleted', status: 'info' });
+      loadData();
+    } catch (err) {
+      toast({ title: 'Deletion failed', status: 'error' });
+    }
+  };
+
+  const handleApply = async (id) => {
+    try {
+      await applyToOpportunity(id);
+      toast({ title: 'Application submitted', status: 'success' });
+    } catch (err) {
+      toast({ title: 'Application failed', status: 'error' });
+    }
+  };
+
+  return (
+    <ChakraProvider>
+      <NavMenu />
+      <Box className="opportunity-management" p={4}>
+        <Heading mb={4}>Opportunity Management</Heading>
+        <SimpleGrid columns={[1, 3]} spacing={4} className="opportunity-stats" mb={4}>
+          <Stat>
+            <StatLabel>Views</StatLabel>
+            <StatNumber>{stats.totalViews}</StatNumber>
+          </Stat>
+          <Stat>
+            <StatLabel>Applications</StatLabel>
+            <StatNumber>{stats.totalApplications}</StatNumber>
+          </Stat>
+          <Stat>
+            <StatLabel>Matches</StatLabel>
+            <StatNumber>{stats.totalMatches}</StatNumber>
+          </Stat>
+        </SimpleGrid>
+        <OpportunityForm onSubmit={handleCreate} />
+        <OpportunityList opportunities={opportunities} onDelete={handleDelete} onApply={handleApply} />
+      </Box>
+    </ChakraProvider>
+  );
+}

--- a/frontend/styles/OpportunityForm.css
+++ b/frontend/styles/OpportunityForm.css
@@ -1,0 +1,3 @@
+.opportunity-form {
+  margin-bottom: 1rem;
+}

--- a/frontend/styles/OpportunityList.css
+++ b/frontend/styles/OpportunityList.css
@@ -1,0 +1,13 @@
+.opportunity-list {
+  margin-top: 1rem;
+}
+
+.opportunity-list-item {
+  border-bottom: 1px solid #e2e8f0;
+  padding-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.opportunity-list-empty {
+  color: #718096;
+}

--- a/frontend/styles/OpportunityManagement.css
+++ b/frontend/styles/OpportunityManagement.css
@@ -1,0 +1,8 @@
+.opportunity-management {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.opportunity-stats {
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add enterprise-ready opportunity management page with listing, creation and application support
- expose secure frontend APIs for opportunities and applications
- wire navigation and dashboard to new opportunity features

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68928ae8e64883208d78d52da3588a37