### PR TITLE
feat: implement basic virtual interview workflow

### DIFF
--- a/frontend/api/interviews.js
+++ b/frontend/api/interviews.js
@@ -1,50 +1,49 @@
-(function(global){
-  async function scheduleInterview(data){
-    const res = await apiFetch('/api/interviews', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data)
-    });
-    if(!res.ok) throw new Error('Failed to schedule interview');
-    return res.json();
-  }
+const API_BASE_URL = window.API_BASE_URL || '/api';
 
-  async function getUserInterviews(){
-    const res = await apiFetch('/api/interviews/user');
-    if(!res.ok) throw new Error('Failed to load interviews');
-    return res.json();
+async function request(path, options = {}) {
+  const token = localStorage.getItem('token');
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...options.headers,
+  };
+  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message || 'Request failed');
   }
+  return res.json();
+}
 
-  async function getEmployerInterviews(){
-    const res = await apiFetch('/api/interviews/employer');
-    if(!res.ok) throw new Error('Failed to load interviews');
-    return res.json();
-  }
+export function scheduleInterview(data) {
+  return request('/interviews', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
 
-  async function updateInterviewStatus(id, status){
-    const res = await apiFetch(`/api/interviews/${id}/status`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ status })
-    });
-    if(!res.ok) throw new Error('Failed to update status');
-    return res.json();
-  }
+export function getUserInterviews() {
+  return request('/interviews/user');
+}
 
-  global.interviewAPI = { scheduleInterview, getUserInterviews, getEmployerInterviews, updateInterviewStatus };
-  async function getInterview(id){
-    const res = await apiFetch(`/api/interviews/${id}`);
-    if(!res.ok) throw new Error('Failed to load interview');
-    return res.json();
-  }
-  async function addNote(id, text){
-    const res = await apiFetch(`/api/interviews/${id}/notes`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text })
-    });
-    if(!res.ok) throw new Error('Failed to add note');
-    return res.json();
-  }
-  global.interviewAPI = { getInterview, addNote };
-})(window);
+export function getEmployerInterviews() {
+  return request('/interviews/employer');
+}
+
+export function updateInterviewStatus(id, status) {
+  return request(`/interviews/${id}/status`, {
+    method: 'PUT',
+    body: JSON.stringify({ status }),
+  });
+}
+
+export function getInterview(id) {
+  return request(`/interviews/${id}`);
+}
+
+export function addNote(id, text) {
+  return request(`/interviews/${id}/notes`, {
+    method: 'POST',
+    body: JSON.stringify({ text }),
+  });
+}

--- a/frontend/components/InterviewForm.jsx
+++ b/frontend/components/InterviewForm.jsx
@@ -1,0 +1,35 @@
+import { Box, Button, FormControl, FormLabel, Input, Stack } from '@chakra-ui/react';
+import { useState } from 'react';
+import '../styles/InterviewForm.css';
+
+export default function InterviewForm({ onSchedule }) {
+  const [form, setForm] = useState({ candidate: '', datetime: '' });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSchedule(form);
+    setForm({ candidate: '', datetime: '' });
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit} className="interview-form">
+      <Stack spacing={3}>
+        <FormControl isRequired>
+          <FormLabel>Candidate Email</FormLabel>
+          <Input name="candidate" value={form.candidate} onChange={handleChange} />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Date &amp; Time</FormLabel>
+          <Input type="datetime-local" name="datetime" value={form.datetime} onChange={handleChange} />
+        </FormControl>
+        <Button colorScheme="teal" type="submit">Schedule</Button>
+      </Stack>
+    </Box>
+  );
+}
+

--- a/frontend/components/InterviewList.jsx
+++ b/frontend/components/InterviewList.jsx
@@ -1,0 +1,30 @@
+import { Box, Button, Heading, HStack, Text, VStack } from '@chakra-ui/react';
+import '../styles/InterviewList.css';
+
+export default function InterviewList({ interviews, onStatus }) {
+  if (!interviews.length) {
+    return <Text className="interview-empty">No interviews scheduled.</Text>;
+  }
+
+  return (
+    <VStack spacing={4} align="stretch" className="interview-list">
+      {interviews.map((iv) => (
+        <Box key={iv.id} p={4} borderWidth="1px" borderRadius="md">
+          <HStack justify="space-between">
+            <Heading size="sm">{iv.candidate}</Heading>
+            <Text>{new Date(iv.datetime).toLocaleString()}</Text>
+          </HStack>
+          <HStack mt={2} justify="space-between">
+            <Text>Status: {iv.status}</Text>
+            {onStatus && (
+              <Button size="sm" onClick={() => onStatus(iv.id, 'completed')}>
+                Mark Complete
+              </Button>
+            )}
+          </HStack>
+        </Box>
+      ))}
+    </VStack>
+  );
+}
+

