### PR TITLE
feat: add live podcast playback room

### DIFF
--- a/backend/controllers/podcastAnalytics.js
+++ b/backend/controllers/podcastAnalytics.js
@@ -5,6 +5,7 @@ const {
   getEngagement,
   getSeriesOverview,
   getEpisodeDetails,
+  recordListen,
 } = require('../services/podcastAnalytics');
 const logger = require('../utils/logger');
 
@@ -83,6 +84,19 @@ async function episodeDetailsHandler(req, res) {
   }
 }
 
+async function recordListenHandler(req, res) {
+  try {
+    const data = await recordListen(req.params.podcastId);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to record podcast listen', {
+      error: err.message,
+      podcastId: req.params.podcastId,
+    });
+    res.status(err.status || 500).json({ error: err.message });
+  }
+}
+
 module.exports = {
   overviewHandler,
   episodeAnalyticsHandler,
@@ -90,4 +104,5 @@ module.exports = {
   engagementHandler,
   seriesOverviewHandler,
   episodeDetailsHandler,
+  recordListenHandler,
 };

--- a/backend/database/podcastAnalytics.sql
+++ b/backend/database/podcastAnalytics.sql
@@ -12,3 +12,13 @@ CREATE TABLE IF NOT EXISTS podcast_analytics (
   engagement JSONB,
   collected_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS podcast_playback_events (
+  id SERIAL PRIMARY KEY,
+  podcast_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+  played_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_podcast_playback_podcast_id
+  ON podcast_playback_events (podcast_id);

--- a/backend/models/podcastAnalytics.js
+++ b/backend/models/podcastAnalytics.js
@@ -25,15 +25,16 @@ podcasts.set(samplePodcastId, {
   podcastId: samplePodcastId,
   seriesId: sampleSeriesId,
   ownerId,
+  engagement: {
+    listens: 0,
+    avgListenDuration: 1700,
+    completionRate: 0.75,
+    dropOffRate: 0.2,
+  },
   demographics: {
     ageGroups: { '18-24': 40, '25-34': 35, '35-44': 25 },
     locations: { US: 60, UK: 20, CA: 20 },
     genders: { male: 55, female: 45 },
-  },
-  engagement: {
-    avgListenDuration: 1700,
-    completionRate: 0.75,
-    dropOffRate: 0.2,
   },
 });
 
@@ -105,6 +106,15 @@ function getEpisodeDetails(episodeId) {
   return episodes.get(episodeId);
 }
 
+function recordListen(podcastId) {
+  const podcast = podcasts.get(podcastId);
+  if (!podcast) {
+    return null;
+  }
+  podcast.engagement.listens = (podcast.engagement.listens || 0) + 1;
+  return podcast.engagement.listens;
+}
+
 module.exports = {
   getOverview,
   getEpisodeAnalytics,
@@ -114,4 +124,5 @@ module.exports = {
   getEpisodeDetails,
   getPodcast,
   getEpisode,
+  recordListen,
 };

--- a/backend/routes/podcastAnalytics.js
+++ b/backend/routes/podcastAnalytics.js
@@ -6,6 +6,7 @@ const {
   engagementHandler,
   seriesOverviewHandler,
   episodeDetailsHandler,
+  recordListenHandler,
 } = require('../controllers/podcastAnalytics');
 const auth = require('../middleware/auth');
 const authorize = require('../middleware/authorize');
@@ -51,6 +52,13 @@ router.get(
   authorize('admin', 'content-manager'),
   validate(podcastIdParamSchema, 'params'),
   engagementHandler
+);
+
+router.post(
+  '/:podcastId/listen',
+  auth,
+  validate(podcastIdParamSchema, 'params'),
+  recordListenHandler
 );
 
 // Creator-specific analytics endpoints

--- a/backend/services/podcastAnalytics.js
+++ b/backend/services/podcastAnalytics.js
@@ -69,6 +69,17 @@ async function getEpisode(episodeId) {
   return podcastModel.getEpisode(episodeId);
 }
 
+async function recordListen(podcastId) {
+  const listens = podcastModel.recordListen(podcastId);
+  if (listens === null) {
+    const error = new Error('Podcast not found');
+    error.status = 404;
+    throw error;
+  }
+  logger.info('Recorded podcast listen', { podcastId, listens });
+  return { listens };
+}
+
 module.exports = {
   getOverview,
   getEpisodeAnalytics,
@@ -78,4 +89,5 @@ module.exports = {
   getEpisodeDetails,
   getPodcast,
   getEpisode,
+  recordListen,
 };

--- a/frontend/components/NavMenu.jsx
+++ b/frontend/components/NavMenu.jsx
@@ -8,6 +8,7 @@ export default function NavMenu() {
       <HStack spacing={4}>
         <Link as={RouterLink} to="/">Dashboard</Link>
         <Link as={RouterLink} to="/jobs">Job Posts</Link>
+        <Link as={RouterLink} to="/live">Live Room</Link>
       </HStack>
     </Box>
   );

--- a/frontend/pages/Dashboard.jsx
+++ b/frontend/pages/Dashboard.jsx
@@ -1,6 +1,8 @@
 import { ChakraProvider, Box, Heading } from '@chakra-ui/react';
 import NavMenu from '../components/NavMenu';
 import '../styles/Dashboard.css';
+import { Link as RouterLink } from 'react-router-dom';
+import { Button } from '@chakra-ui/react';
 
 export default function Dashboard() {
   return (
@@ -8,6 +10,9 @@ export default function Dashboard() {
       <NavMenu />
       <Box p={4} className="dashboard">
         <Heading>Dashboard</Heading>
+        <Button as={RouterLink} to="/live" mt={4} colorScheme="teal">
+          Go to Live Room
+        </Button>
       </Box>
     </ChakraProvider>
   );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -38,6 +38,7 @@ import { ChakraProvider, Box } from '@chakra-ui/react';
 import NavBar from './components/NavBar.jsx';
 import ProfilePage from './pages/ProfilePage.jsx';
 import ProfileCustomizationPage from './pages/ProfileCustomizationPage.jsx';
+import LivePlaybackPage from './pages/LivePlaybackPage.jsx';
 import { ProfileProvider } from './context/ProfileContext.jsx';
 
 function App() {
@@ -51,6 +52,7 @@ function App() {
               <Route path="/" element={<Navigate to="/profile" replace />} />
               <Route path="/profile" element={<ProfilePage />} />
               <Route path="/profile/customize" element={<ProfileCustomizationPage />} />
+              <Route path="/live" element={<LivePlaybackPage />} />
             </Routes>
           </Box>
         </ProfileProvider>

--- a/frontend/src/api/podcast.js
+++ b/frontend/src/api/podcast.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL;
+
+export async function fetchPopularPodcasts() {
+  const { data } = await axios.get(`${API_BASE}/third-party/podcast`);
+  return data;
+}
+
+export async function recordPodcastListen(podcastId) {
+  const { data } = await axios.post(`${API_BASE}/podcast-analytics/${podcastId}/listen`);
+  return data;
+}

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -15,13 +15,16 @@ export default function NavBar() {
   };
 
   return (
-    <Flex className="nav-bar" p={4} align="center">
+    <Flex className="nav-bar" bg="teal.500" color="white" p={4} align="center">
       <Heading size="md">Workhouse</Heading>
       <Spacer />
       {user ? (
         <>
           <Button as={RouterLink} to="/profile" variant="ghost" color="white" mr={2}>
             Profile
+          </Button>
+          <Button as={RouterLink} to="/live" variant="ghost" color="white" mr={2}>
+            Live
           </Button>
           <Button variant="outline" color="white" onClick={handleLogout}>
             Logout
@@ -40,28 +43,3 @@ export default function NavBar() {
     </Flex>
   );
 }
-import { Flex } from '@chakra-ui/react';
-import { NavLink } from 'react-router-dom';
-import { Flex, Heading, Spacer, Button } from '@chakra-ui/react';
-import { Link as RouterLink } from 'react-router-dom';
-import '../styles/NavBar.css';
-
-function NavBar() {
-  return (
-    <Flex as="nav" className="navbar" p={4} bg="gray.700" color="white">
-      <NavLink to="/profile" className="nav-link">Profile</NavLink>
-      <NavLink to="/profile/customize" className="nav-link">Customize</NavLink>
-    <Flex className="nav-bar" bg="teal.500" color="white" p={4} align="center">
-      <Heading size="md">Workhouse</Heading>
-      <Spacer />
-      <Button as={RouterLink} to="/profile" variant="ghost" color="white" mr={2}>
-        Profile
-      </Button>
-      <Button as={RouterLink} to="/orders" variant="ghost" color="white">
-        Orders
-      </Button>
-    </Flex>
-  );
-}
-
-export default NavBar;

--- a/frontend/src/components/PodcastPlayer.jsx
+++ b/frontend/src/components/PodcastPlayer.jsx
@@ -1,0 +1,69 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Heading,
+  List,
+  ListItem,
+  Spinner,
+  Text,
+} from '@chakra-ui/react';
+import { fetchPopularPodcasts, recordPodcastListen } from '../api/podcast.js';
+import '../styles/PodcastPlayer.css';
+
+export default function PodcastPlayer() {
+  const [podcasts, setPodcasts] = useState([]);
+  const [current, setCurrent] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await fetchPopularPodcasts();
+        const list = data?.data || data?.results || [];
+        setPodcasts(list);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleSelect = (p) => {
+    setCurrent(p);
+    if (p.key) {
+      recordPodcastListen(p.key).catch(() => {});
+    }
+  };
+
+  return (
+    <Box className="podcast-player" p={4} borderWidth="1px" borderRadius="md">
+      <Heading size="md" mb={4}>Popular Podcasts</Heading>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <List spacing={2} className="podcast-list">
+          {podcasts.map((p) => (
+            <ListItem
+              key={p.key}
+              className="podcast-item"
+              onClick={() => handleSelect(p)}
+            >
+              {p.name || p.title}
+            </ListItem>
+          ))}
+        </List>
+      )}
+      {current && (
+        <Box mt={4} className="podcast-current">
+          <Heading size="sm" mb={2}>{current.name || current.title}</Heading>
+          <iframe
+            title="podcast-player"
+            src={`https://www.mixcloud.com/widget/iframe/?feed=${encodeURIComponent(current.url)}&hide_cover=1`}
+            frameBorder="0"
+            width="100%"
+            height="120"
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/pages/LivePlaybackPage.jsx
+++ b/frontend/src/pages/LivePlaybackPage.jsx
@@ -1,0 +1,36 @@
+import React, { useEffect, useRef } from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+import PodcastPlayer from '../components/PodcastPlayer.jsx';
+import '../styles/LivePlaybackPage.css';
+
+export default function LivePlaybackPage() {
+  const jitsiRef = useRef(null);
+
+  useEffect(() => {
+    const domain = import.meta.env.VITE_JITSI_DOMAIN;
+    const load = () => {
+      const api = new window.JitsiMeetExternalAPI(domain.replace(/^https?:\/\//, ''), {
+        roomName: 'WorkhouseWebinarDemo',
+        parentNode: jitsiRef.current,
+      });
+      return () => api.dispose();
+    };
+
+    if (window.JitsiMeetExternalAPI) {
+      return load();
+    }
+    const script = document.createElement('script');
+    script.src = `${domain}/external_api.js`;
+    script.async = true;
+    script.onload = load;
+    document.body.appendChild(script);
+  }, []);
+
+  return (
+    <Box className="live-playback-page" p={4}>
+      <Heading mb={4}>Live Webinar Room</Heading>
+      <Box id="jitsi-container" ref={jitsiRef} className="jitsi-container" mb={8} />
+      <PodcastPlayer />
+    </Box>
+  );
+}

--- a/frontend/src/styles/LivePlaybackPage.css
+++ b/frontend/src/styles/LivePlaybackPage.css
@@ -1,0 +1,8 @@
+.live-playback-page {
+  background-color: #ffffff;
+}
+
+.jitsi-container {
+  width: 100%;
+  height: 400px;
+}

--- a/frontend/src/styles/PodcastPlayer.css
+++ b/frontend/src/styles/PodcastPlayer.css
@@ -1,0 +1,15 @@
+.podcast-player {
+  background-color: #f9f9f9;
+}
+
+.podcast-list {
+  cursor: pointer;
+}
+
+.podcast-item:hover {
+  background-color: #e2e8f0;
+}
+
+.podcast-current iframe {
+  border: none;
+}


### PR DESCRIPTION
## Summary
- add backend podcast listen endpoint and playback events table
- create Live Playback Room with Jitsi webinar and Mixcloud podcast player
- wire page into nav, dashboard, and routing

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68928baa9db8832089a357e6392f5bf2