### PR TITLE
Add legal and support links to landing page footer

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "react-dom": "^18.2.0",
     "react-google-recaptcha": "^2.1.0",
     "react-router-dom": "^6.23.0",
-    "react-calendar": "^4.0.0"
+    "react-calendar": "^4.0.0",
     "chart.js": "^4.4.0",
     "react-chartjs-2": "^5.2.0"
   },

--- a/frontend/views/landing_page.js
+++ b/frontend/views/landing_page.js
@@ -62,9 +62,11 @@ function LandingPage() {
       <Box as="footer" className="landing-footer" py={8} textAlign="center" bg="gray.800" color="white">
         <Stack spacing={2} align="center">
           <Stack direction="row" spacing={4}>
+            <a href="#">Terms &amp; Conditions</a>
             <a href="#">Privacy Policy</a>
-            <a href="#">Terms of Service</a>
-            <a href="#">Help Center</a>
+            <a href="#">Support Centre</a>
+            <a href="#">About Us</a>
+            <a href="#">For Investors</a>
           </Stack>
           <Text>&copy; {new Date().getFullYear()} Workhouse</Text>
         </Stack>


### PR DESCRIPTION
## Summary
- add Terms & Conditions, Privacy Policy, Support Centre, About Us, and For Investors links to the landing page footer
- fix invalid JSON in frontend package.json to allow tests to run

## Testing
- `cd frontend && npm test`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892a6a246588320bfde2a86eb932578