--- a/frontend/pages/VirtualInterview.jsx
+++ b/frontend/pages/VirtualInterview.jsx
@@ -1,0 +1,57 @@
+import { ChakraProvider, Box, Heading, useToast } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import NavMenu from '../components/NavMenu';
+import InterviewForm from '../components/InterviewForm.jsx';
+import InterviewList from '../components/InterviewList.jsx';
+import { getUserInterviews, scheduleInterview, updateInterviewStatus } from '../api/interviews.js';
+import '../styles/VirtualInterview.css';
+
+export default function VirtualInterview() {
+  const [interviews, setInterviews] = useState([]);
+  const toast = useToast();
+
+  const load = async () => {
+    try {
+      const data = await getUserInterviews();
+      setInterviews(data);
+    } catch (err) {
+      toast({ title: 'Failed to load interviews', status: 'error' });
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleSchedule = async (form) => {
+    try {
+      await scheduleInterview(form);
+      toast({ title: 'Interview scheduled', status: 'success' });
+      load();
+    } catch (err) {
+      toast({ title: 'Scheduling failed', status: 'error' });
+    }
+  };
+
+  const handleStatus = async (id, status) => {
+    try {
+      await updateInterviewStatus(id, status);
+      toast({ title: 'Status updated', status: 'info' });
+      load();
+    } catch (err) {
+      toast({ title: 'Update failed', status: 'error' });
+    }
+  };
+
+  return (
+    <ChakraProvider>
+      <NavMenu />
+      <Box className="virtual-interview-page" p={4}>
+        <Heading mb={4}>Virtual Interview</Heading>
+        <InterviewForm onSchedule={handleSchedule} />
+        <InterviewList interviews={interviews} onStatus={handleStatus} />
+      </Box>
+    </ChakraProvider>
+  );
+}
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -59,6 +59,7 @@ import PaymentTimesheetManagement from '../pages/PaymentTimesheetManagement.jsx'
 import EducationDashboard from '../pages/EducationDashboard.jsx';
 import WorkspaceDashboard from '../pages/WorkspaceDashboard.jsx';
 import JobPostManagement from '../pages/JobPostManagement.jsx';
+import VirtualInterview from '../pages/VirtualInterview.jsx';
 
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 import { ProfileProvider } from './context/ProfileContext.jsx';
@@ -102,7 +103,7 @@ export default function App() {
     { path: '/jobs', element: <JobListingsPage />, protected: true },
     { path: '/applications-interviews', element: <PlaceholderPage title="Application & Interview Management" />, protected: true },
     { path: '/headhunter/dashboard', element: <PlaceholderPage title="Headhunter Dashboard" />, protected: true },
-    { path: '/interview/:id', element: <PlaceholderPage title="Virtual Interview" />, protected: true },
+    { path: '/interviews', element: <VirtualInterview />, protected: true },
     { path: '/job-posts', element: <JobPostManagement />, protected: true },
     { path: '/gigs', element: <PlaceholderPage title="Gigs Dashboard" />, protected: true },
     { path: '/gigs/manage', element: <PlaceholderPage title="Gig Creation & Management" />, protected: true },

--- a/frontend/src/nav/menu.js
+++ b/frontend/src/nav/menu.js
@@ -19,7 +19,7 @@ export const menu = [
       { label: 'Employment', path: '/employment' },
       { label: 'Volunteering', path: '/volunteering' },
       { label: 'Applications & Interviews', path: '/applications-interviews' },
-      { label: 'Interview', path: '/interview/1' },
+      { label: 'Interview', path: '/interviews' },
       { label: 'Jobs', path: '/jobs' },
       { label: 'Gigs', path: '/gigs' },
       { label: 'Manage Gigs', path: '/gigs/manage' },

--- a/frontend/styles/InterviewForm.css
+++ b/frontend/styles/InterviewForm.css
@@ -1,0 +1,4 @@
+.interview-form {
+  max-width: 400px;
+}
+

--- a/frontend/styles/InterviewList.css
+++ b/frontend/styles/InterviewList.css
@@ -1,0 +1,8 @@
+.interview-list {
+  width: 100%;
+}
+
+.interview-empty {
+  padding: 1rem;
+}
+

--- a/frontend/styles/VirtualInterview.css
+++ b/frontend/styles/VirtualInterview.css
@@ -1,0 +1,4 @@
+.virtual-interview-page {
+  padding-bottom: 2rem;
+}
+


### PR DESCRIPTION
## Summary
- add modular interviews API
- create virtual interview page with scheduling and status updates
- integrate new page into navigation

## Testing
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_6893352c5ff88320b58503877e35d660