### PR TITLE
Implement stage 3 job listings and messaging pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -42,6 +42,8 @@ import SimDashboardPage from './pages/SimDashboardPage.jsx';
 import LandingPage from './pages/LandingPage.jsx';
 import FinancialMediaSetupPage from './pages/FinancialMediaSetupPage.jsx';
 import OnboardingDocumentsPage from './pages/OnboardingDocumentsPage.jsx';
+import ChatInboxPage from './pages/ChatInboxPage.jsx';
+import JobListingsPage from './pages/JobListingsPage.jsx';
 
 import AdCreateEdit from '../pages/AdCreateEdit.jsx';
 import AdminDashboard from '../pages/AdminDashboard.jsx';
@@ -92,12 +94,12 @@ export default function App() {
     { path: '/feed', element: <PlaceholderPage title="Live Feed" />, protected: true },
     { path: '/profile', element: <ProfilePage />, protected: true },
     { path: '/profile/customize', element: <ProfileCustomizationPage />, protected: true },
-    { path: '/messages', element: <PlaceholderPage title="Chat Inbox" />, protected: true },
+    { path: '/messages', element: <ChatInboxPage />, protected: true },
     { path: '/connections', element: <ConnectionManagementPage />, protected: true },
 
     // Employment & Gigs
     { path: '/employment', element: <PlaceholderPage title="Employment Dashboard" />, protected: true },
-    { path: '/jobs', element: <PlaceholderPage title="Job Listings" />, protected: true },
+    { path: '/jobs', element: <JobListingsPage />, protected: true },
     { path: '/applications-interviews', element: <PlaceholderPage title="Application & Interview Management" />, protected: true },
     { path: '/headhunter/dashboard', element: <PlaceholderPage title="Headhunter Dashboard" />, protected: true },
     { path: '/interview/:id', element: <PlaceholderPage title="Virtual Interview" />, protected: true },

--- a/frontend/src/api/communications.js
+++ b/frontend/src/api/communications.js
@@ -1,0 +1,16 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function fetchConversations() {
+  const { data } = await apiClient.get('/communications/messages/conversations');
+  return data;
+}
+
+export async function fetchMessages(conversationId) {
+  const { data } = await apiClient.get(`/communications/messages/conversation/${conversationId}`);
+  return data;
+}
+
+export async function sendMessage(payload) {
+  const { data } = await apiClient.post('/communications/messages', payload);
+  return data;
+}

--- a/frontend/src/api/jobPostings.js
+++ b/frontend/src/api/jobPostings.js
@@ -1,0 +1,11 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function fetchJobPostings() {
+  const { data } = await apiClient.get('/hr/recruitment/job-postings');
+  return data;
+}
+
+export async function submitJobApplication(payload) {
+  const { data } = await apiClient.post('/hr/recruitment/applications', payload);
+  return data;
+}

--- a/frontend/src/pages/ChatInboxPage.jsx
+++ b/frontend/src/pages/ChatInboxPage.jsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Flex,
+  VStack,
+  HStack,
+  Text,
+  Input,
+  Button,
+  List,
+  ListItem,
+  Spinner,
+  Divider
+} from '@chakra-ui/react';
+import { fetchConversations, fetchMessages, sendMessage } from '../api/communications.js';
+import '../styles/ChatInboxPage.css';
+
+export default function ChatInboxPage() {
+  const [conversations, setConversations] = useState([]);
+  const [activeId, setActiveId] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [messageText, setMessageText] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await fetchConversations();
+        setConversations(data);
+        if (data.length) {
+          selectConversation(data[0].id);
+        }
+      } catch (err) {
+        console.error('Failed to load conversations', err);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  async function selectConversation(id) {
+    setActiveId(id);
+    try {
+      const msgs = await fetchMessages(id);
+      setMessages(msgs);
+    } catch (err) {
+      console.error('Failed to load messages', err);
+    }
+  }
+
+  async function handleSend() {
+    if (!messageText.trim() || !activeId) return;
+    try {
+      const { message } = await sendMessage({ conversationId: activeId, content: messageText });
+      setMessages((prev) => [...prev, message]);
+      setMessageText('');
+    } catch (err) {
+      console.error('Failed to send message', err);
+    }
+  }
+
+  return (
+    <Flex className="chat-inbox-page" h="100vh">
+      <Box w="30%" borderRight="1px solid #e2e8f0" overflowY="auto">
+        <VStack align="stretch" spacing={0}>
+          {loading ? (
+            <Spinner m={4} />
+          ) : (
+            conversations.map((conv) => (
+              <Box
+                key={conv.id}
+                p={4}
+                bg={conv.id === activeId ? 'gray.100' : 'transparent'}
+                cursor="pointer"
+                onClick={() => selectConversation(conv.id)}
+              >
+                <Text fontWeight="bold">{conv.id}</Text>
+                <Text fontSize="sm">Participants: {conv.participants.join(', ')}</Text>
+              </Box>
+            ))
+          )}
+        </VStack>
+      </Box>
+      <Flex direction="column" flex="1" className="chat-inbox-container">
+        <Box flex="1" overflowY="auto" p={4}>
+          <List spacing={3}>
+            {messages.map((msg) => (
+              <ListItem key={msg.id}>
+                <Box bg="gray.50" p={2} borderRadius="md">
+                  <Text fontSize="sm" color="gray.600">
+                    {msg.senderId} - {new Date(msg.createdAt).toLocaleString()}
+                  </Text>
+                  <Text>{msg.content}</Text>
+                </Box>
+              </ListItem>
+            ))}
+          </List>
+        </Box>
+        <Divider />
+        <HStack p={4} spacing={2}>
+          <Input
+            value={messageText}
+            onChange={(e) => setMessageText(e.target.value)}
+            placeholder="Type a message"
+          />
+          <Button colorScheme="teal" onClick={handleSend}>
+            Send
+          </Button>
+        </HStack>
+      </Flex>
+    </Flex>
+  );
+}

