### PR TITLE
Add freelance dashboard and clean service API

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -44,6 +44,7 @@ import FinancialMediaSetupPage from './pages/FinancialMediaSetupPage.jsx';
 import OnboardingDocumentsPage from './pages/OnboardingDocumentsPage.jsx';
 import ChatInboxPage from './pages/ChatInboxPage.jsx';
 import JobListingsPage from './pages/JobListingsPage.jsx';
+import FreelanceDashboardPage from './pages/FreelanceDashboardPage.jsx';
 
 import AdCreateEdit from '../pages/AdCreateEdit.jsx';
 import AdminDashboard from '../pages/AdminDashboard.jsx';
@@ -107,7 +108,8 @@ export default function App() {
     { path: '/job-posts', element: <JobPostManagement />, protected: true },
     { path: '/gigs', element: <PlaceholderPage title="Gigs Dashboard" />, protected: true },
     { path: '/gigs/manage', element: <PlaceholderPage title="Gig Creation & Management" />, protected: true },
-    { path: '/gigs/search', element: <PlaceholderPage title="Gig Search & Discovery" />, protected: true },
+    { path: '/gigs/search', element: <ServiceSearchPage />, protected: true },
+    { path: '/gigs/:id', element: <ServiceDetailPage />, protected: true },
     { path: '/orders', element: <OrderManagementPage />, protected: true },
     { path: '/payments', element: <PaymentPage />, protected: true },
     { path: '/ads', element: <AdsDashboardPage />, protected: true },
@@ -115,6 +117,7 @@ export default function App() {
     { path: '/ads/:adId/edit', element: <AdCreateEdit />, protected: true },
 
     // Contracts & Freelancing
+    { path: '/freelance', element: <FreelanceDashboardPage />, protected: true },
     { path: '/contracts', element: <ContractManagementPage />, protected: true },
     { path: '/contracts/new', element: <ContractFormPage />, protected: true },
     { path: '/proposals-invoices', element: <ProposalInvoiceManagement />, protected: true },

--- a/frontend/src/api/services.js
+++ b/frontend/src/api/services.js
@@ -1,57 +1,31 @@
 import apiClient from '../utils/apiClient.js';
 
-export async function getServices(sellerId) {
-  const { data } = await apiClient.get('/service-providers/services', {
-    params: { sellerId },
-  });
+export async function searchServices(params = {}) {
+  const { data } = await apiClient.get('/marketplace/services', { params });
+  return data;
+}
+
+export async function getService(id) {
+  const { data } = await apiClient.get(`/marketplace/services/${id}`);
+  return data;
+}
+
+export async function getServices({ sellerId } = {}) {
+  const { data } = await apiClient.get('/service-providers/services', { params: { sellerId } });
+  return data;
+}
+
+export async function createService(service) {
+  const { data } = await apiClient.post('/service-providers/services', service);
   return data;
 }
 
 export async function updateService(id, updates) {
   const { data } = await apiClient.put(`/service-providers/services/${id}`, updates);
   return data;
-import axios from 'axios';
-
-const BASE_URL = window.env.API_BASE_URL;
-
-export async function createService(data) {
-  const token = localStorage.getItem('token');
-  const res = await axios.post(`${BASE_URL}/service-providers/services`, data, {
-    headers: { Authorization: `Bearer ${token}` },
-const API_URL = import.meta.env.VITE_API_URL || '';
-
-function authHeader() {
-  const token = localStorage.getItem('token');
-  return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
-export async function searchServices(params = {}) {
-  const res = await axios.get(`${API_URL}/marketplace/services`, {
-    params,
-    headers: authHeader(),
-  });
-  return res.data;
-}
-
-export async function updateService(serviceId, data) {
-  const token = localStorage.getItem('token');
-  const res = await axios.put(`${BASE_URL}/service-providers/services/${serviceId}`, data, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  return res.data;
-}
-export async function getService(id) {
-  const res = await axios.get(`${API_URL}/marketplace/services/${id}`, {
-    headers: authHeader(),
-  });
-  return res.data;
 }
 
 export async function requestService(serviceId, description = '') {
-  const res = await axios.post(
-    `${API_URL}/marketplace/services/request`,
-    { serviceId, description },
-    { headers: authHeader() }
-  );
-  return res.data;
+  const { data } = await apiClient.post('/marketplace/services/request', { serviceId, description });
+  return data;
 }

--- a/frontend/src/nav/menu.js
+++ b/frontend/src/nav/menu.js
@@ -33,6 +33,7 @@ export const menu = [
       { label: 'Proposals & Invoices', path: '/proposals-invoices' },
       { label: 'Orders', path: '/orders' },
       { label: 'Payments', path: '/payments' },
+      { label: 'Freelance Dashboard', path: '/freelance' },
       { label: 'Contracts', path: '/contracts' },
       { label: 'New Contract', path: '/contracts/new' },
       { label: 'Services', path: '/services' },

--- a/frontend/src/pages/FreelanceDashboardPage.jsx
+++ b/frontend/src/pages/FreelanceDashboardPage.jsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  Stat,
+  StatLabel,
+  StatNumber,
+  Switch,
+  FormControl,
+  FormLabel
+} from '@chakra-ui/react';
+import NavBar from '../components/NavBar.jsx';
+import NavMenu from '../components/NavMenu.jsx';
+import '../styles/FreelanceDashboardPage.css';
+import { getContracts } from '../api/contracts.js';
+import { getOrders } from '../api/orders.js';
+
+export default function FreelanceDashboardPage() {
+  const [mode, setMode] = useState('client');
+  const [contracts, setContracts] = useState([]);
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [c, o] = await Promise.all([
+          getContracts(),
+          getOrders(),
+        ]);
+        setContracts(c);
+        setOrders(o);
+      } catch (err) {
+        console.error('Failed to load dashboard data', err);
+      }
+    }
+    load();
+  }, []);
+
+  const activeContracts = contracts.filter(c => c.status === 'active').length;
+  const pendingContracts = contracts.filter(c => c.status === 'pending').length;
+  const totalSpend = orders.reduce((sum, o) => sum + (o.amount || 0), 0);
+  const totalEarnings = orders.reduce((sum, o) => sum + (o.payout || 0), 0);
+
+  return (
+    <Box className="freelance-dashboard-page">
+      <NavBar />
+      <NavMenu />
+      <Box p={4}>
+        <Heading mb={4}>Freelance Dashboard</Heading>
+        <FormControl display="flex" alignItems="center" mb={6}>
+          <FormLabel htmlFor="mode-switch" mb="0">
+            {mode === 'client' ? 'Client View' : 'Freelancer View'}
+          </FormLabel>
+          <Switch id="mode-switch" onChange={e => setMode(e.target.checked ? 'freelancer' : 'client')} />
+        </FormControl>
+        <SimpleGrid columns={[1, 2, 3]} spacing={4}>
+          <Stat>
+            <StatLabel>Active Contracts</StatLabel>
+            <StatNumber>{activeContracts}</StatNumber>
+          </Stat>
+          <Stat>
+            <StatLabel>{mode === 'client' ? 'Total Spend' : 'Total Earnings'}</StatLabel>
+            <StatNumber>${mode === 'client' ? totalSpend : totalEarnings}</StatNumber>
+          </Stat>
+          <Stat>
+            <StatLabel>Pending Contracts</StatLabel>
+            <StatNumber>{pendingContracts}</StatNumber>
+          </Stat>
+        </SimpleGrid>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/pages/ServiceSearchPage.jsx
+++ b/frontend/src/pages/ServiceSearchPage.jsx
@@ -85,7 +85,7 @@ export default function ServiceSearchPage() {
             borderWidth="1px"
             borderRadius="md"
             overflow="hidden"
-            onClick={() => navigate(`/services/${svc.id}`)}
+            onClick={() => navigate(`/gigs/${svc.id}`)}
             cursor="pointer"
           >
             <Image src={svc.image} alt={svc.name} className="service-image" />

--- a/frontend/styles/FreelanceDashboardPage.css
+++ b/frontend/styles/FreelanceDashboardPage.css
@@ -1,0 +1,5 @@
+.freelance-dashboard-page .chakra-stat {
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  padding: 1rem;
+}


### PR DESCRIPTION
## Summary
- streamline service API module with consistent `apiClient` usage
- introduce combined client/freelancer dashboard with contract and order stats
- wire up gig search, detail, and dashboard routes and menu entry

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689338ebf41c8320b4f25797956316e8