### PR TITLE
Add networking dashboard with backend support

### DIFF
--- a/backend/controllers/event.js
+++ b/backend/controllers/event.js
@@ -53,6 +53,13 @@ async function getNetworkingEvent(req, res) {
   res.json(event);
 }
 
+async function listNetworkingEvents(req, res) {
+  const userId = req.user.id;
+  const hosted = await eventService.listNetworkingEventsForHost(userId);
+  const attending = await eventService.listNetworkingEventsForUser(userId);
+  res.json({ hosted, attending });
+}
+
 async function createWorkshop(req, res) {
   try {
     const event = await eventService.createWorkshopEvent(req.body, req.user.id);
@@ -91,6 +98,7 @@ module.exports = {
   getPitchLivestream,
   createNetworkingEvent,
   getNetworkingEvent,
+  listNetworkingEvents,
   createWorkshop,
   getWorkshop,
   submitQuestion,

--- a/backend/models/eventController.js
+++ b/backend/models/eventController.js
@@ -61,6 +61,14 @@ function getQuestions(id) {
   return event ? event.questions : null;
 }
 
+function findByHost(hostId) {
+  return Array.from(events.values()).filter((e) => e.hostId === hostId);
+}
+
+function findByAttendee(userId) {
+  return Array.from(events.values()).filter((e) => e.attendees.has(userId));
+}
+
 module.exports = {
   createEvent,
   findById,
@@ -69,4 +77,6 @@ module.exports = {
   getLivestream,
   addQuestion,
   getQuestions,
+  findByHost,
+  findByAttendee,
 };

--- a/backend/routes/events.js
+++ b/backend/routes/events.js
@@ -42,6 +42,7 @@ router.get('/pitch/livestream/:eventId', eventItemExists, investorEventControlle
 
 router.post('/networking/create', auth, validate(networkingEventSchema), investorEventController.createNetworkingEvent);
 router.get('/networking/:eventId', eventItemExists, investorEventController.getNetworkingEvent);
+router.get('/networking', auth, investorEventController.listNetworkingEvents);
 
 router.post('/workshop/create', auth, validate(workshopEventSchema), investorEventController.createWorkshop);
 router.get('/workshop/:eventId', eventItemExists, investorEventController.getWorkshop);

--- a/backend/services/event.js
+++ b/backend/services/event.js
@@ -50,6 +50,18 @@ async function getNetworkingEvent(eventId) {
   return ensureType(eventModel.findById(eventId), 'networking');
 }
 
+async function listNetworkingEventsForHost(hostId) {
+  return eventModel
+    .findByHost(hostId)
+    .filter((e) => e.type === 'networking');
+}
+
+async function listNetworkingEventsForUser(userId) {
+  return eventModel
+    .findByAttendee(userId)
+    .filter((e) => e.type === 'networking');
+}
+
 async function createWorkshopEvent(data, hostId) {
   const event = eventModel.createEvent({ ...data, type: 'workshop', hostId });
   logger.info('Workshop event created', { eventId: event.id, hostId });
@@ -85,6 +97,8 @@ module.exports = {
   getPitchLivestream,
   createNetworkingEvent,
   getNetworkingEvent,
+  listNetworkingEventsForHost,
+  listNetworkingEventsForUser,
   createWorkshopEvent,
   getWorkshopEvent,
   submitQuestion,

--- a/frontend/api/networking.js
+++ b/frontend/api/networking.js
@@ -1,0 +1,10 @@
+(function(global){
+  async function getNetworkingDashboard() {
+    const res = await apiFetch('/events/networking');
+    if (!res.ok) {
+      throw new Error('Failed to load networking data');
+    }
+    return res.json();
+  }
+  global.networkingAPI = { getNetworkingDashboard };
+})(window);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -15,6 +15,7 @@ function App() {
             <Route path="/employment" element={<Protected><EmploymentDashboard /></Protected>} />
             <Route path="/messages" element={<Protected><ChatInbox /></Protected>} />
             <Route path="/applications-interviews" element={<Protected><ApplicationInterviewManagement /></Protected>} />
+            <Route path="/networking" element={<Protected><NetworkingDashboard /></Protected>} />
           </Routes>
         </BrowserRouter>
       </AuthProvider>
@@ -39,6 +40,7 @@ function App() {
         <Route path="/interview/:id" element={<Protected><VirtualInterviewPage /></Protected>} />
         <Route path="/gigs/manage" element={<Protected><GigManagementPage /></Protected>} />
         <Route path="/gigs" element={<Protected><GigsDashboard /></Protected>} />
+        <Route path="/networking" element={<Protected><NetworkingDashboard /></Protected>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/components/NavMenu.jsx
+++ b/frontend/components/NavMenu.jsx
@@ -8,6 +8,7 @@ export default function NavMenu() {
       <HStack spacing={4}>
         <Link as={RouterLink} to="/">Dashboard</Link>
         <Link as={RouterLink} to="/jobs">Job Posts</Link>
+        <Link as={RouterLink} to="/networking">Networking</Link>
       </HStack>
     </Box>
   );

--- a/frontend/components/SessionCard.css
+++ b/frontend/components/SessionCard.css
@@ -1,0 +1,6 @@
+.session-card {
+  transition: background-color 0.2s ease;
+}
+.session-card:hover {
+  background-color: #f7fafc;
+}

--- a/frontend/components/SessionCard.js
+++ b/frontend/components/SessionCard.js
@@ -1,0 +1,14 @@
+const { Box, Heading, Text, Badge } = ChakraUI;
+
+function SessionCard({ session }) {
+  return (
+    <Box className="session-card" borderWidth="1px" borderRadius="md" p={4} mb={4}>
+      <Heading size="md">{session.title}</Heading>
+      <Text fontSize="sm" color="gray.600">{new Date(session.date).toLocaleString()}</Text>
+      {session.description && <Text mt={2}>{session.description}</Text>}
+      <Badge mt={2}>{session.type}</Badge>
+    </Box>
+  );
+}
+
+window.SessionCard = SessionCard;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,6 +31,8 @@
     <link rel="stylesheet" href="views/home_dashboard.css" />
     <link rel="stylesheet" href="views/home_dashboard.css" />
     <link rel="stylesheet" href="components/JobCard.css" />
+    <link rel="stylesheet" href="components/SessionCard.css" />
+    <link rel="stylesheet" href="views/networking_dashboard.css" />
     <link rel="stylesheet" href="views/job_listings.css" />
     <link rel="stylesheet" href="views/live_feed.css" />
     <link rel="stylesheet" href="components/FeatureCard.css" />
@@ -137,6 +139,9 @@
     <script type="text/babel" data-presets="env,react" src="api/gigs.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/gig_creation.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/gigs_dashboard.js"></script>
+    <script type="text/babel" data-presets="env,react" src="api/networking.js"></script>
+    <script type="text/babel" data-presets="env,react" src="components/SessionCard.js"></script>
+    <script type="text/babel" data-presets="env,react" src="views/networking_dashboard.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/jobs.js"></script>
     <script type="text/babel" data-presets="env,react" src="components/JobCard.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/job_listings.js"></script>

--- a/frontend/pages/Dashboard.jsx
+++ b/frontend/pages/Dashboard.jsx
@@ -1,4 +1,5 @@
-import { ChakraProvider, Box, Heading } from '@chakra-ui/react';
+import { ChakraProvider, Box, Heading, Button } from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router-dom';
 import NavMenu from '../components/NavMenu';
 import '../styles/Dashboard.css';
 
@@ -8,6 +9,9 @@ export default function Dashboard() {
       <NavMenu />
       <Box p={4} className="dashboard">
         <Heading>Dashboard</Heading>
+        <Button as={RouterLink} to="/networking" mt={4} colorScheme="purple">
+          Networking
+        </Button>
       </Box>
     </ChakraProvider>
   );

--- a/frontend/views/home_dashboard.js
+++ b/frontend/views/home_dashboard.js
@@ -88,6 +88,9 @@ function HomeDashboard() {
         <Button colorScheme="teal" onClick={() => window.location.href = '/profile'}>
           View Profile
         </Button>
+        <Button colorScheme="purple" onClick={() => window.location.href = '/networking'}>
+          Networking Dashboard
+        </Button>
       </Flex>
       <Button colorScheme="blue" onClick={() => window.location.href = '/feed'}>
         Go to Live Feed

--- a/frontend/views/networking_dashboard.css
+++ b/frontend/views/networking_dashboard.css
@@ -1,0 +1,4 @@
+.networking-dashboard {
+  max-width: 900px;
+  margin: 0 auto;
+}

--- a/frontend/views/networking_dashboard.js
+++ b/frontend/views/networking_dashboard.js
@@ -1,0 +1,54 @@
+const { Box, Heading, Tabs, TabList, TabPanels, Tab, TabPanel, Spinner, Text } = ChakraUI;
+const { useEffect, useState } = React;
+
+function NetworkingDashboard() {
+  const [data, setData] = useState({ hosted: [], attending: [] });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const result = await networkingAPI.getNetworkingDashboard();
+        setData(result);
+      } catch (err) {
+        console.error('Failed to load networking data', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <Box className="networking-dashboard" p={4}>
+      <NavMenu />
+      <Heading mb={4}>Networking Dashboard</Heading>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <Tabs variant="enclosed">
+          <TabList>
+            <Tab>Participant View</Tab>
+            <Tab>Company View</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>
+              {data.attending.length === 0 && <Text>No sessions found.</Text>}
+              {data.attending.map((s) => (
+                <SessionCard key={s.id} session={s} />
+              ))}
+            </TabPanel>
+            <TabPanel>
+              {data.hosted.length === 0 && <Text>No hosted sessions.</Text>}
+              {data.hosted.map((s) => (
+                <SessionCard key={s.id} session={s} />
+              ))}
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      )}
+    </Box>
+  );
+}
+
+window.NetworkingDashboard = NetworkingDashboard;


### PR DESCRIPTION
## Summary
- add networking event listing functions and route to backend
- create Chakra-powered networking dashboard with participant/company views
- introduce reusable SessionCard component and wire into navigation

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68928b45a7e8832081386ea3a47f8d24