### PR TITLE
Add installation wizard

### DIFF
--- a/.env
+++ b/.env
@@ -21,6 +21,13 @@ BINLIST_API=/payments/bin
 AI_SERVICE_URL=
 AI_SERVICE_KEY=
 
+APP_ID=workhouse
+APP_URL=http://localhost:5173
+DB_HOST=localhost
+DB_USER=workhouse
+DB_PASSWORD=workhouse
+DB_NAME=workhouse
+
 VITE_API_BASE_URL=http://localhost:5000
 VITE_AVATAR_API=https://api.dicebear.com/6.x/initials/svg
 VITE_JITSI_DOMAIN=https://meet.jit.si

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ BINLIST_API=/payments/bin
 AI_SERVICE_URL=
 AI_SERVICE_KEY=
 
+APP_ID=workhouse
+APP_URL=http://localhost:5173
+DB_HOST=localhost
+DB_USER=workhouse
+DB_PASSWORD=workhouse
+DB_NAME=workhouse
+
 VITE_API_BASE_URL=http://localhost:5000
 VITE_AVATAR_API=https://api.dicebear.com/6.x/initials/svg
 VITE_JITSI_DOMAIN=https://meet.jit.si

--- a/backend/app.js
+++ b/backend/app.js
@@ -147,6 +147,7 @@ const interviewRoutes = require('./routes/interviews');
 const startupRoutes = require('./routes/startups');
 const settingsRoutes = require('./routes/settings');
 const simDashboardRoutes = require('./routes/simDashboard');
+const installRoutes = require('./routes/install');
 const app = express();
 app.use(cors());
 app.use(express.json());
