### PR TITLE
Add startup/investor/mentor dashboard

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -116,6 +116,7 @@ const successStoryRoutes = require('./routes/successStories');
 const thirdPartyApiRoutes = require('./routes/thirdPartyApis');
 const userSetupRoutes = require('./routes/userSetup');
 const interviewRoutes = require('./routes/interviews');
+const simDashboardRoutes = require('./routes/simDashboard');
 const app = express();
 app.use(cors());
 app.use(express.json());
@@ -239,6 +240,7 @@ app.use('/affiliates/notifications', notificationRoutes);
 app.use('/workspace', projectManagementRoutes);
 app.use('/third-party', thirdPartyApiRoutes);
 app.use('/user-setup', userSetupRoutes);
+app.use('/sim', simDashboardRoutes);
 
 const port = process.env.PORT || 5000;
 if (require.main === module) {

--- a/backend/controllers/simDashboard.js
+++ b/backend/controllers/simDashboard.js
@@ -1,0 +1,13 @@
+const { fetchSimDashboard } = require('../services/simDashboard');
+
+async function simDashboardHandler(req, res) {
+  try {
+    const data = await fetchSimDashboard();
+    res.json(data);
+  } catch (err) {
+    console.error('SIM dashboard retrieval failed', err);
+    res.status(500).json({ error: 'Failed to load dashboard' });
+  }
+}
+
+module.exports = { simDashboardHandler };

--- a/backend/models/simDashboard.js
+++ b/backend/models/simDashboard.js
@@ -1,0 +1,11 @@
+const stats = {
+  startups: { total: 12, active: 9 },
+  investors: { total: 5, active: 4 },
+  mentors: { total: 8, active: 6 }
+};
+
+function getSimStats() {
+  return stats;
+}
+
+module.exports = { getSimStats };

--- a/backend/routes/simDashboard.js
+++ b/backend/routes/simDashboard.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { simDashboardHandler } = require('../controllers/simDashboard');
+const auth = require('../middleware/auth');
+
+const router = express.Router();
+
+router.get('/dashboard', auth, simDashboardHandler);
+
+module.exports = router;

--- a/backend/services/simDashboard.js
+++ b/backend/services/simDashboard.js
@@ -1,0 +1,7 @@
+const { getSimStats } = require('../models/simDashboard');
+
+async function fetchSimDashboard() {
+  return getSimStats();
+}
+
+module.exports = { fetchSimDashboard };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,7 @@ import NavBar from './components/NavBar.jsx';
 import ProfilePage from './pages/ProfilePage.jsx';
 import ProfileCustomizationPage from './pages/ProfileCustomizationPage.jsx';
 import { ProfileProvider } from './context/ProfileContext.jsx';
+import SimDashboardPage from './pages/SimDashboardPage.jsx';
 
 function App() {
   return (
@@ -51,6 +52,7 @@ function App() {
               <Route path="/" element={<Navigate to="/profile" replace />} />
               <Route path="/profile" element={<ProfilePage />} />
               <Route path="/profile/customize" element={<ProfileCustomizationPage />} />
+              <Route path="/sim-dashboard" element={<SimDashboardPage />} />
             </Routes>
           </Box>
         </ProfileProvider>

--- a/frontend/src/api/simDashboard.js
+++ b/frontend/src/api/simDashboard.js
@@ -1,0 +1,6 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function getSimDashboard() {
+  const { data } = await apiClient.get('/sim/dashboard');
+  return data;
+}

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -23,6 +23,9 @@ export default function NavBar() {
           <Button as={RouterLink} to="/profile" variant="ghost" color="white" mr={2}>
             Profile
           </Button>
+          <Button as={RouterLink} to="/sim-dashboard" variant="ghost" color="white" mr={2}>
+            Dashboard
+          </Button>
           <Button variant="outline" color="white" onClick={handleLogout}>
             Logout
           </Button>
@@ -40,28 +43,3 @@ export default function NavBar() {
     </Flex>
   );
 }
-import { Flex } from '@chakra-ui/react';
-import { NavLink } from 'react-router-dom';
-import { Flex, Heading, Spacer, Button } from '@chakra-ui/react';
-import { Link as RouterLink } from 'react-router-dom';
-import '../styles/NavBar.css';
-
-function NavBar() {
-  return (
-    <Flex as="nav" className="navbar" p={4} bg="gray.700" color="white">
-      <NavLink to="/profile" className="nav-link">Profile</NavLink>
-      <NavLink to="/profile/customize" className="nav-link">Customize</NavLink>
-    <Flex className="nav-bar" bg="teal.500" color="white" p={4} align="center">
-      <Heading size="md">Workhouse</Heading>
-      <Spacer />
-      <Button as={RouterLink} to="/profile" variant="ghost" color="white" mr={2}>
-        Profile
-      </Button>
-      <Button as={RouterLink} to="/orders" variant="ghost" color="white">
-        Orders
-      </Button>
-    </Flex>
-  );
-}
-
-export default NavBar;

--- a/frontend/src/pages/SimDashboardPage.jsx
+++ b/frontend/src/pages/SimDashboardPage.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Heading, SimpleGrid, Stat, StatLabel, StatNumber } from '@chakra-ui/react';
+import { getSimDashboard } from '../api/simDashboard.js';
+import '../styles/SimDashboard.css';
+
+export default function SimDashboardPage() {
+  const [stats, setStats] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await getSimDashboard();
+        setStats(data);
+      } catch (err) {
+        console.error('Failed to load dashboard', err);
+      }
+    }
+    load();
+  }, []);
+
+  if (!stats) {
+    return <Box p={4}>Loading...</Box>;
+  }
+
+  const roles = [
+    { key: 'startups', title: 'Startups' },
+    { key: 'investors', title: 'Investors' },
+    { key: 'mentors', title: 'Mentors' }
+  ];
+
+  return (
+    <Box className="sim-dashboard" p={4}>
+      <Heading mb={6}>Ecosystem Dashboard</Heading>
+      <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4}>
+        {roles.map(({ key, title }) => (
+          <Box key={key} className="sim-card">
+            <Heading size="md" mb={2}>{title}</Heading>
+            <Stat>
+              <StatLabel>Total</StatLabel>
+              <StatNumber>{stats[key].total}</StatNumber>
+            </Stat>
+            <Stat>
+              <StatLabel>Active</StatLabel>
+              <StatNumber>{stats[key].active}</StatNumber>
+            </Stat>
+          </Box>
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/frontend/src/styles/NavBar.css
+++ b/frontend/src/styles/NavBar.css
@@ -1,6 +1,8 @@
 .nav-bar {
   background-color: #319795;
   color: white;
+}
+
 .navbar {
   gap: 1rem;
 }
@@ -12,6 +14,4 @@
 
 .nav-link.active {
   text-decoration: underline;
-.nav-bar {
-  background-color: #319795;
 }

--- a/frontend/src/styles/SimDashboard.css
+++ b/frontend/src/styles/SimDashboard.css
@@ -1,0 +1,11 @@
+.sim-dashboard {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.sim-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 16px;
+  background-color: #ffffff;
+}


### PR DESCRIPTION
## Summary
- add backend routes and models for combined startup/investor/mentor dashboard
- create Chakra UI dashboard page and API client
- integrate dashboard into navigation and app routing

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68928bfa81e48320846248ad01580d38