### PR TITLE
Add employment and headhunter dashboards

### DIFF
--- a/frontend/api/headhunter.js
+++ b/frontend/api/headhunter.js
@@ -1,19 +1,27 @@
-(function(global){
-  async function searchJobSeekers(query, token){
-    const res = await fetch(`/api/headhunter/search-job-seekers?query=${encodeURIComponent(query)}`, {
-      headers: { 'Authorization': `Bearer ${token}` }
-    });
-    if(!res.ok) throw new Error('Failed to search job seekers');
-    return res.json();
-  }
+const API_BASE_URL = window.API_BASE_URL || '/api';
 
-  async function getRecommendations(token){
-    const res = await fetch('/api/headhunter/recommendations', {
-      headers: { 'Authorization': `Bearer ${token}` }
-    });
-    if(!res.ok) throw new Error('Failed to load recommendations');
-    return res.json();
+async function request(path, options = {}) {
+  const token = localStorage.getItem('token');
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...options.headers,
+  };
+  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
+  if (!res.ok) {
+    const message = await res.text();
+    throw new Error(message || 'Request failed');
   }
+  return res.json();
+}
 
-  global.headhunterAPI = { searchJobSeekers, getRecommendations };
-})(window);
+export function searchJobSeekers(query) {
+  return request(`/headhunter/search-job-seekers?query=${encodeURIComponent(query)}`);
+}
+
+export function getRecommendations() {
+  return request('/headhunter/recommendations');
+}
+
+export default { searchJobSeekers, getRecommendations };
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,6 +45,9 @@ import OnboardingDocumentsPage from './pages/OnboardingDocumentsPage.jsx';
 import ChatInboxPage from './pages/ChatInboxPage.jsx';
 import JobListingsPage from './pages/JobListingsPage.jsx';
 import FreelanceDashboardPage from './pages/FreelanceDashboardPage.jsx';
+import EmploymentDashboardPage from './pages/EmploymentDashboardPage.jsx';
+import ApplicationInterviewManagementPage from './pages/ApplicationInterviewManagementPage.jsx';
+import HeadhunterDashboardPage from './pages/HeadhunterDashboardPage.jsx';
 
 import AdCreateEdit from '../pages/AdCreateEdit.jsx';
 import AdminDashboard from '../pages/AdminDashboard.jsx';
