### PR TITLE
feat: fetch landing content from API

### DIFF
--- a/frontend/src/api/landing.js
+++ b/frontend/src/api/landing.js
@@ -1,0 +1,6 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function getLandingContent() {
+  const { data } = await apiClient.get('/landing/content');
+  return data;
+}

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -1,45 +1,107 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Box,
   Button,
   Heading,
   Text,
-  VStack,
   HStack,
-  Icon
+  Flex,
+  Grid,
+  Stack,
+  Image
 } from '@chakra-ui/react';
-import { CheckCircleIcon } from '@chakra-ui/icons';
 import { useNavigate } from 'react-router-dom';
+import { getLandingContent } from '../api/landing.js';
 import '../styles/LandingPage.css';
 
 export default function LandingPage() {
+  const [features, setFeatures] = useState([]);
+  const [testimonials, setTestimonials] = useState([]);
+  const [partners, setPartners] = useState([]);
+  const [badges, setBadges] = useState([]);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    getLandingContent()
+      .then((data) => {
+        setFeatures(data.features || []);
+        setTestimonials(data.testimonials || []);
+        setPartners(data.partners || []);
+        setBadges(data.badges || []);
+      })
+      .catch(() => {});
+  }, []);
+
   return (
-    <Box className="landing-page" textAlign="center" py={20} px={6}>
-      <VStack spacing={8}>
-        <Heading size="2xl">Revolutionize Your Work Journey</Heading>
-        <Text fontSize="lg">
-          Connect, collaborate, and grow with the all-in-one work platform.
-        </Text>
+    <Box>
+      <HStack as="header" className="landing-header" justify="space-between" align="center" p={4} boxShadow="sm" position="sticky" top="0" bg="white" zIndex="1000">
+        <Heading size="md">Workhouse</Heading>
         <HStack spacing={4}>
-          <Button colorScheme="teal" onClick={() => navigate('/signup')}>Get Started</Button>
-          <Button variant="outline" onClick={() => navigate('/login')}>Login</Button>
+          <Button variant="ghost" onClick={() => navigate('/login')}>Login</Button>
+          <Button colorScheme="teal" onClick={() => navigate('/signup')}>Sign Up</Button>
         </HStack>
-        <HStack spacing={8} mt={10} flexWrap="wrap" justify="center">
-          <VStack>
-            <Icon as={CheckCircleIcon} w={8} h={8} color="teal.500" />
-            <Text>AI-Powered Matching</Text>
-          </VStack>
-          <VStack>
-            <Icon as={CheckCircleIcon} w={8} h={8} color="teal.500" />
-            <Text>Integrated Gig Management</Text>
-          </VStack>
-          <VStack>
-            <Icon as={CheckCircleIcon} w={8} h={8} color="teal.500" />
-            <Text>Real-Time Analytics</Text>
-          </VStack>
-        </HStack>
-      </VStack>
+      </HStack>
+      <Box as="main">
+        <Flex className="hero" direction="column" align="center" justify="center" textAlign="center" p={8}>
+          <Heading mb={4}>Revolutionize Your Recruitment &amp; Gig Management</Heading>
+          <Text mb={6}>AI-powered platform connecting talent, employers, and service providers.</Text>
+          <Button colorScheme="teal" size="lg" onClick={() => navigate('/signup')}>Get Started</Button>
+        </Flex>
+        <Box py={16} px={8}>
+          <Grid templateColumns={{ base: '1fr', md: 'repeat(3, 1fr)' }} gap={6}>
+            {features.map((f) => (
+              <Box key={f.id} borderWidth="1px" borderRadius="lg" p={6} textAlign="center" bg="white" className="feature-card">
+                {f.icon && <Image src={f.icon} alt="" boxSize="50px" mx="auto" mb={4} />}
+                <Heading size="md" mb={2}>{f.title}</Heading>
+                <Text fontSize="sm" color="gray.600">{f.description}</Text>
+              </Box>
+            ))}
+          </Grid>
+        </Box>
+        <Box bg="gray.50" py={16} px={8}>
+          <Heading size="lg" textAlign="center" mb={8}>What People Say</Heading>
+          <Stack spacing={6} align="center">
+            {testimonials.map((t) => (
+              <Box key={t.id} className="testimonial" textAlign="center">
+                <Text fontStyle="italic" mb={2}>&ldquo;{t.quote}&rdquo;</Text>
+                <Text fontWeight="bold">{t.name}</Text>
+              </Box>
+            ))}
+          </Stack>
+        </Box>
+        <Box py={8} px={8}>
+          <HStack spacing={8} justify="center" flexWrap="wrap">
+            {partners.map((p) => (
+              <Image key={p.id} src={p.logo} alt={p.name} h="50px" />
+            ))}
+          </HStack>
+        </Box>
+        <Box py={16} px={8} textAlign="center">
+          <Heading mb={4}>Ready to Join?</Heading>
+          <Text mb={6}>Start your journey with Workhouse today.</Text>
+          <Button colorScheme="teal" size="lg" onClick={() => navigate('/signup')}>Create Account</Button>
+          <HStack spacing={4} mt={8} justify="center">
+            {badges.map((b) => (
+              <HStack key={b.id} spacing={2}>
+                <Image src={b.image} alt={b.name} boxSize="40px" />
+                <Text>{b.name}</Text>
+              </HStack>
+            ))}
+          </HStack>
+        </Box>
+      </Box>
+      <Box as="footer" className="landing-footer" py={8} textAlign="center" bg="gray.800" color="white">
+        <Stack spacing={2} align="center">
+          <HStack spacing={4}>
+            <a href="#">Terms &amp; Conditions</a>
+            <a href="#">Privacy Policy</a>
+            <a href="#">Support Centre</a>
+            <a href="#">About Us</a>
+            <a href="#">For Investors</a>
+          </HStack>
+          <Text>&copy; {new Date().getFullYear()} Workhouse</Text>
+        </Stack>
+      </Box>
     </Box>
   );
 }

--- a/frontend/styles/LandingPage.css
+++ b/frontend/styles/LandingPage.css
@@ -1,0 +1,16 @@
+.landing-header a {
+  text-decoration: none;
+}
+.hero {
+  background-image: url('https://images.unsplash.com/photo-1521791055366-0d553872125f?auto=format&fit=crop&w=1350&q=80');
+  background-size: cover;
+  background-position: center;
+  color: white;
+  min-height: 60vh;
+}
+.testimonial {
+  max-width: 600px;
+}
+.landing-footer a {
+  color: #ffffff;
+}


### PR DESCRIPTION
## Summary
- load landing page features, testimonials, partners, and badges from backend
- style landing page and expose landing content API client

## Testing
- `cd frontend && npm test`
- `cd ../backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68933c279bc88320868172851bbb8d58