### PR TITLE
Add creator dashboard with podcast and webinar analytics

### DIFF
--- a/.env
+++ b/.env
@@ -33,3 +33,4 @@ VITE_IMGBB_UPLOAD_URL=https://api.imgbb.com/1/upload
 WORLD_TIME_API=https://worldtimeapi.org/api
 JITSI_DOMAIN=https://meet.jit.si
 EXTERNAL_JOB_TITLES_API=https://raw.githubusercontent.com/dariusk/corpora/master/data/humans/job_titles.json
+MIXCLOUD_API=https://api.mixcloud.com

--- a/backend/controllers/podcastAnalytics.js
+++ b/backend/controllers/podcastAnalytics.js
@@ -5,6 +5,7 @@ const {
   getEngagement,
   getSeriesOverview,
   getEpisodeDetails,
+  getCreatorSeries,
 } = require('../services/podcastAnalytics');
 const logger = require('../utils/logger');
 
@@ -83,6 +84,16 @@ async function episodeDetailsHandler(req, res) {
   }
 }
 
+async function creatorSeriesHandler(req, res) {
+  try {
+    const data = await getCreatorSeries(req.user.id);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to retrieve creator series', { error: err.message });
+    res.status(500).json({ error: 'Failed to retrieve creator series' });
+  }
+}
+
 module.exports = {
   overviewHandler,
   episodeAnalyticsHandler,
@@ -90,4 +101,5 @@ module.exports = {
   engagementHandler,
   seriesOverviewHandler,
   episodeDetailsHandler,
+  creatorSeriesHandler,
 };

--- a/backend/controllers/webinarAnalytics.js
+++ b/backend/controllers/webinarAnalytics.js
@@ -12,6 +12,7 @@ const {
   analyzeBehaviorPatterns,
   predictUserBehavior,
   segmentUserBehavior,
+  getCreatorWebinars,
 } = require('../services/webinarAnalytics');
 const logger = require('../utils/logger');
 
@@ -151,6 +152,16 @@ async function segmentUserBehaviorHandler(req, res) {
   }
 }
 