@@ -100,10 +103,10 @@ export default function App() {
     { path: '/connections', element: <ConnectionManagementPage />, protected: true },
 
     // Employment & Gigs
-    { path: '/employment', element: <PlaceholderPage title="Employment Dashboard" />, protected: true },
+    { path: '/employment', element: <EmploymentDashboardPage />, protected: true },
     { path: '/jobs', element: <JobListingsPage />, protected: true },
-    { path: '/applications-interviews', element: <PlaceholderPage title="Application & Interview Management" />, protected: true },
-    { path: '/headhunter/dashboard', element: <PlaceholderPage title="Headhunter Dashboard" />, protected: true },
+    { path: '/applications-interviews', element: <ApplicationInterviewManagementPage />, protected: true },
+    { path: '/headhunter/dashboard', element: <HeadhunterDashboardPage />, protected: true },
     { path: '/interviews', element: <VirtualInterview />, protected: true },
     { path: '/job-posts', element: <JobPostManagement />, protected: true },
     { path: '/gigs', element: <PlaceholderPage title="Gigs Dashboard" />, protected: true },

--- a/frontend/src/pages/ApplicationInterviewManagementPage.jsx
+++ b/frontend/src/pages/ApplicationInterviewManagementPage.jsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Spinner,
+  Text,
+} from '@chakra-ui/react';
+import { getUserApplications } from '../api/applications.js';
+import { getUserInterviews, getEmployerInterviews } from '../api/interviews.js';
+import { useAuth } from '../context/AuthContext.jsx';
+import '../styles/ApplicationInterviewManagementPage.css';
+
+export default function ApplicationInterviewManagementPage() {
+  const { user } = useAuth();
+  const [applications, setApplications] = useState([]);
+  const [interviews, setInterviews] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const apps = await getUserApplications();
+        const ints = user?.role === 'employer' ? await getEmployerInterviews() : await getUserInterviews();
+        setApplications(apps);
+        setInterviews(ints);
+      } catch (err) {
+        console.error('Failed to load data', err);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [user]);
+
+  if (loading) return <Spinner mt={4} />;
+
+  return (
+    <Box className="application-interview-management-page" p={4}>
+      <Heading size="lg" mb={4}>Applications & Interviews</Heading>
+      <Tabs>
+        <TabList>
+          <Tab>Applications</Tab>
+          <Tab>Interviews</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <Table variant="simple">
+              <Thead>
+                <Tr>
+                  <Th>Job</Th>
+                  <Th>Status</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {applications.map((app) => (
+                  <Tr key={app.id}>
+                    <Td>{app.jobTitle || app.opportunityId}</Td>
+                    <Td>{app.status}</Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+            {!applications.length && <Text mt={4}>No applications yet.</Text>}
+          </TabPanel>
+          <TabPanel>
+            <Table variant="simple">
+              <Thead>
+                <Tr>
+                  <Th>Application</Th>
+                  <Th>Date</Th>
+                  <Th>Status</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {interviews.map((inv) => (
+                  <Tr key={inv.id}>
+                    <Td>{inv.applicationId}</Td>
+                    <Td>{new Date(inv.interviewDate).toLocaleString()}</Td>
+                    <Td>{inv.status}</Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+            {!interviews.length && <Text mt={4}>No interviews scheduled.</Text>}
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Box>
+  );
+}
+

--- a/frontend/src/pages/EmploymentDashboardPage.jsx
+++ b/frontend/src/pages/EmploymentDashboardPage.jsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  Text,
+  SimpleGrid,
+  Stat,
+  StatLabel,
+  StatNumber,
+  Tabs,
+  TabList,
+  Tab,
+  TabPanels,
+  TabPanel,
+  Card,
+  CardBody,
+  Spinner,
+} from '@chakra-ui/react';
+import { getOverview, getJobs, getJob } from '../api/employment.js';
+import '../styles/EmploymentDashboardPage.css';
+
+export default function EmploymentDashboardPage() {
+  const [mode, setMode] = useState('seeker');
+  const [overview, setOverview] = useState(null);
+  const [jobs, setJobs] = useState([]);
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [ov, js] = await Promise.all([getOverview(), getJobs()]);
+        setOverview(ov);
+        setJobs(js);
+      } catch (err) {
+        console.error('Failed to load employment data', err);
+      }
+    })();
+  }, []);
+
+  async function showJob(id) {
+    try {
+      const job = await getJob(id);
+      setSelected(job);
+    } catch (err) {
+      console.error('Failed to load job', err);
+    }
+  }
+
+  return (
+    <Box className="employment-dashboard-page" p={4}>
+      <Heading size="lg" mb={4}>Employment Dashboard</Heading>
+      {!overview ? (
+        <Spinner />
+      ) : (
+        <SimpleGrid columns={[1, 2, 3]} spacing={4} mb={8}>
+          <Stat>
+            <StatLabel>Total Jobs</StatLabel>
+            <StatNumber>{overview.totalJobs}</StatNumber>
+          </Stat>
+          <Stat>
+            <StatLabel>Open Jobs</StatLabel>
+            <StatNumber>{overview.openJobs}</StatNumber>
+          </Stat>
+          <Stat>
+            <StatLabel>Applications</StatLabel>
+            <StatNumber>{overview.totalApplications}</StatNumber>
+          </Stat>
+        </SimpleGrid>
+      )}
+
+      <Tabs onChange={(i) => setMode(i === 0 ? 'seeker' : 'employer')}>
+        <TabList>
+          <Tab>Job Seeker</Tab>
+          <Tab>Employer</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <SimpleGrid columns={[1, 2]} spacing={4}>
+              {jobs.map((job) => (
+                <Card key={job.id} className="job-card" onClick={() => showJob(job.id)}>
+                  <CardBody>
+                    <Heading size="md">{job.title}</Heading>
+                    <Text mt={2}>Status: {job.status}</Text>
+                  </CardBody>
+                </Card>
+              ))}
+            </SimpleGrid>
+            {selected && (
+              <Box mt={6} p={4} borderWidth="1px" borderRadius="md">
+                <Heading size="md" mb={2}>{selected.title}</Heading>
+                <Text>Views: {selected.views}</Text>
+                <Text>Applications: {selected.applications}</Text>
+                <Text>Hires: {selected.hires}</Text>
+              </Box>
+            )}
+          </TabPanel>
+          <TabPanel>
+            <SimpleGrid columns={[1, 2]} spacing={4}>
+              {jobs.map((job) => (
+                <Card key={job.id} className="job-card" onClick={() => showJob(job.id)}>
+                  <CardBody>
+                    <Heading size="md">{job.title}</Heading>
+                    <Text mt={2}>Applications: {job.applications}</Text>
+                    <Text>Hires: {job.hires}</Text>
+                  </CardBody>
+                </Card>
+              ))}
+            </SimpleGrid>
+            {selected && (
+              <Box mt={6} p={4} borderWidth="1px" borderRadius="md">
+                <Heading size="md" mb={2}>{selected.title}</Heading>
+                <Text>Status: {selected.status}</Text>
+                <Text>Views: {selected.views}</Text>
+                <Text>Applications: {selected.applications}</Text>
+                <Text>Hires: {selected.hires}</Text>
+              </Box>
+            )}
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Box>
+  );
+}
+