@@ -158,6 +159,7 @@ app.get('/operations/retail/products', (req, res) => {
 // when integrating the backend.
 app.use('/auth', authRoutes);
 app.use('/landing', landingRoutes);
+app.use('/install', installRoutes);
 app.use('/config', configRoutes);
 app.use('/affiliates', dashboardRoutes);
 app.use('/commissions', commissionRoutes);

--- a/backend/controllers/install.js
+++ b/backend/controllers/install.js
@@ -1,0 +1,24 @@
+const { checkInstallation, runInstallation } = require('../services/install');
+const logger = require('../utils/logger');
+
+async function getStatus(req, res) {
+  try {
+    const status = await checkInstallation();
+    res.json(status);
+  } catch (err) {
+    logger.error('Failed to check installation status', { error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+}
+
+async function install(req, res) {
+  try {
+    const result = await runInstallation(req.body);
+    res.status(201).json(result);
+  } catch (err) {
+    logger.error('Installation failed', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+module.exports = { getStatus, install };

--- a/backend/data/install.json
+++ b/backend/data/install.json
@@ -1,0 +1,3 @@
+{
+  "installed": false
+}

--- a/backend/models/installation.js
+++ b/backend/models/installation.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+
+const INSTALL_PATH = path.join(__dirname, '../data/install.json');
+
+function readInstallFile() {
+  try {
+    const raw = fs.readFileSync(INSTALL_PATH, 'utf8');
+    return JSON.parse(raw);
+  } catch (err) {
+    return { installed: false };
+  }
+}
+
+function writeInstallFile(data) {
+  fs.writeFileSync(INSTALL_PATH, JSON.stringify(data, null, 2));
+}
+
+function getStatus() {
+  return readInstallFile();
+}
+
+function saveInstallation({ appId, appUrl, dbConfig }) {
+  const record = {
+    installed: true,
+    appId,
+    appUrl,
+    dbConfig,
+    installedAt: new Date().toISOString(),
+  };
+  writeInstallFile(record);
+  return record;
+}
+
+module.exports = { getStatus, saveInstallation };

--- a/backend/routes/install.js
+++ b/backend/routes/install.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const { getStatus, install } = require('../controllers/install');
+
+const router = express.Router();
+
+router.get('/status', getStatus);
+router.post('/', install);
+
+module.exports = router;

--- a/backend/services/install.js
+++ b/backend/services/install.js
@@ -1,0 +1,36 @@
+const { getStatus, saveInstallation } = require('../models/installation');
+const { addUser, findUser } = require('../models/user');
+const logger = require('../utils/logger');
+
+async function checkInstallation() {
+  return getStatus();
+}
+
+async function runInstallation({ dbConfig = {}, admin = {}, app = {} }) {
+  const status = getStatus();
+  if (status.installed) {
+    throw new Error('Application is already installed');
+  }
+  if (!admin.username || !admin.password) {
+    throw new Error('Admin username and password are required');
+  }
+  if (findUser(admin.username)) {
+    throw new Error('Admin user already exists');
+  }
+  const adminUser = addUser({
+    username: admin.username,
+    password: admin.password,
+    role: 'admin',
+    email: admin.email || admin.username,
+    fullName: admin.fullName || '',
+  });
+  const record = saveInstallation({
+    appId: app.appId || 'workhouse',
+    appUrl: app.appUrl || '',
+    dbConfig,
+  });
+  logger.info('Installation completed', { adminId: adminUser.id });
+  return { installation: record, admin: adminUser };
+}
+
+module.exports = { checkInstallation, runInstallation };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -38,6 +38,7 @@ import AnalyticsAuditPage from './pages/AnalyticsAuditPage.jsx';
 import PaymentPage from './pages/PaymentPage.jsx';
 import SimDashboardPage from './pages/SimDashboardPage.jsx';
 import LandingPage from './pages/LandingPage.jsx';
+import InstallationWizardPage from './pages/InstallationWizardPage.jsx';
 import FinancialMediaSetupPage from './pages/FinancialMediaSetupPage.jsx';
 import OnboardingDocumentsPage from './pages/OnboardingDocumentsPage.jsx';
 import ChatInboxPage from './pages/ChatInboxPage.jsx';
@@ -90,6 +91,7 @@ export default function App() {
   const routes = [
     // Entry & Authentication
     { path: '/', element: <LandingPage /> },
+    { path: '/install', element: <InstallationWizardPage /> },
     { path: '/login', element: <LoginPage /> },
     { path: '/signup', element: <SignupPage /> },
     { path: '/onboarding/documents', element: <OnboardingDocumentsPage />, protected: true },

--- a/frontend/src/api/install.js
+++ b/frontend/src/api/install.js
@@ -1,0 +1,11 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function getInstallStatus() {
+  const { data } = await apiClient.get('/install/status');
+  return data;
+}
+
+export async function runInstallation(payload) {
+  const { data } = await apiClient.post('/install', payload);
+  return data;
+}

--- a/frontend/src/nav/menu.js
+++ b/frontend/src/nav/menu.js
@@ -86,7 +86,8 @@ export const menu = [
       { label: 'Admin Settings', path: '/admin/system-settings' },
       { label: 'Affiliates', path: '/affiliates' },
       { label: 'Sim Dashboard', path: '/sim-dashboard' },
-      { label: 'Headhunter Dashboard', path: '/headhunter/dashboard' }
+      { label: 'Headhunter Dashboard', path: '/headhunter/dashboard' },
+      { label: 'Install Wizard', path: '/install' }
     ]
   }
 ];

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -36,6 +36,9 @@ export default function DashboardPage() {
       <NavMenu />
       <Box p={4}>
         <Heading mb={4}>Welcome back, {user?.name || user?.username}</Heading>
+        <Button mb={4} colorScheme="purple" onClick={() => navigate('/install')}>
+          Run Installation Wizard
+        </Button>
         <Button mb={4} colorScheme="teal" onClick={() => navigate('/feed')}>
           View Live Feed
         </Button>

--- a/frontend/src/pages/InstallationWizardPage.jsx
+++ b/frontend/src/pages/InstallationWizardPage.jsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  VStack,
+  FormControl,
+  FormLabel,
+  Input,
+  Button,
+  Alert,
+  AlertIcon
+} from '@chakra-ui/react';
+import { getInstallStatus, runInstallation } from '../api/install.js';
+import '../styles/InstallationWizardPage.css';
+
+export default function InstallationWizardPage() {
+  const [status, setStatus] = useState(null);
+  const [step, setStep] = useState(0);
+  const [dbConfig, setDbConfig] = useState({ host: '', user: '', password: '', name: '' });
+  const [admin, setAdmin] = useState({ username: '', email: '', password: '' });
+  const [app, setApp] = useState({ appId: '', appUrl: '' });
+  const [error, setError] = useState('');
+  const [complete, setComplete] = useState(false);
+
+  useEffect(() => {
+    getInstallStatus()
+      .then(setStatus)
+      .catch(() => setStatus({ installed: false }));
+  }, []);
+
+  if (status?.installed) {
+    return (
+      <Box p={6}>
+        <Alert status="success">
+          <AlertIcon />Application already installed.
+        </Alert>
+      </Box>
+    );
+  }
+
+  const handleNext = async () => {
+    setError('');
+    if (step < 2) {
+      setStep(step + 1);
+    } else {
+      try {
+        await runInstallation({ dbConfig, admin, app });
+        setComplete(true);
+      } catch (e) {
+        setError(e.response?.data?.error || e.message);
+      }
+    }
+  };
+
+  if (complete) {
+    return (
+      <Box p={6}>
+        <Alert status="success">
+          <AlertIcon />Installation completed successfully.
+        </Alert>
+      </Box>
+    );
+  }
+
+  const renderStep = () => {
+    switch (step) {
+      case 0:
+        return (
+          <>
+            <FormControl>
+              <FormLabel>Database Host</FormLabel>
+              <Input value={dbConfig.host} onChange={e => setDbConfig({ ...dbConfig, host: e.target.value })} />
+            </FormControl>
+            <FormControl>
+              <FormLabel>Database User</FormLabel>
+              <Input value={dbConfig.user} onChange={e => setDbConfig({ ...dbConfig, user: e.target.value })} />
+            </FormControl>
+            <FormControl>
+              <FormLabel>Database Password</FormLabel>
+              <Input type="password" value={dbConfig.password} onChange={e => setDbConfig({ ...dbConfig, password: e.target.value })} />
+            </FormControl>
+            <FormControl>
+              <FormLabel>Database Name</FormLabel>
+              <Input value={dbConfig.name} onChange={e => setDbConfig({ ...dbConfig, name: e.target.value })} />
+            </FormControl>
+          </>
+        );
+      case 1:
+        return (
+          <>
+            <FormControl>
+              <FormLabel>Admin Username</FormLabel>
+              <Input value={admin.username} onChange={e => setAdmin({ ...admin, username: e.target.value })} />
+            </FormControl>
+            <FormControl>
+              <FormLabel>Admin Email</FormLabel>
+              <Input value={admin.email} onChange={e => setAdmin({ ...admin, email: e.target.value })} />
+            </FormControl>
+            <FormControl>
+              <FormLabel>Admin Password</FormLabel>
+              <Input type="password" value={admin.password} onChange={e => setAdmin({ ...admin, password: e.target.value })} />
+            </FormControl>
+          </>
+        );
+      case 2:
+        return (
+          <>
+            <FormControl>
+              <FormLabel>App ID</FormLabel>
+              <Input value={app.appId} onChange={e => setApp({ ...app, appId: e.target.value })} />
+            </FormControl>
+            <FormControl>
+              <FormLabel>App URL</FormLabel>
+              <Input value={app.appUrl} onChange={e => setApp({ ...app, appUrl: e.target.value })} />
+            </FormControl>
+          </>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Box className="installation-wizard" p={6}>
+      <Heading mb={4}>Installation Wizard</Heading>
+      {error && (
+        <Alert status="error" mb={4}>
+          <AlertIcon />
+          {error}
+        </Alert>
+      )}
+      <VStack spacing={4} align="stretch">
+        {renderStep()}
+      </VStack>
+      <Button mt={6} colorScheme="teal" onClick={handleNext}>
+        {step < 2 ? 'Next' : 'Install'}
+      </Button>
+    </Box>
+  );
+}

--- a/frontend/src/styles/InstallationWizardPage.css
+++ b/frontend/src/styles/InstallationWizardPage.css
@@ -1,0 +1,4 @@
+.installation-wizard {
+  max-width: 600px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- add backend install routes and services for initial setup and admin creation
- create multi-step Chakra UI installation wizard and navigation links
- extend environment templates with app and database configuration

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68933c754a9083209558b1636c731f4e