### PR TITLE
feat: add workspace dashboard

### DIFF
--- a/backend/controllers/projectManagement.js
+++ b/backend/controllers/projectManagement.js
@@ -313,6 +313,38 @@ async function createTextDocumentHandler(req, res) {
   }
 }
 
+async function listProjectsHandler(req, res) {
+  try {
+    const projects = await service.listProjects();
+    res.json(projects);
+  } catch (err) {
+    logger.error('Failed to list projects', { error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function listProjectTasksHandler(req, res) {
+  const { projectId } = req.params;
+  try {
+    const tasks = await service.listTasks(projectId);
+    res.json(tasks);
+  } catch (err) {
+    logger.error('Failed to list project tasks', { error: err.message, projectId });
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function getBudgetHandler(req, res) {
+  const { projectId } = req.params;
+  try {
+    const summary = await service.getBudgetSummary(projectId);
+    res.json(summary);
+  } catch (err) {
+    logger.error('Failed to get budget summary', { error: err.message, projectId });
+    res.status(500).json({ error: err.message });
+  }
+}
+
 module.exports = {
   createProjectHandler,
   getProjectHandler,
@@ -343,4 +375,7 @@ module.exports = {
   setupWorkflowHandler,
   getSpreadsheetHandler,
   createTextDocumentHandler,
+  listProjectsHandler,
+  listProjectTasksHandler,
+  getBudgetHandler,
 };

--- a/backend/models/projectManagement.js
+++ b/backend/models/projectManagement.js
@@ -15,7 +15,7 @@ const workflows = new Map();
 const spreadsheets = new Map();
 const textDocs = new Map();
 
-function createProject({ name, description = '', ownerId }) {
+function createProject({ name, description = '', ownerId, budget = 0 }) {
   const id = randomUUID();
   const now = new Date();
   const project = {
@@ -23,6 +23,7 @@ function createProject({ name, description = '', ownerId }) {
     name,
     description,
     ownerId,
+    budget,
     status: 'active',
     createdAt: now,
     updatedAt: now,
@@ -188,6 +189,26 @@ function createText({ projectId, title = '', content }) {
   return doc;
 }
 
+function listProjects() {
+  return Array.from(projects.values());
+}
+
+function listTasksByProject(projectId) {
+  return Array.from(tasks.values()).filter((t) => t.projectId === projectId);
+}
+
+function getBudgetSummary(projectId) {
+  const project = projects.get(projectId) || {};
+  const allocatedBudget = project.budget || 0;
+  const entries = Array.from(budgetEntries.values()).filter((e) => e.projectId === projectId);
+  const totalSpent = entries.reduce((sum, e) => sum + e.amount, 0);
+  return {
+    allocatedBudget,
+    totalSpent,
+    remainingBudget: allocatedBudget - totalSpent,
+  };
+}
+
 module.exports = {
   createProject,
   getProjectById,
@@ -215,4 +236,7 @@ module.exports = {
   storeSpreadsheet,
   getSpreadsheet,
   createText,
+  listProjects,
+  listTasksByProject,
+  getBudgetSummary,
 };

--- a/backend/routes/projectManagement.js
+++ b/backend/routes/projectManagement.js
@@ -29,6 +29,9 @@ const {
   setupWorkflowHandler,
   getSpreadsheetHandler,
   createTextDocumentHandler,
+  listProjectsHandler,
+  listProjectTasksHandler,
+  getBudgetHandler,
 } = require('../controllers/projectManagement');
 const auth = require('../middleware/auth');
 const validate = require('../middleware/validate');
@@ -62,10 +65,13 @@ const {
 const router = express.Router();
 
 // Project routes
+router.get('/projects', auth, listProjectsHandler);
 router.post('/projects/create', auth, validate(createProjectSchema), createProjectHandler);
 router.get('/projects/:projectId', auth, validate(projectIdParamSchema, 'params'), projectExists, getProjectHandler);
 router.put('/projects/update/:projectId', auth, validate(projectIdParamSchema, 'params'), validate(updateProjectSchema), projectExists, updateProjectHandler);
 router.delete('/projects/delete/:projectId', auth, validate(projectIdParamSchema, 'params'), projectExists, deleteProjectHandler);
+router.get('/projects/:projectId/tasks', auth, validate(projectIdParamSchema, 'params'), projectExists, listProjectTasksHandler);
+router.get('/projects/:projectId/budget', auth, validate(projectIdParamSchema, 'params'), projectExists, getBudgetHandler);
 
 // Task routes
 router.post('/tasks/create', auth, validate(createTaskSchema), createTaskHandler);

--- a/backend/services/projectManagement.js
+++ b/backend/services/projectManagement.js
@@ -170,6 +170,18 @@ async function createTextDocument(data) {
   return doc;
 }
 
+async function listProjects() {
+  return model.listProjects();
+}
+
+async function listTasks(projectId) {
+  return model.listTasksByProject(projectId);
+}
+
+async function getBudgetSummary(projectId) {
+  return model.getBudgetSummary(projectId);
+}
+
 module.exports = {
   createProject,
   getProject,
@@ -200,4 +212,7 @@ module.exports = {
   setupWorkflow,
   getSpreadsheet,
   createTextDocument,
+  listProjects,
+  listTasks,
+  getBudgetSummary,
 };

--- a/backend/validation/projectManagement.js
+++ b/backend/validation/projectManagement.js
@@ -24,12 +24,14 @@ const createProjectSchema = Joi.object({
   name: Joi.string().min(3).max(255).required(),
   description: Joi.string().max(1000).allow('', null),
   ownerId: Joi.string().required(),
+  budget: Joi.number().positive().optional(),
 });
 
 const updateProjectSchema = Joi.object({
   name: Joi.string().min(3).max(255),
   description: Joi.string().max(1000).allow('', null),
   status: Joi.string().valid('active', 'archived', 'completed'),
+  budget: Joi.number().positive(),
 });
 
 const createTaskSchema = Joi.object({

--- a/frontend/api/workspace.js
+++ b/frontend/api/workspace.js
@@ -1,0 +1,36 @@
+const API_BASE_URL = window.API_BASE_URL || '/api';
+
+async function request(path, options = {}) {
+  const token = localStorage.getItem('token');
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...options.headers,
+  };
+  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message || 'Request failed');
+  }
+  return res.json();
+}
+
+export function fetchWorkspaceOverview() {
+  return request('/analytics/workspace/overview');
+}
+
+export function fetchProjects() {
+  return request('/workspace/projects');
+}
+
+export function fetchProjectTasks(projectId) {
+  return request(`/workspace/projects/${projectId}/tasks`);
+}
+
+export function fetchProjectBudget(projectId) {
+  return request(`/workspace/projects/${projectId}/budget`);
+}
+
+export function fetchProjectTeam(projectId) {
+  return request(`/workspace/employment/list?projectId=${projectId}`);
+}

--- a/frontend/components/NavMenu.jsx
+++ b/frontend/components/NavMenu.jsx
@@ -8,6 +8,7 @@ export default function NavMenu() {
       <HStack spacing={4}>
         <Link as={RouterLink} to="/">Dashboard</Link>
         <Link as={RouterLink} to="/jobs">Job Posts</Link>
+        <Link as={RouterLink} to="/workspace">Workspace</Link>
       </HStack>
     </Box>
   );

--- a/frontend/components/ProjectCard.jsx
+++ b/frontend/components/ProjectCard.jsx
@@ -1,0 +1,20 @@
+import { Box, Heading, Text, Badge, VStack } from '@chakra-ui/react';
+import '../styles/ProjectCard.css';
+
+export default function ProjectCard({ project }) {
+  const tasksCount = project.tasks ? project.tasks.length : 0;
+  const teamCount = project.team ? project.team.length : 0;
+  const budget = project.budget || { allocatedBudget: 0, totalSpent: 0, remainingBudget: 0 };
+
+  return (
+    <Box borderWidth="1px" borderRadius="lg" p={4} className="project-card">
+      <Heading size="md" mb={2}>{project.name}</Heading>
+      <Text mb={2}>{project.description}</Text>
+      <VStack align="start" spacing={1}>
+        <Badge colorScheme="purple">Tasks: {tasksCount}</Badge>
+        <Badge colorScheme="green">Team: {teamCount}</Badge>
+        <Badge colorScheme="blue">Budget: ${budget.totalSpent}/{budget.allocatedBudget}</Badge>
+      </VStack>
+    </Box>
+  );
+}

--- a/frontend/components/WorkspaceSummary.jsx
+++ b/frontend/components/WorkspaceSummary.jsx
@@ -1,0 +1,31 @@
+import { SimpleGrid, Stat, StatLabel, StatNumber } from '@chakra-ui/react';
+import '../styles/WorkspaceSummary.css';
+
+export default function WorkspaceSummary({ data = [] }) {
+  if (!data.length) return null;
+  const totals = data.reduce(
+    (acc, item) => ({
+      activeUsers: acc.activeUsers + (item.activeUsers || 0),
+      projectsCreated: acc.projectsCreated + (item.projectsCreated || 0),
+      messagesExchanged: acc.messagesExchanged + (item.messagesExchanged || 0),
+    }),
+    { activeUsers: 0, projectsCreated: 0, messagesExchanged: 0 }
+  );
+
+  return (
+    <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4} className="workspace-summary">
+      <Stat>
+        <StatLabel>Active Users</StatLabel>
+        <StatNumber>{totals.activeUsers}</StatNumber>
+      </Stat>
+      <Stat>
+        <StatLabel>Projects</StatLabel>
+        <StatNumber>{totals.projectsCreated}</StatNumber>
+      </Stat>
+      <Stat>
+        <StatLabel>Messages</StatLabel>
+        <StatNumber>{totals.messagesExchanged}</StatNumber>
+      </Stat>
+    </SimpleGrid>
+  );
+}

--- a/frontend/nav/menu.js
+++ b/frontend/nav/menu.js
@@ -48,6 +48,7 @@ function NavMenu() {
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/gigs')}>Gigs</Button>
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/jobs')}>Jobs</Button>
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/orders')}>Orders</Button>
+      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/workspace')}>Workspace</Button>
       <Button variant="outline" color="white" onClick={handleLogout}>Logout</Button>
     </Flex>
   );

--- a/frontend/pages/Dashboard.jsx
+++ b/frontend/pages/Dashboard.jsx
@@ -1,13 +1,27 @@
-import { ChakraProvider, Box, Heading } from '@chakra-ui/react';
+import { ChakraProvider, Box, Heading, Button } from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import NavMenu from '../components/NavMenu';
+import WorkspaceSummary from '../components/WorkspaceSummary';
+import { fetchWorkspaceOverview } from '../api/workspace';
 import '../styles/Dashboard.css';
 
 export default function Dashboard() {
+  const [overview, setOverview] = useState([]);
+
+  useEffect(() => {
+    fetchWorkspaceOverview().then(setOverview).catch(() => {});
+  }, []);
+
   return (
     <ChakraProvider>
       <NavMenu />
       <Box p={4} className="dashboard">
-        <Heading>Dashboard</Heading>
+        <Heading mb={4}>Dashboard</Heading>
+        <WorkspaceSummary data={overview} />
+        <Button as={RouterLink} to="/workspace" mt={6} colorScheme="teal">
+          Open Workspace
+        </Button>
       </Box>
     </ChakraProvider>
   );

--- a/frontend/pages/WorkspaceDashboard.jsx
+++ b/frontend/pages/WorkspaceDashboard.jsx
@@ -1,0 +1,60 @@
+import { ChakraProvider, Box, Heading, SimpleGrid, Spinner } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import NavMenu from '../components/NavMenu';
+import WorkspaceSummary from '../components/WorkspaceSummary';
+import ProjectCard from '../components/ProjectCard';
+import { fetchWorkspaceOverview, fetchProjects, fetchProjectTasks, fetchProjectBudget, fetchProjectTeam } from '../api/workspace';
+import '../styles/WorkspaceDashboard.css';
+
+export default function WorkspaceDashboard() {
+  const [overview, setOverview] = useState([]);
+  const [projects, setProjects] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const ov = await fetchWorkspaceOverview();
+        const projs = await fetchProjects();
+        const detailed = await Promise.all(
+          projs.map(async (p) => {
+            const [tasks, budget, team] = await Promise.all([
+              fetchProjectTasks(p.id),
+              fetchProjectBudget(p.id),
+              fetchProjectTeam(p.id),
+            ]);
+            return { ...p, tasks, budget, team };
+          })
+        );
+        setOverview(ov);
+        setProjects(detailed);
+      } catch (err) {
+        console.error('Failed to load workspace', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <ChakraProvider>
+      <NavMenu />
+      <Box p={4} className="workspace-dashboard">
+        <Heading mb={4}>Workspace Dashboard</Heading>
+        {loading ? (
+          <Spinner />
+        ) : (
+          <>
+            <WorkspaceSummary data={overview} />
+            <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4} mt={4}>
+              {projects.map((p) => (
+                <ProjectCard key={p.id} project={p} />
+              ))}
+            </SimpleGrid>
+          </>
+        )}
+      </Box>
+    </ChakraProvider>
+  );
+}

--- a/frontend/styles/ProjectCard.css
+++ b/frontend/styles/ProjectCard.css
@@ -1,0 +1,3 @@
+.project-card {
+  background-color: #ffffff;
+}

--- a/frontend/styles/WorkspaceDashboard.css
+++ b/frontend/styles/WorkspaceDashboard.css
@@ -1,0 +1,3 @@
+.workspace-dashboard {
+  min-height: 100vh;
+}

--- a/frontend/styles/WorkspaceSummary.css
+++ b/frontend/styles/WorkspaceSummary.css
@@ -1,0 +1,3 @@
+.workspace-summary {
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- add backend endpoints to list projects, tasks, and budget summaries for workspace
- build Workspace Dashboard page with summary and project cards
- wire workspace links into navigation and dashboard

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_68928c3dc2d883209efba43b4f269548