--- a/frontend/src/pages/HeadhunterDashboardPage.jsx
+++ b/frontend/src/pages/HeadhunterDashboardPage.jsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  Input,
+  Button,
+  List,
+  ListItem,
+  Text,
+  VStack,
+  Spinner,
+} from '@chakra-ui/react';
+import { searchJobSeekers, getRecommendations } from '../api/headhunter.js';
+import '../styles/HeadhunterDashboardPage.css';
+
+export default function HeadhunterDashboardPage() {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        setLoading(true);
+        const recs = await getRecommendations();
+        setResults(recs);
+      } catch (err) {
+        console.error('Failed to load recommendations', err);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  async function handleSearch() {
+    try {
+      setLoading(true);
+      const data = await searchJobSeekers(query);
+      setResults(data);
+    } catch (err) {
+      console.error('Search failed', err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <Box className="headhunter-dashboard-page" p={4}>
+      <Heading size="lg" mb={4}>Headhunter Dashboard</Heading>
+      <VStack align="stretch" spacing={4} mb={4}>
+        <Input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search job seekers" />
+        <Button colorScheme="teal" onClick={handleSearch}>Search</Button>
+      </VStack>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <List spacing={3}>
+          {results.map((c) => (
+            <ListItem key={c.id} p={3} borderWidth="1px" borderRadius="md" bg="white">
+              <Text fontWeight="bold">{c.name || c.id}</Text>
+              {c.skills && <Text fontSize="sm">Skills: {c.skills.join(', ')}</Text>}
+            </ListItem>
+          ))}
+          {!results.length && <Text>No candidates found.</Text>}
+        </List>
+      )}
+    </Box>
+  );
+}
+

--- a/frontend/styles/ApplicationInterviewManagementPage.css
+++ b/frontend/styles/ApplicationInterviewManagementPage.css
@@ -1,0 +1,4 @@
+.application-interview-management-page {
+  background-color: #f7fafc;
+}
+

--- a/frontend/styles/EmploymentDashboardPage.css
+++ b/frontend/styles/EmploymentDashboardPage.css
@@ -1,0 +1,12 @@
+.employment-dashboard-page {
+  background-color: #f7fafc;
+}
+
+.job-card {
+  cursor: pointer;
+}
+
+.job-card:hover {
+  box-shadow: var(--chakra-shadows-md);
+}
+

--- a/frontend/styles/HeadhunterDashboardPage.css
+++ b/frontend/styles/HeadhunterDashboardPage.css
@@ -1,0 +1,4 @@
+.headhunter-dashboard-page {
+  background-color: #f7fafc;
+}
+


### PR DESCRIPTION
## Summary
- implement employment dashboard with stats and job details
- add application & interview management interface
- create headhunter dashboard with candidate search
- refactor headhunter API module and wire new routes

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68933c11892c8320bbd5cc12a9574d73