### PR TITLE
feat: add dashboard and live feed pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { ChakraProvider, Box } from '@chakra-ui/react';
-import NavBar from './components/NavBar.jsx';
-import NavMenu from './components/NavMenu.jsx';
 import LoginPage from './pages/LoginPage.jsx';
 import SignupPage from './pages/SignupPage.jsx';
 import ProfilePage from './pages/ProfilePage.jsx';
@@ -45,6 +43,8 @@ import OnboardingDocumentsPage from './pages/OnboardingDocumentsPage.jsx';
 import ChatInboxPage from './pages/ChatInboxPage.jsx';
 import JobListingsPage from './pages/JobListingsPage.jsx';
 import FreelanceDashboardPage from './pages/FreelanceDashboardPage.jsx';
+import DashboardPage from './pages/DashboardPage.jsx';
+import LiveFeedPage from './pages/LiveFeedPage.jsx';
 
 import AdCreateEdit from '../pages/AdCreateEdit.jsx';
 import AdminDashboard from '../pages/AdminDashboard.jsx';
@@ -92,8 +92,8 @@ export default function App() {
     { path: '/setup/financial-media', element: <FinancialMediaSetupPage />, protected: true },
 
     // Core User Hub
-    { path: '/dashboard', element: <PlaceholderPage title="Home Dashboard" />, protected: true },
-    { path: '/feed', element: <PlaceholderPage title="Live Feed" />, protected: true },
+    { path: '/dashboard', element: <DashboardPage />, protected: true },
+    { path: '/feed', element: <LiveFeedPage />, protected: true },
     { path: '/profile', element: <ProfilePage />, protected: true },
     { path: '/profile/customize', element: <ProfileCustomizationPage />, protected: true },
     { path: '/messages', element: <ChatInboxPage />, protected: true },

--- a/frontend/src/api/dashboard.js
+++ b/frontend/src/api/dashboard.js
@@ -1,0 +1,7 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function getDashboard(role = 'client') {
+  const endpoint = role === 'freelancer' ? '/dashboard/freelancer' : '/dashboard/client';
+  const { data } = await apiClient.get(endpoint);
+  return data;
+}

--- a/frontend/src/api/liveFeed.js
+++ b/frontend/src/api/liveFeed.js
@@ -1,0 +1,22 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function getPosts(category) {
+  const params = category ? { category } : {};
+  const { data } = await apiClient.get('/live-feed/posts', { params });
+  return data;
+}
+
+export async function createPost(payload) {
+  const { data } = await apiClient.post('/live-feed/posts', payload);
+  return data;
+}
+
+export async function getEvents() {
+  const { data } = await apiClient.get('/live-feed/events');
+  return data;
+}
+
+export async function likePost(postId) {
+  const { data } = await apiClient.post(`/live-feed/posts/${postId}/like`);
+  return data;
+}

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -12,8 +12,12 @@ export function AuthProvider({ children }) {
       try {
         const data = await fetchMe();
         setUser(data);
+        if (data?.id) {
+          localStorage.setItem('userId', data.id);
+        }
       } catch {
         setUser(null);
+        localStorage.removeItem('userId');
       } finally {
         setLoading(false);
       }
@@ -23,11 +27,15 @@ export function AuthProvider({ children }) {
 
   async function login(username, password) {
     const data = await apiLogin({ username, password });
+    if (data?.id) {
+      localStorage.setItem('userId', data.id);
+    }
     setUser(data);
   }
 
   function logout() {
     localStorage.removeItem('token');
+    localStorage.removeItem('userId');
     setUser(null);
   }
 

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Heading, SimpleGrid, Stat, StatLabel, StatNumber, Spinner, Button } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+import NavBar from '../components/NavBar.jsx';
+import NavMenu from '../components/NavMenu.jsx';
+import '../styles/DashboardPage.css';
+import { getDashboard } from '../api/dashboard.js';
+import { useAuth } from '../context/AuthContext.jsx';
+
+export default function DashboardPage() {
+  const { user } = useAuth();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const dashboard = await getDashboard(user?.role);
+        setData(dashboard);
+      } catch {
+        setData(null);
+      } finally {
+        setLoading(false);
+      }
+    }
+    if (user) load();
+  }, [user]);
+
+  if (loading) return <Spinner />;
+  if (!data) return <Box p={4}>Unable to load dashboard.</Box>;
+
+  return (
+    <Box className="dashboard-page">
+      <NavBar />
+      <NavMenu />
+      <Box p={4}>
+        <Heading mb={4}>Welcome back, {user?.name || user?.username}</Heading>
+        <Button mb={4} colorScheme="teal" onClick={() => navigate('/feed')}>
+          View Live Feed
+        </Button>
+        <SimpleGrid columns={[1, 3]} spacing={4}>
+          {'totalSpend' in data && (
+            <Stat>
+              <StatLabel>Total Spend</StatLabel>
+              <StatNumber>${data.totalSpend}</StatNumber>
+            </Stat>
+          )}
+          {'totalEarnings' in data && (
+            <Stat>
+              <StatLabel>Total Earnings</StatLabel>
+              <StatNumber>${data.totalEarnings}</StatNumber>
+            </Stat>
+          )}
+          <Stat>
+            <StatLabel>Active Contracts</StatLabel>
+            <StatNumber>{data.activeContracts}</StatNumber>
+          </Stat>
+          <Stat>
+            <StatLabel>Pending Proposals</StatLabel>
+            <StatNumber>{data.pendingProposals}</StatNumber>
+          </Stat>
+        </SimpleGrid>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/pages/LiveFeedPage.jsx
+++ b/frontend/src/pages/LiveFeedPage.jsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Heading, VStack, HStack, Textarea, Button, Text, Spinner } from '@chakra-ui/react';
+import NavBar from '../components/NavBar.jsx';
+import NavMenu from '../components/NavMenu.jsx';
+import '../styles/LiveFeedPage.css';
+import { getPosts, createPost, likePost, getEvents } from '../api/liveFeed.js';
+
+export default function LiveFeedPage() {
+  const [posts, setPosts] = useState([]);
+  const [events, setEvents] = useState([]);
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [p, e] = await Promise.all([getPosts(), getEvents()]);
+        setPosts(p);
+        setEvents(e);
+      } catch (err) {
+        console.error('Failed to load feed', err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  const handlePost = async () => {
+    if (!content.trim()) return;
+    try {
+      const newPost = await createPost({ content });
+      setPosts([newPost, ...posts]);
+      setContent('');
+    } catch (err) {
+      console.error('Post failed', err);
+    }
+  };
+
+  const handleLike = async (id) => {
+    try {
+      const updated = await likePost(id);
+      setPosts(posts.map((p) => (p.id === id ? updated : p)));
+    } catch (err) {
+      console.error('Like failed', err);
+    }
+  };
+
+  if (loading) return <Spinner />;
+
+  return (
+    <Box className="live-feed-page">
+      <NavBar />
+      <NavMenu />
+      <Box p={4} className="feed-content">
+        <Heading mb={4}>Live Feed</Heading>
+        <VStack align="stretch" spacing={2} mb={6}>
+          <Textarea placeholder="Share an update..." value={content} onChange={(e) => setContent(e.target.value)} />
+          <Button alignSelf="flex-end" colorScheme="teal" onClick={handlePost}>
+            Post
+          </Button>
+        </VStack>
+        <HStack align="start" spacing={8} alignItems="flex-start">
+          <VStack flex="1" spacing={4} align="stretch">
+            {posts.map((post) => (
+              <Box key={post.id} p={4} borderWidth="1px" borderRadius="md">
+                <Text mb={2}>{post.content}</Text>
+                <Button size="sm" onClick={() => handleLike(post.id)}>
+                  Like ({post.likes || 0})
+                </Button>
+              </Box>
+            ))}
+          </VStack>
+          <VStack w="250px" spacing={4} align="stretch" className="events-sidebar">
+            <Heading size="sm">Live Events</Heading>
+            {events.map((ev, idx) => (
+              <Box key={idx} p={2} borderWidth="1px" borderRadius="md">
+                {ev.title}
+              </Box>
+            ))}
+          </VStack>
+        </HStack>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -29,7 +29,7 @@ export default function LoginPage() {
     setLoading(true);
     try {
       await login(username, password);
-      navigate('/profile');
+      navigate('/dashboard');
     } catch (err) {
       toast({ title: 'Login failed', status: 'error', description: err.message });
     } finally {

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,81 +1,49 @@
 import React, { useEffect, useState } from 'react';
-import { Box, VStack, Spinner } from '@chakra-ui/react';
-import NavBar from '../components/NavBar.jsx';
-import React, { useEffect } from 'react';
 import { Box, VStack, Spinner, Button } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
+import NavBar from '../components/NavBar.jsx';
+import NavMenu from '../components/NavMenu.jsx';
 import ProfileHeader from '../components/ProfileHeader.jsx';
 import AboutSection from '../components/AboutSection.jsx';
 import ProfessionalDetails from '../components/ProfessionalDetails.jsx';
 import ActivityFeed from '../components/ActivityFeed.jsx';
-import NavMenu from '../components/NavMenu.jsx';
 import '../styles/ProfilePage.css';
 import { getUserProfile } from '../api/profile.js';
 import { useAuth } from '../context/AuthContext.jsx';
 
 function ProfilePage() {
+  const { user, loading: authLoading } = useAuth();
   const [profile, setProfile] = useState(null);
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
-  const { user, loading: authLoading } = useAuth();
 
   useEffect(() => {
-    if (!authLoading && !user) {
-      navigate('/login');
+    if (!authLoading && user) {
+      getUserProfile(user.id)
+        .then(setProfile)
+        .catch(() => setProfile(null))
+        .finally(() => setLoading(false));
     }
-  }, [authLoading, user, navigate]);
+  }, [authLoading, user]);
 
-  useEffect(() => {
-    async function fetchProfile() {
-      try {
-        if (!user) return;
-        const data = await getUserProfile(user.id);
-        setProfile(data);
-      } catch (err) {
-        console.error('Failed to load profile', err);
-      } finally {
-        setLoading(false);
-      }
-    }
-    fetchProfile();
-  }, [user]);
-
-  if (loading || authLoading) return <Spinner />;
-  if (!profile) return <Box>Profile not found.</Box>;
+  if (authLoading || loading) return <Spinner />;
+  if (!profile) return <Box p={4}>Profile not found.</Box>;
 
   return (
     <Box className="profile-page-container">
       <NavBar />
       <NavMenu />
-import { useProfile } from '../context/ProfileContext.jsx';
-
-function ProfilePage() {
-  const { profile, fetchProfile } = useProfile();
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    fetchProfile();
-  }, [fetchProfile]);
-
-  if (!profile) return <Spinner />;
-
-  return (
-    <Box className="profile-page-container">
-      <Button className="customize-btn" onClick={() => navigate('/profile/customize')} colorScheme="teal" mb={4}>
-        Customize Profile
-      </Button>
-      <Button onClick={() => navigate('/tasks')} colorScheme="teal" mb={4}>
-        Manage Tasks
-      </Button>
-      <Button onClick={() => navigate('/notifications')} colorScheme="teal" mb={4}>
-        Notifications
-      </Button>
-      <VStack spacing={6} align="stretch">
-        <ProfileHeader profile={profile} />
-        <AboutSection bio={profile.bio} />
-        <ProfessionalDetails skills={profile.skills} />
-        <ActivityFeed activities={profile.activities || []} />
-      </VStack>
+      <Box p={4}>
+        <Button className="customize-btn" onClick={() => navigate('/profile/customize')} colorScheme="teal" mb={4}>
+          Customize Profile
+        </Button>
+        <VStack spacing={6} align="stretch">
+          <ProfileHeader profile={profile} />
+          <AboutSection bio={profile.bio} />
+          <ProfessionalDetails skills={profile.skills} />
+          <ActivityFeed activities={profile.activities || []} />
+        </VStack>
+      </Box>
     </Box>
   );
 }

--- a/frontend/src/styles/DashboardPage.css
+++ b/frontend/src/styles/DashboardPage.css
@@ -1,0 +1,8 @@
+.dashboard-page {
+  display: flex;
+  min-height: 100vh;
+}
+
+.dashboard-page > .chakra-box {
+  flex: 1;
+}

--- a/frontend/src/styles/LiveFeedPage.css
+++ b/frontend/src/styles/LiveFeedPage.css
@@ -1,0 +1,12 @@
+.live-feed-page {
+  display: flex;
+  min-height: 100vh;
+}
+
+.live-feed-page .feed-content {
+  flex: 1;
+}
+
+.events-sidebar {
+  max-width: 250px;
+}


### PR DESCRIPTION
## Summary
- persist authenticated user id and clean logout handling
- implement dashboard and live feed pages with API integration
- redirect login flow to dashboard and tidy profile page

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68933c1ce3808320a29cef9649d9d88e