### PR TITLE
Add onboarding and setup pages for stage 1

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,9 @@ import AdsDashboardPage from './pages/AdsDashboardPage.jsx';
 import AnalyticsAuditPage from './pages/AnalyticsAuditPage.jsx';
 import PaymentPage from './pages/PaymentPage.jsx';
 import SimDashboardPage from './pages/SimDashboardPage.jsx';
+import LandingPage from './pages/LandingPage.jsx';
+import FinancialMediaSetupPage from './pages/FinancialMediaSetupPage.jsx';
+import OnboardingDocumentsPage from './pages/OnboardingDocumentsPage.jsx';
 
 import AdCreateEdit from '../pages/AdCreateEdit.jsx';
 import AdminDashboard from '../pages/AdminDashboard.jsx';
@@ -78,11 +81,11 @@ const PlaceholderPage = ({ title }) => <Box p={4}>{title}</Box>;
 export default function App() {
   const routes = [
     // Entry & Authentication
-    { path: '/', element: <PlaceholderPage title="Landing Page" /> },
+    { path: '/', element: <LandingPage /> },
     { path: '/login', element: <LoginPage /> },
     { path: '/signup', element: <SignupPage /> },
-    { path: '/onboarding/documents', element: <PlaceholderPage title="CV & Cover Letter Upload" /> },
-    { path: '/setup/financial-media', element: <PlaceholderPage title="Financials & Media Setup" /> },
+    { path: '/onboarding/documents', element: <OnboardingDocumentsPage />, protected: true },
+    { path: '/setup/financial-media', element: <FinancialMediaSetupPage />, protected: true },
 
     // Core User Hub
     { path: '/dashboard', element: <PlaceholderPage title="Home Dashboard" />, protected: true },

--- a/frontend/src/api/resume.js
+++ b/frontend/src/api/resume.js
@@ -1,0 +1,34 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function uploadCv(file) {
+  const formData = new FormData();
+  formData.append('cv', file);
+  const { data } = await apiClient.post('/resume/cv/upload', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
+  return data;
+}
+
+export async function generateCv(prompt) {
+  const { data } = await apiClient.post('/resume/cv/generate', { prompt });
+  return data;
+}
+
+export async function uploadCoverLetter(file) {
+  const formData = new FormData();
+  formData.append('coverLetter', file);
+  const { data } = await apiClient.post('/resume/cover-letter/upload', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
+  return data;
+}
+
+export async function generateCoverLetter(prompt) {
+  const { data } = await apiClient.post('/resume/cover-letter/generate', { prompt });
+  return data;
+}
+
+export async function fetchResume() {
+  const { data } = await apiClient.get('/resume');
+  return data;
+}

--- a/frontend/src/api/userSetup.js
+++ b/frontend/src/api/userSetup.js
@@ -1,0 +1,11 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function saveFinancialMedia(userId, payload) {
+  const { data } = await apiClient.post(`/user-setup/${userId}/financial-media`, payload);
+  return data;
+}
+
+export async function getFinancialMedia(userId) {
+  const { data } = await apiClient.get(`/user-setup/${userId}/financial-media`);
+  return data;
+}

--- a/frontend/src/components/NavMenu.jsx
+++ b/frontend/src/components/NavMenu.jsx
@@ -2,8 +2,11 @@ import React from 'react';
 import { Box, VStack, Link, Text } from '@chakra-ui/react';
 import { NavLink } from 'react-router-dom';
 import { menu } from '../nav/menu.js';
+import { useAuth } from '../context/AuthContext.jsx';
 
 export default function NavMenu() {
+  const { user } = useAuth();
+  if (!user) return null;
   return (
     <Box as="aside" w="250px" p={4} bg="gray.50" h="100vh" overflowY="auto">
       {menu.map((section) => (

--- a/frontend/src/pages/FinancialMediaSetupPage.jsx
+++ b/frontend/src/pages/FinancialMediaSetupPage.jsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Heading,
+  Input,
+  Textarea,
+  VStack,
+  useToast
+} from '@chakra-ui/react';
+import { useAuth } from '../context/AuthContext.jsx';
+import { saveFinancialMedia } from '../api/userSetup.js';
+import '../styles/FinancialMediaSetupPage.css';
+
+export default function FinancialMediaSetupPage() {
+  const { user } = useAuth();
+  const toast = useToast();
+  const [form, setForm] = useState({
+    paymentMethod: '',
+    taxId: '',
+    vatNumber: '',
+    bio: '',
+    portfolioLinks: '',
+    title: ''
+  });
+  const [profilePic, setProfilePic] = useState(null);
+  const [introVideo, setIntroVideo] = useState(null);
+
+  const handleChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const fileToBase64 = (file) =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result.split(',')[1]);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+
+  const handleSubmit = async () => {
+    const payload = {
+      paymentMethod: form.paymentMethod,
+      taxId: form.taxId || undefined,
+      vatNumber: form.vatNumber || undefined,
+      bio: form.bio,
+      portfolioLinks: form.portfolioLinks
+        ? form.portfolioLinks.split(',').map((s) => s.trim()).filter(Boolean)
+        : [],
+      title: form.title || undefined,
+    };
+    if (profilePic) payload.profilePicture = await fileToBase64(profilePic);
+    if (introVideo) payload.introVideo = await fileToBase64(introVideo);
+    try {
+      await saveFinancialMedia(user.id, payload);
+      toast({ title: 'Setup saved', status: 'success', duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({ title: 'Save failed', status: 'error', description: err.message });
+    }
+  };
+
+  return (
+    <Box className="financial-media-page" maxW="xl" mx="auto" p={6}>
+      <Heading mb={6} textAlign="center">Financial & Media Setup</Heading>
+      <VStack spacing={4} align="stretch">
+        <FormControl isRequired>
+          <FormLabel>Payment Method</FormLabel>
+          <Input
+            name="paymentMethod"
+            value={form.paymentMethod}
+            onChange={handleChange}
+            placeholder="Card number"
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Tax ID</FormLabel>
+          <Input name="taxId" value={form.taxId} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>VAT Number</FormLabel>
+          <Input name="vatNumber" value={form.vatNumber} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Title</FormLabel>
+          <Input name="title" value={form.title} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Bio</FormLabel>
+          <Textarea name="bio" value={form.bio} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Portfolio Links (comma separated)</FormLabel>
+          <Input
+            name="portfolioLinks"
+            value={form.portfolioLinks}
+            onChange={handleChange}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Profile Picture</FormLabel>
+          <Input type="file" accept="image/*" onChange={(e) => setProfilePic(e.target.files[0])} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Intro Video</FormLabel>
+          <Input type="file" accept="video/*" onChange={(e) => setIntroVideo(e.target.files[0])} />
+        </FormControl>
+        <Button colorScheme="teal" onClick={handleSubmit}>Save</Button>
+      </VStack>
+    </Box>
+  );
+}

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  Heading,
+  Text,
+  VStack,
+  HStack,
+  Icon
+} from '@chakra-ui/react';
+import { CheckCircleIcon } from '@chakra-ui/icons';
+import { useNavigate } from 'react-router-dom';
+import '../styles/LandingPage.css';
+
+export default function LandingPage() {
+  const navigate = useNavigate();
+  return (
+    <Box className="landing-page" textAlign="center" py={20} px={6}>
+      <VStack spacing={8}>
+        <Heading size="2xl">Revolutionize Your Work Journey</Heading>
+        <Text fontSize="lg">
+          Connect, collaborate, and grow with the all-in-one work platform.
+        </Text>
+        <HStack spacing={4}>
+          <Button colorScheme="teal" onClick={() => navigate('/signup')}>Get Started</Button>
+          <Button variant="outline" onClick={() => navigate('/login')}>Login</Button>
+        </HStack>
+        <HStack spacing={8} mt={10} flexWrap="wrap" justify="center">
+          <VStack>
+            <Icon as={CheckCircleIcon} w={8} h={8} color="teal.500" />
+            <Text>AI-Powered Matching</Text>
+          </VStack>
+          <VStack>
+            <Icon as={CheckCircleIcon} w={8} h={8} color="teal.500" />
+            <Text>Integrated Gig Management</Text>
+          </VStack>
+          <VStack>
+            <Icon as={CheckCircleIcon} w={8} h={8} color="teal.500" />
+            <Text>Real-Time Analytics</Text>
+          </VStack>
+        </HStack>
+      </VStack>
+    </Box>
+  );
+}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -8,79 +8,15 @@ import {
   FormLabel,
   Heading,
   Input,
-  Text,
-  useToast
-} from '@chakra-ui/react';
-import { useNavigate } from 'react-router-dom';
-import { login } from '../api/auth.js';
-import { useAuth } from '../context/AuthContext.jsx';
-import NavBar from '../components/NavBar.jsx';
-import '../styles/LoginPage.css';
-
-export default function LoginPage() {
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [use2FA, setUse2FA] = useState(false);
-  const [code, setCode] = useState('');
-  const [error, setError] = useState('');
-  const toast = useToast();
-  const navigate = useNavigate();
-  const { setUser } = useAuth();
-
-  const handleSubmit = async () => {
-    setError('');
-    try {
-      const user = await login({ username, password, code: use2FA ? code : undefined });
-      setUser(user);
-      toast({ title: 'Login successful', status: 'success', duration: 3000, isClosable: true });
-      navigate('/profile');
-    } catch (err) {
-      setError(err.message);
-    }
-  };
-
-  return (
-    <Box>
-      <NavBar />
-      <Flex className="login-page">
-        <Box w="sm" p={8} bg="white" boxShadow="md" borderRadius="md">
-          <Heading mb={6} textAlign="center">Login</Heading>
-          <FormControl id="username" mb={4} isRequired>
-            <FormLabel>Username</FormLabel>
-            <Input value={username} onChange={(e) => setUsername(e.target.value)} />
-          </FormControl>
-          <FormControl id="password" mb={4} isRequired>
-            <FormLabel>Password</FormLabel>
-            <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
-          </FormControl>
-          <Checkbox mb={4} isChecked={use2FA} onChange={(e) => setUse2FA(e.target.checked)}>
-            Use 2FA code
-          </Checkbox>
-          {use2FA && (
-            <FormControl id="code" mb={4} isRequired>
-              <FormLabel>Authentication Code</FormLabel>
-              <Input value={code} onChange={(e) => setCode(e.target.value)} />
-            </FormControl>
-          )}
-          {error && <Text color="red.500" mb={4}>{error}</Text>}
-          <Button colorScheme="blue" w="100%" onClick={handleSubmit}>Login</Button>
-          <Button variant="link" w="100%" mt={4} onClick={() => navigate('/signup')}>
-            Create an account
-          </Button>
-        </Box>
-      </Flex>
-    </Box>
-  );
-}
   Link,
   Stack,
   useToast
 } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
-import '../styles/LoginPage.css';
 import { useAuth } from '../context/AuthContext.jsx';
+import '../styles/LoginPage.css';
 
-function LoginPage() {
+export default function LoginPage() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -120,11 +56,10 @@ function LoginPage() {
               Login
             </Button>
             <Link color="teal.500" href="#">Forgot Password?</Link>
+            <Link color="teal.500" onClick={() => navigate('/signup')}>Create an account</Link>
           </Stack>
         </form>
       </Box>
     </Flex>
   );
 }
-
-export default LoginPage;

--- a/frontend/src/pages/OnboardingDocumentsPage.jsx
+++ b/frontend/src/pages/OnboardingDocumentsPage.jsx
@@ -1,0 +1,118 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Heading,
+  Input,
+  Text,
+  Textarea,
+  VStack,
+  useToast
+} from '@chakra-ui/react';
+import {
+  uploadCv,
+  generateCv,
+  uploadCoverLetter,
+  generateCoverLetter,
+  fetchResume
+} from '../api/resume.js';
+import '../styles/OnboardingDocumentsPage.css';
+
+export default function OnboardingDocumentsPage() {
+  const [cvFile, setCvFile] = useState(null);
+  const [cvPrompt, setCvPrompt] = useState('');
+  const [coverFile, setCoverFile] = useState(null);
+  const [coverPrompt, setCoverPrompt] = useState('');
+  const [resume, setResume] = useState({ cv: null, coverLetter: null });
+  const toast = useToast();
+
+  useEffect(() => {
+    fetchResume().then(setResume).catch(() => {});
+  }, []);
+
+  const handleUploadCv = async () => {
+    if (!cvFile) return;
+    try {
+      await uploadCv(cvFile);
+      const data = await fetchResume();
+      setResume(data);
+      toast({ title: 'CV uploaded', status: 'success', duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({ title: 'Upload failed', status: 'error', description: err.message });
+    }
+  };
+
+  const handleGenerateCv = async () => {
+    try {
+      const { content } = await generateCv(cvPrompt);
+      setResume((prev) => ({ ...prev, cv: { content } }));
+    } catch (err) {
+      toast({ title: 'Generation failed', status: 'error', description: err.message });
+    }
+  };
+
+  const handleUploadCover = async () => {
+    if (!coverFile) return;
+    try {
+      await uploadCoverLetter(coverFile);
+      const data = await fetchResume();
+      setResume(data);
+      toast({ title: 'Cover letter uploaded', status: 'success', duration: 3000, isClosable: true });
+    } catch (err) {
+      toast({ title: 'Upload failed', status: 'error', description: err.message });
+    }
+  };
+
+  const handleGenerateCover = async () => {
+    try {
+      const { content } = await generateCoverLetter(coverPrompt);
+      setResume((prev) => ({ ...prev, coverLetter: { content } }));
+    } catch (err) {
+      toast({ title: 'Generation failed', status: 'error', description: err.message });
+    }
+  };
+
+  return (
+    <Box className="documents-page" maxW="xl" mx="auto" p={6}>
+      <Heading mb={6} textAlign="center">CV & Cover Letter</Heading>
+      <VStack align="stretch" spacing={6}>
+        <Box>
+          <Heading size="md" mb={4}>Curriculum Vitae</Heading>
+          {resume.cv?.filename && <Text mb={2}>Uploaded: {resume.cv.filename}</Text>}
+          {resume.cv?.content && (
+            <Textarea value={resume.cv.content} readOnly mb={2} />
+          )}
+          <FormControl mb={2}>
+            <FormLabel>Upload CV</FormLabel>
+            <Input type="file" onChange={(e) => setCvFile(e.target.files[0])} />
+          </FormControl>
+          <Button onClick={handleUploadCv} mr={2} colorScheme="teal">Upload</Button>
+          <FormControl mt={4}>
+            <FormLabel>Generate CV</FormLabel>
+            <Textarea value={cvPrompt} onChange={(e) => setCvPrompt(e.target.value)} />
+          </FormControl>
+          <Button onClick={handleGenerateCv} mt={2} colorScheme="teal">Generate</Button>
+        </Box>
+        <Box>
+          <Heading size="md" mb={4}>Cover Letter</Heading>
+          {resume.coverLetter?.filename && <Text mb={2}>Uploaded: {resume.coverLetter.filename}</Text>}
+          {resume.coverLetter?.content && (
+            <Textarea value={resume.coverLetter.content} readOnly mb={2} />
+          )}
+          <FormControl mb={2}>
+            <FormLabel>Upload Cover Letter</FormLabel>
+            <Input type="file" onChange={(e) => setCoverFile(e.target.files[0])} />
+          </FormControl>
+          <Button onClick={handleUploadCover} mr={2} colorScheme="teal">Upload</Button>
+          <FormControl mt={4}>
+            <FormLabel>Generate Cover Letter</FormLabel>
+            <Textarea value={coverPrompt} onChange={(e) => setCoverPrompt(e.target.value)} />
+          </FormControl>
+          <Button onClick={handleGenerateCover} mt={2} colorScheme="teal">Generate</Button>
+        </Box>
+      </VStack>
+    </Box>
+  );
+}

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -15,7 +15,6 @@ import {
 } from '@chakra-ui/react';
 import ReCAPTCHA from 'react-google-recaptcha';
 import { useNavigate } from 'react-router-dom';
-import NavBar from '../components/NavBar.jsx';
 import { register } from '../api/auth.js';
 import '../styles/SignupPage.css';
 
@@ -63,61 +62,58 @@ export default function SignupPage() {
   };
 
   return (
-    <Box>
-      <NavBar />
-      <Flex className="signup-page">
-        <Box w="lg" p={8} bg="white" boxShadow="md" borderRadius="md">
-          <Progress value={33} mb={6} />
-          <Heading mb={6} textAlign="center">Create Your Account</Heading>
-          <FormControl id="fullName" mb={4} isRequired>
-            <FormLabel>Full Name</FormLabel>
-            <Input name="fullName" value={form.fullName} onChange={handleChange} />
-          </FormControl>
-          <FormControl id="email" mb={4} isRequired>
-            <FormLabel>Email Address</FormLabel>
-            <Input type="email" name="email" value={form.email} onChange={handleChange} />
-          </FormControl>
-          <FormControl id="phone" mb={4} isRequired>
-            <FormLabel>Phone Number</FormLabel>
-            <Input type="tel" name="phone" value={form.phone} onChange={handleChange} />
-          </FormControl>
-          <FormControl id="username" mb={4} isRequired>
-            <FormLabel>Username</FormLabel>
-            <Input name="username" value={form.username} onChange={handleChange} />
-          </FormControl>
-          <FormControl id="password" mb={4} isRequired>
-            <FormLabel>Password</FormLabel>
-            <Input type="password" name="password" value={form.password} onChange={handleChange} />
-          </FormControl>
-          <FormControl id="location" mb={4} isRequired>
-            <FormLabel>Location</FormLabel>
-            <HStack>
-              <Input name="location" value={form.location} onChange={handleChange} />
-              <Button onClick={detectLocation}>Use my location</Button>
-            </HStack>
-          </FormControl>
-          <FormControl id="bio" mb={4} isRequired>
-            <FormLabel>Professional Bio</FormLabel>
-            <Textarea name="bio" value={form.bio} onChange={handleChange} />
-          </FormControl>
-          <FormControl id="expertise" mb={4}>
-            <FormLabel>Expertise (Optional)</FormLabel>
-            <Input name="expertise" value={form.expertise} onChange={handleChange} />
-          </FormControl>
-          <ReCAPTCHA
-            sitekey={import.meta.env.VITE_RECAPTCHA_SITE_KEY}
-            onChange={setRecaptchaToken}
-            className="recaptcha"
-          />
-          {error && <Text color="red.500" mb={4}>{error}</Text>}
-          <Button colorScheme="blue" w="100%" onClick={handleSubmit} isLoading={loading} mt={4}>
-            Sign Up
-          </Button>
-          <Button variant="link" w="100%" mt={4} onClick={() => navigate('/login')}>
-            Already have an account? Login
-          </Button>
-        </Box>
-      </Flex>
-    </Box>
+    <Flex className="signup-page">
+      <Box w="lg" p={8} bg="white" boxShadow="md" borderRadius="md">
+        <Progress value={33} mb={6} />
+        <Heading mb={6} textAlign="center">Create Your Account</Heading>
+        <FormControl id="fullName" mb={4} isRequired>
+          <FormLabel>Full Name</FormLabel>
+          <Input name="fullName" value={form.fullName} onChange={handleChange} />
+        </FormControl>
+        <FormControl id="email" mb={4} isRequired>
+          <FormLabel>Email Address</FormLabel>
+          <Input type="email" name="email" value={form.email} onChange={handleChange} />
+        </FormControl>
+        <FormControl id="phone" mb={4} isRequired>
+          <FormLabel>Phone Number</FormLabel>
+          <Input type="tel" name="phone" value={form.phone} onChange={handleChange} />
+        </FormControl>
+        <FormControl id="username" mb={4} isRequired>
+          <FormLabel>Username</FormLabel>
+          <Input name="username" value={form.username} onChange={handleChange} />
+        </FormControl>
+        <FormControl id="password" mb={4} isRequired>
+          <FormLabel>Password</FormLabel>
+          <Input type="password" name="password" value={form.password} onChange={handleChange} />
+        </FormControl>
+        <FormControl id="location" mb={4} isRequired>
+          <FormLabel>Location</FormLabel>
+          <HStack>
+            <Input name="location" value={form.location} onChange={handleChange} />
+            <Button onClick={detectLocation}>Use my location</Button>
+          </HStack>
+        </FormControl>
+        <FormControl id="bio" mb={4} isRequired>
+          <FormLabel>Professional Bio</FormLabel>
+          <Textarea name="bio" value={form.bio} onChange={handleChange} />
+        </FormControl>
+        <FormControl id="expertise" mb={4}>
+          <FormLabel>Expertise (Optional)</FormLabel>
+          <Input name="expertise" value={form.expertise} onChange={handleChange} />
+        </FormControl>
+        <ReCAPTCHA
+          sitekey={import.meta.env.VITE_RECAPTCHA_SITE_KEY}
+          onChange={setRecaptchaToken}
+          className="recaptcha"
+        />
+        {error && <Text color="red.500" mb={4}>{error}</Text>}
+        <Button colorScheme="blue" w="100%" onClick={handleSubmit} isLoading={loading} mt={4}>
+          Sign Up
+        </Button>
+        <Button variant="link" w="100%" mt={4} onClick={() => navigate('/login')}>
+          Already have an account? Login
+        </Button>
+      </Box>
+    </Flex>
   );
 }

--- a/frontend/src/styles/FinancialMediaSetupPage.css
+++ b/frontend/src/styles/FinancialMediaSetupPage.css
@@ -1,0 +1,3 @@
+.financial-media-page {
+  background-color: #f7fafc;
+}

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -1,0 +1,7 @@
+.landing-page {
+  background: linear-gradient(135deg, #e6f7ff 0%, #ffffff 100%);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/frontend/src/styles/OnboardingDocumentsPage.css
+++ b/frontend/src/styles/OnboardingDocumentsPage.css
@@ -1,0 +1,3 @@
+.documents-page {
+  background-color: #f7fafc;
+}


### PR DESCRIPTION
## Summary
- Implement landing page with CTA and value propositions.
- Add financial/media setup and document upload pages integrated with backend APIs.
- Clean login/signup pages and restrict nav menu to authenticated users.

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6892c7d0d2e483209bc8a591bf4d7950