+async function getCreatorWebinarsHandler(req, res) {
+  try {
+    const data = await getCreatorWebinars(req.user.id);
+    res.json(data);
+  } catch (err) {
+    logger.error('Failed to fetch creator webinars', { error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+}
+
 module.exports = {
   getWebinarOverviewHandler,
   getWebinarDetailsHandler,
@@ -165,4 +176,5 @@ module.exports = {
   analyzeBehaviorPatternsHandler,
   predictUserBehaviorHandler,
   segmentUserBehaviorHandler,
+  getCreatorWebinarsHandler,
 };

--- a/backend/database/webinar_analytics.sql
+++ b/backend/database/webinar_analytics.sql
@@ -3,6 +3,8 @@
 CREATE TABLE IF NOT EXISTS webinar_analytics (
   id UUID PRIMARY KEY,
   webinar_id UUID NOT NULL,
+  owner_id UUID NOT NULL,
+  title TEXT,
   overview JSONB,
   engagement JSONB,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/backend/models/podcastAnalytics.js
+++ b/backend/models/podcastAnalytics.js
@@ -13,6 +13,8 @@ const sampleEpisodeId = randomUUID();
 seriesStats.set(sampleSeriesId, {
   seriesId: sampleSeriesId,
   ownerId,
+  title: 'Sample Podcast Series',
+  episodes: 1,
   listens: 5000,
   likes: 1200,
   donations: 300,
@@ -101,6 +103,10 @@ function getSeriesOverview(seriesId) {
   return seriesStats.get(seriesId);
 }
 
+function getSeriesByOwner(ownerId) {
+  return Array.from(seriesStats.values()).filter(s => s.ownerId === ownerId);
+}
+
 function getEpisodeDetails(episodeId) {
   return episodes.get(episodeId);
 }
@@ -111,6 +117,7 @@ module.exports = {
   getDemographics,
   getEngagement,
   getSeriesOverview,
+  getSeriesByOwner,
   getEpisodeDetails,
   getPodcast,
   getEpisode,

--- a/backend/models/webinarAnalytics.js
+++ b/backend/models/webinarAnalytics.js
@@ -4,10 +4,12 @@ const { randomUUID } = require('crypto');
 const webinarAnalyticsStore = new Map();
 const userBehaviorStore = new Map();
 
-function saveWebinarAnalytics(webinarId, data = {}) {
+function saveWebinarAnalytics(webinarId, data = {}, ownerId) {
   const record = {
     id: randomUUID(),
     webinarId,
+    ownerId,
+    title: data.title || '',
     overview: data.overview || {},
     engagement: data.engagement || {},
     createdAt: new Date(),
@@ -22,6 +24,10 @@ function getWebinarAnalytics(webinarId) {
 
 function getAllWebinarAnalytics() {
   return Array.from(webinarAnalyticsStore.values());
+}
+
+function getWebinarsByOwner(ownerId) {
+  return Array.from(webinarAnalyticsStore.values()).filter(w => w.ownerId === ownerId);
 }
 
 function saveUserBehavior(userId, behavior = {}) {
@@ -47,7 +53,21 @@ module.exports = {
   saveWebinarAnalytics,
   getWebinarAnalytics,
   getAllWebinarAnalytics,
+  getWebinarsByOwner,
   saveUserBehavior,
   getUserBehavior,
   getAllUserBehavior,
 };
+
+// Seed sample webinar analytics
+const ownerId = 'user-123';
+const sampleWebinarId = randomUUID();
+saveWebinarAnalytics(
+  sampleWebinarId,
+  {
+    title: 'Sample Webinar',
+    overview: { attendees: 150, registrations: 200, revenue: 1000 },
+    engagement: { engagementRate: 0.82 },
+  },
+  ownerId
+);

--- a/backend/routes/podcastAnalytics.js
+++ b/backend/routes/podcastAnalytics.js
@@ -6,6 +6,7 @@ const {
   engagementHandler,
   seriesOverviewHandler,
   episodeDetailsHandler,
+  creatorSeriesHandler,
 } = require('../controllers/podcastAnalytics');
 const auth = require('../middleware/auth');
 const authorize = require('../middleware/authorize');
@@ -70,6 +71,13 @@ router.get(
   validate(episodeIdParamSchema, 'params'),
   ownership,
   episodeDetailsHandler
+);
+
+router.get(
+  '/creator/series',
+  auth,
+  authorize('creator'),
+  creatorSeriesHandler
 );
 
 module.exports = router;

--- a/backend/routes/webinarAnalytics.js
+++ b/backend/routes/webinarAnalytics.js
@@ -13,6 +13,7 @@ const {
   analyzeBehaviorPatternsHandler,
   predictUserBehaviorHandler,
   segmentUserBehaviorHandler,
+  getCreatorWebinarsHandler,
 } = require('../controllers/webinarAnalytics');
 const auth = require('../middleware/auth');
 const authorize = require('../middleware/authorize');
@@ -58,5 +59,6 @@ router.get('/behavior-trends', auth, authorize(['admin', 'analytics-manager']), 
 router.post('/behavior-pattern-analysis', auth, authorize(['admin', 'analytics-manager']), validate(behaviorAnalysisSchema), analyzeBehaviorPatternsHandler);
 router.post('/behavior-prediction', auth, authorize(['admin', 'analytics-manager']), validate(behaviorPredictionSchema), predictUserBehaviorHandler);
 router.post('/behavior-segmentation', auth, authorize(['admin', 'analytics-manager']), validate(behaviorSegmentationSchema), segmentUserBehaviorHandler);
+router.get('/creator/webinars', auth, authorize('creator'), getCreatorWebinarsHandler);
 
 module.exports = router;

--- a/backend/services/podcastAnalytics.js
+++ b/backend/services/podcastAnalytics.js
@@ -69,6 +69,11 @@ async function getEpisode(episodeId) {
   return podcastModel.getEpisode(episodeId);
 }
 
+async function getCreatorSeries(ownerId) {
+  logger.info('Fetching creator series', { ownerId });
+  return podcastModel.getSeriesByOwner(ownerId);
+}
+
 module.exports = {
   getOverview,
   getEpisodeAnalytics,
@@ -78,4 +83,5 @@ module.exports = {
   getEpisodeDetails,
   getPodcast,
   getEpisode,
+  getCreatorSeries,
 };

--- a/backend/services/thirdPartyApis.js
+++ b/backend/services/thirdPartyApis.js
@@ -44,9 +44,11 @@ async function fetchCached(url = 'https://example.com') {
   return data;
 }
 
+const MIXCLOUD_API = process.env.MIXCLOUD_API || 'https://api.mixcloud.com';
+
 async function getPodcastSample() {
   // Mixcloud exposes a free API with podcast and music information.
-  const { data } = await axios.get('https://api.mixcloud.com/popular/');
+  const { data } = await axios.get(`${MIXCLOUD_API}/popular/`);
   return data;
 }
 

--- a/backend/services/webinarAnalytics.js
+++ b/backend/services/webinarAnalytics.js
@@ -53,6 +53,11 @@ async function getUserBehavior(userId) {
   return record.behavior;
 }
 
+async function getCreatorWebinars(ownerId) {
+  logger.info('Fetching creator webinars', { ownerId });
+  return webinarAnalyticsModel.getWebinarsByOwner(ownerId);
+}
+
 async function getPopularPages() {
   const behaviors = webinarAnalyticsModel.getAllUserBehavior();
   const pageCounts = {};
@@ -155,4 +160,5 @@ module.exports = {
   analyzeBehaviorPatterns,
   predictUserBehavior,
   segmentUserBehavior,
+  getCreatorWebinars,
 };

--- a/frontend/api/creator.js
+++ b/frontend/api/creator.js
@@ -1,0 +1,27 @@
+(function(global){
+  async function getCreatorSeries(){
+    const res = await apiFetch('/api/podcast-analytics/creator/series');
+    if(!res.ok){
+      throw new Error('Failed to load podcast series');
+    }
+    return res.json();
+  }
+
+  async function getCreatorWebinars(){
+    const res = await apiFetch('/api/webinar-analytics/creator/webinars');
+    if(!res.ok){
+      throw new Error('Failed to load webinars');
+    }
+    return res.json();
+  }
+
+  async function getTrendingPodcasts(){
+    const res = await apiFetch('/api/third-party/podcast');
+    if(!res.ok){
+      throw new Error('Failed to load trending podcasts');
+    }
+    return res.json();
+  }
+
+  global.creatorAPI = { getCreatorSeries, getCreatorWebinars, getTrendingPodcasts };
+})(window);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -39,6 +39,7 @@ function App() {
         <Route path="/interview/:id" element={<Protected><VirtualInterviewPage /></Protected>} />
         <Route path="/gigs/manage" element={<Protected><GigManagementPage /></Protected>} />
         <Route path="/gigs" element={<Protected><GigsDashboard /></Protected>} />
+        <Route path="/creator/dashboard" element={<Protected><CreatorDashboard /></Protected>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,6 +38,7 @@
     <link rel="stylesheet" href="views/cv_cover_letter_page.css" />
     <link rel="stylesheet" href="components/FeedPost.css" />
     <link rel="stylesheet" href="views/profile_customization.css" />
+    <link rel="stylesheet" href="views/creator_dashboard.css" />
     <link rel="stylesheet" href="views/signup_userinfo.css" />
     <link rel="stylesheet" href="views/signup_page.css" />
     <link rel="stylesheet" href="views/chat_inbox.css" />
@@ -140,6 +141,8 @@
     <script type="text/babel" data-presets="env,react" src="api/jobs.js"></script>
     <script type="text/babel" data-presets="env,react" src="components/JobCard.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/job_listings.js"></script>
+    <script type="text/babel" data-presets="env,react" src="api/creator.js"></script>
+    <script type="text/babel" data-presets="env,react" src="views/creator_dashboard.js"></script>
     <script type="text/babel" data-presets="env,react" src="app.js"></script>
   </body>
 </html>

--- a/frontend/nav/menu.js
+++ b/frontend/nav/menu.js
@@ -48,6 +48,7 @@ function NavMenu() {
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/gigs')}>Gigs</Button>
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/jobs')}>Jobs</Button>
       <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/orders')}>Orders</Button>
+      <Button variant="ghost" color="white" mr={2} onClick={() => navigate('/creator/dashboard')}>Creator</Button>
       <Button variant="outline" color="white" onClick={handleLogout}>Logout</Button>
     </Flex>
   );

--- a/frontend/views/creator_dashboard.css
+++ b/frontend/views/creator_dashboard.css
@@ -1,0 +1,8 @@
+.creator-dashboard {
+  background-color: #f9f9f9;
+}
+
+.creator-dashboard .stat-card,
+.creator-dashboard .series-card {
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}

--- a/frontend/views/creator_dashboard.js
+++ b/frontend/views/creator_dashboard.js
@@ -1,0 +1,94 @@
+const { Box, Heading, Text, SimpleGrid, Button, Flex } = ChakraUI;
+const { useEffect, useState } = React;
+
+function StatCard({ label, value }) {
+  return (
+    <Box className="stat-card" p={4} borderWidth="1px" borderRadius="md" bg="white">
+      <Heading size="sm" mb={2}>{label}</Heading>
+      <Text fontSize="xl" fontWeight="bold">{value}</Text>
+    </Box>
+  );
+}
+
+function CreatorDashboard() {
+  const [series, setSeries] = useState([]);
+  const [webinars, setWebinars] = useState([]);
+  const [trending, setTrending] = useState([]);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    async function loadData() {
+      try {
+        const [s, w, t] = await Promise.all([
+          creatorAPI.getCreatorSeries(),
+          creatorAPI.getCreatorWebinars(),
+          creatorAPI.getTrendingPodcasts(),
+        ]);
+        setSeries(s);
+        setWebinars(w);
+        setTrending(t.data || []);
+      } catch (err) {
+        console.error('Failed to load creator dashboard', err);
+        setError('Failed to load data');
+      }
+    }
+    loadData();
+  }, []);
+
+  const totalPlays = series.reduce((sum, s) => sum + (s.listens || 0), 0);
+  const totalAttendees = webinars.reduce((sum, w) => sum + (w.overview?.attendees || 0), 0);
+  const totalRevenue = webinars.reduce((sum, w) => sum + (w.overview?.revenue || 0), 0);
+
+  return (
+    <Box className="creator-dashboard" p={4}>
+      <NavMenu />
+      <Heading mb={4}>Creator Dashboard</Heading>
+      {error && <Text color="red.500">{error}</Text>}
+      <SimpleGrid columns={[1, 2, 3]} spacing={4} mb={6}>
+        <StatCard label="Total Plays" value={totalPlays} />
+        <StatCard label="Total Attendees" value={totalAttendees} />
+        <StatCard label="Revenue" value={`$${totalRevenue}`} />
+      </SimpleGrid>
+      <Heading size="md" mb={2}>Podcast Series</Heading>
+      <SimpleGrid columns={[1, 2, 3]} spacing={4} mb={6}>
+        {series.map(s => (
+          <Box key={s.seriesId} className="series-card" borderWidth="1px" borderRadius="md" p={4} bg="white">
+            <Heading size="sm" mb={2}>{s.title || 'Untitled Series'}</Heading>
+            <Text>Episodes: {s.episodes || 0}</Text>
+            <Text>Listens: {s.listens}</Text>
+            <Flex mt={2} gap={2}>
+              <Button size="sm" colorScheme="teal">Edit</Button>
+              <Button size="sm" colorScheme="blue">Add Episode</Button>
+              <Button size="sm" colorScheme="purple">Stats</Button>
+            </Flex>
+          </Box>
+        ))}
+      </SimpleGrid>
+      <Heading size="md" mb={2}>Webinars</Heading>
+      <SimpleGrid columns={[1, 2, 3]} spacing={4} mb={6}>
+        {webinars.map(w => (
+          <Box key={w.webinarId} className="series-card" borderWidth="1px" borderRadius="md" p={4} bg="white">
+            <Heading size="sm" mb={2}>{w.title || 'Webinar'}</Heading>
+            <Text>Attendees: {w.overview?.attendees || 0}</Text>
+            <Text>Revenue: ${w.overview?.revenue || 0}</Text>
+            <Flex mt={2} gap={2}>
+              <Button size="sm" colorScheme="teal">Edit</Button>
+              <Button size="sm" colorScheme="blue">Add Webinar</Button>
+              <Button size="sm" colorScheme="purple">Stats</Button>
+            </Flex>
+          </Box>
+        ))}
+      </SimpleGrid>
+      <Heading size="md" mb={2}>Trending Podcasts</Heading>
+      <SimpleGrid columns={[1, 2, 3]} spacing={4}>
+        {trending.slice(0,3).map(p => (
+          <Box key={p.key || p.url} className="series-card" borderWidth="1px" borderRadius="md" p={4} bg="white">
+            <Text fontWeight="bold">{p.name || 'Podcast'}</Text>
+          </Box>
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}
+
+window.CreatorDashboard = CreatorDashboard;

--- a/frontend/views/home_dashboard.js
+++ b/frontend/views/home_dashboard.js
@@ -106,6 +106,9 @@ function HomeDashboard() {
       <Button colorScheme="teal" ml={2} onClick={() => window.location.href = '/jobs'}>
         Browse Jobs
       </Button>
+      <Button colorScheme="purple" ml={2} onClick={() => window.location.href = '/creator/dashboard'}>
+        Creator Dashboard
+      </Button>
     </Box>
     <ChatWidget />
     </>


### PR DESCRIPTION
## Summary
- implement backend endpoints for creators to fetch podcast series, webinar analytics, and Mixcloud podcast samples
- build Chakra UI creator dashboard showing stats, series/webinar management cards, and trending podcasts
- wire new dashboard into navigation, routing, and environment configuration

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68928b899f90832082e02ed623737f96