### PR TITLE
Add employment and messaging APIs and styles

### DIFF
--- a/frontend/src/api/applications.js
+++ b/frontend/src/api/applications.js
@@ -5,6 +5,10 @@ export async function fetchUserApplications() {
   return data;
 }
 
+export async function getUserApplications() {
+  return fetchUserApplications();
+}
+
 export async function fetchOpportunityApplications(opportunityId) {
   const { data } = await apiClient.get(`/applications/opportunity/${opportunityId}`);
   return data;

--- a/frontend/src/api/employment.js
+++ b/frontend/src/api/employment.js
@@ -1,0 +1,17 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function getOverview() {
+  const { data } = await apiClient.get('/analytics/employment/overview');
+  return data;
+}
+
+export async function getJobs() {
+  const { data } = await apiClient.get('/analytics/employment/jobs');
+  return data;
+}
+
+export async function getJob(jobId) {
+  const { data } = await apiClient.get(`/analytics/employment/jobs/${jobId}`);
+  return data;
+}
+

--- a/frontend/src/api/headhunter.js
+++ b/frontend/src/api/headhunter.js
@@ -1,0 +1,14 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function searchJobSeekers(query) {
+  const { data } = await apiClient.get('/matching-engine/search', {
+    params: { search: query }
+  });
+  return data;
+}
+
+export async function getRecommendations() {
+  const { data } = await apiClient.get('/matching-engine/search');
+  return data;
+}
+

--- a/frontend/src/api/interviews.js
+++ b/frontend/src/api/interviews.js
@@ -1,0 +1,12 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function getUserInterviews() {
+  const { data } = await apiClient.get('/interviews/user');
+  return data;
+}
+
+export async function getEmployerInterviews() {
+  const { data } = await apiClient.get('/interviews/employer');
+  return data;
+}
+

--- a/frontend/src/styles/ApplicationInterviewManagementPage.css
+++ b/frontend/src/styles/ApplicationInterviewManagementPage.css
@@ -1,0 +1,8 @@
+.application-interview-management-page {
+  background: #f4f7f9;
+}
+
+.application-interview-management-page table {
+  background: #ffffff;
+}
+

--- a/frontend/src/styles/EmploymentDashboardPage.css
+++ b/frontend/src/styles/EmploymentDashboardPage.css
@@ -1,0 +1,13 @@
+.employment-dashboard-page {
+  background: #f4f7f9;
+}
+
+.job-card {
+  cursor: pointer;
+  transition: box-shadow 0.2s ease;
+}
+
+.job-card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+

--- a/frontend/src/styles/HeadhunterDashboardPage.css
+++ b/frontend/src/styles/HeadhunterDashboardPage.css
@@ -1,0 +1,12 @@
+.headhunter-dashboard-page {
+  background: #f4f7f9;
+}
+
+.headhunter-dashboard-page .chakra-list__item {
+  transition: background 0.2s ease;
+}
+
+.headhunter-dashboard-page .chakra-list__item:hover {
+  background: #f0f4f8;
+}
+


### PR DESCRIPTION
## Summary
- provide user applications fetch alias
- add employment, interviews, and headhunter API modules
- include styles for employment and messaging pages

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893404c39b08320a3d14523825c794c