### PR TITLE
feat: add live engagement analytics page

### DIFF
--- a/frontend/api/analytics.js
+++ b/frontend/api/analytics.js
@@ -1,0 +1,11 @@
+(function(global){
+  async function getLiveFeedEngagement(params = {}) {
+    const query = new URLSearchParams(params).toString();
+    const res = await apiFetch(`/analytics/live-feed/engagement${query ? `?${query}` : ''}`);
+    if (!res.ok) {
+      throw new Error('Failed to fetch engagement analytics');
+    }
+    return res.json();
+  }
+  global.analyticsAPI = { getLiveFeedEngagement };
+})(window);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -39,6 +39,7 @@ function App() {
         <Route path="/interview/:id" element={<Protected><VirtualInterviewPage /></Protected>} />
         <Route path="/gigs/manage" element={<Protected><GigManagementPage /></Protected>} />
         <Route path="/gigs" element={<Protected><GigsDashboard /></Protected>} />
+        <Route path="/analytics" element={<Protected><LiveEngagementAnalytics /></Protected>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,6 +32,7 @@
     <link rel="stylesheet" href="views/home_dashboard.css" />
     <link rel="stylesheet" href="components/JobCard.css" />
     <link rel="stylesheet" href="views/job_listings.css" />
+    <link rel="stylesheet" href="views/live_engagement_analytics.css" />
     <link rel="stylesheet" href="views/live_feed.css" />
     <link rel="stylesheet" href="components/FeatureCard.css" />
     <link rel="stylesheet" href="components/FileUpload.css" />
@@ -138,7 +139,9 @@
     <script type="text/babel" data-presets="env,react" src="views/gig_creation.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/gigs_dashboard.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/jobs.js"></script>
+    <script type="text/babel" data-presets="env,react" src="api/analytics.js"></script>
     <script type="text/babel" data-presets="env,react" src="components/JobCard.js"></script>
+    <script type="text/babel" data-presets="env,react" src="views/live_engagement_analytics.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/job_listings.js"></script>
     <script type="text/babel" data-presets="env,react" src="app.js"></script>
   </body>

--- a/frontend/nav/menu.js
+++ b/frontend/nav/menu.js
@@ -45,12 +45,13 @@ function NavMenu() {
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/applications-interviews')}>Applications</Button>
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/interview/1')}>Interview</Button>
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/gigs/manage')}>Gigs</Button>
-      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/gigs')}>Gigs</Button>
-      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/jobs')}>Jobs</Button>
-      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/orders')}>Orders</Button>
-      <Button variant="outline" color="white" onClick={handleLogout}>Logout</Button>
-    </Flex>
-  );
-}
+        <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/gigs')}>Gigs</Button>
+        <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/jobs')}>Jobs</Button>
+        <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/analytics')}>Analytics</Button>
+        <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/orders')}>Orders</Button>
+        <Button variant="outline" color="white" onClick={handleLogout}>Logout</Button>
+      </Flex>
+    );
+  }
 
 window.NavMenu = NavMenu;

--- a/frontend/views/home_dashboard.js
+++ b/frontend/views/home_dashboard.js
@@ -106,6 +106,9 @@ function HomeDashboard() {
       <Button colorScheme="teal" ml={2} onClick={() => window.location.href = '/jobs'}>
         Browse Jobs
       </Button>
+      <Button ml={2} colorScheme="purple" onClick={() => window.location.href = '/analytics'}>
+        Engagement Analytics
+      </Button>
     </Box>
     <ChatWidget />
     </>

--- a/frontend/views/live_engagement_analytics.css
+++ b/frontend/views/live_engagement_analytics.css
@@ -1,0 +1,10 @@
+.live-engagement-analytics {
+  background: #f9fafb;
+}
+
+.live-engagement-analytics .stat-card {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}

--- a/frontend/views/live_engagement_analytics.js
+++ b/frontend/views/live_engagement_analytics.js
@@ -1,0 +1,49 @@
+const { Box, Heading, SimpleGrid, Stat, StatLabel, StatNumber, useToast } = ChakraUI;
+const { useState, useEffect } = React;
+
+function LiveEngagementAnalytics() {
+  const [totals, setTotals] = useState(null);
+  const toast = useToast();
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await analyticsAPI.getLiveFeedEngagement();
+        setTotals(data.totals);
+      } catch (err) {
+        console.error('Analytics fetch failed', err);
+        toast({ title: 'Failed to load analytics', status: 'error' });
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <Box className="live-engagement-analytics" p={4}>
+      <NavMenu />
+      <Heading size="lg" mb={4}>Live Engagement Analytics</Heading>
+      {totals && (
+        <SimpleGrid columns={[1, 2, 4]} spacing={4}>
+          <Stat className="stat-card">
+            <StatLabel>Views</StatLabel>
+            <StatNumber>{totals.views}</StatNumber>
+          </Stat>
+          <Stat className="stat-card">
+            <StatLabel>Likes</StatLabel>
+            <StatNumber>{totals.likes}</StatNumber>
+          </Stat>
+          <Stat className="stat-card">
+            <StatLabel>Comments</StatLabel>
+            <StatNumber>{totals.comments}</StatNumber>
+          </Stat>
+          <Stat className="stat-card">
+            <StatLabel>Shares</StatLabel>
+            <StatNumber>{totals.shares}</StatNumber>
+          </Stat>
+        </SimpleGrid>
+      )}
+    </Box>
+  );
+}
+
+window.LiveEngagementAnalytics = LiveEngagementAnalytics;


### PR DESCRIPTION
## Summary
- add API helper for live feed engagement analytics
- build Chakra UI live engagement analytics view with basic metrics
- integrate analytics page into navigation and dashboard

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68928c30ac5083208ca77e2221d2b6da