--- a/frontend/src/pages/JobListingsPage.jsx
+++ b/frontend/src/pages/JobListingsPage.jsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  Spinner,
+  Text,
+  Button,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton
+} from '@chakra-ui/react';
+import { fetchJobPostings, submitJobApplication } from '../api/jobPostings.js';
+import { useProfile } from '../context/ProfileContext.jsx';
+import '../styles/JobListingsPage.css';
+
+export default function JobListingsPage() {
+  const [jobs, setJobs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState(null);
+  const { profile } = useProfile();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await fetchJobPostings();
+        setJobs(data);
+      } catch (err) {
+        console.error('Failed to load jobs', err);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  async function handleApply(job) {
+    try {
+      await submitJobApplication({ jobId: job.id, applicantName: profile?.name || 'Anonymous' });
+      alert('Application submitted');
+      setSelected(null);
+    } catch (err) {
+      console.error('Failed to apply', err);
+      alert('Failed to apply');
+    }
+  }
+
+  return (
+    <Box className="job-listings-page" p={4}>
+      <Heading size="lg" mb={4}>Job Listings</Heading>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <SimpleGrid columns={[1, 2, 3]} spacing={4}>
+          {jobs.map((job) => (
+            <Box
+              key={job.id}
+              p={4}
+              borderWidth="1px"
+              borderRadius="md"
+              bg="white"
+              boxShadow="sm"
+              _hover={{ boxShadow: 'md' }}
+              cursor="pointer"
+              onClick={() => setSelected(job)}
+            >
+              <Heading size="md">{job.title}</Heading>
+              {job.location && <Text mt={2}>{job.location}</Text>}
+            </Box>
+          ))}
+        </SimpleGrid>
+      )}
+
+      <Modal isOpen={!!selected} onClose={() => setSelected(null)}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>{selected?.title}</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            <Text mb={3}>{selected?.description}</Text>
+            {selected?.budget && <Text>Budget: {selected.budget}</Text>}
+            {selected?.deadline && (
+              <Text>Deadline: {new Date(selected.deadline).toLocaleDateString()}</Text>
+            )}
+            <Button mt={4} colorScheme="teal" onClick={() => handleApply(selected)}>
+              Apply Now
+            </Button>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </Box>
+  );
+}

--- a/frontend/src/styles/ChatInboxPage.css
+++ b/frontend/src/styles/ChatInboxPage.css
@@ -1,0 +1,6 @@
+.chat-inbox-page {
+  background: #f4f7f9;
+}
+.chat-inbox-container {
+  height: calc(100vh - 64px);
+}

--- a/frontend/src/styles/JobListingsPage.css
+++ b/frontend/src/styles/JobListingsPage.css
@@ -1,0 +1,3 @@
+.job-listings-page {
+  background: #f7fafc;
+}


### PR DESCRIPTION
## Summary
- add Chakra-based chat inbox with conversation and messaging functionality
- implement job listings page that consumes HR recruitment APIs and allows applying to jobs
- wire new pages into app routing and create API modules for communications and job postings

## Testing
- `cd frontend && npm test`
- `cd ../backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892ce2ae0548320b4d378ff78ffa94d