### PR TITLE
feat: add virtual interview scheduling and session

### DIFF
--- a/.env
+++ b/.env
@@ -21,9 +21,12 @@ BINLIST_API=/payments/bin
 AI_SERVICE_URL=
 AI_SERVICE_KEY=
 
+JITSI_DOMAIN=https://meet.jit.si
+JITSI_ROOM_PREFIX=workhouse-interview
 VITE_API_BASE_URL=http://localhost:5000
 VITE_AVATAR_API=https://api.dicebear.com/6.x/initials/svg
 VITE_JITSI_DOMAIN=https://meet.jit.si
+VITE_JITSI_ROOM_PREFIX=workhouse-interview
 VITE_ADVICE_API=/advice
 VITE_WORLD_TIME_API=/worldtime
 VITE_INDUSTRIES_API=/industries

--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,12 @@ BINLIST_API=/payments/bin
 AI_SERVICE_URL=
 AI_SERVICE_KEY=
 
+JITSI_DOMAIN=https://meet.jit.si
+JITSI_ROOM_PREFIX=workhouse-interview
 VITE_API_BASE_URL=http://localhost:5000
 VITE_AVATAR_API=https://api.dicebear.com/6.x/initials/svg
 VITE_JITSI_DOMAIN=https://meet.jit.si
+VITE_JITSI_ROOM_PREFIX=workhouse-interview
 VITE_ADVICE_API=/advice
 VITE_WORLD_TIME_API=/worldtime
 VITE_INDUSTRIES_API=/industries

--- a/backend/database/interviews.sql
+++ b/backend/database/interviews.sql
@@ -1,11 +1,12 @@
 -- SQL schema for interviews
 CREATE TABLE IF NOT EXISTS interviews (
   id UUID PRIMARY KEY,
-  application_id UUID NOT NULL,
   employer_id UUID NOT NULL,
-  applicant_id UUID NOT NULL,
-  interview_date TIMESTAMP NOT NULL,
+  candidate_email TEXT NOT NULL,
+  scheduled_for TIMESTAMP NOT NULL,
+  meeting_link TEXT NOT NULL,
   status VARCHAR(20) NOT NULL DEFAULT 'scheduled',
+  notes JSONB DEFAULT '[]',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/backend/models/interview.js
+++ b/backend/models/interview.js
@@ -3,35 +3,26 @@ const { randomUUID } = require('crypto');
 // In-memory storage for interviews
 const interviews = new Map();
 
-function scheduleInterview({ applicationId, employerId, applicantId, interviewDate }) {
+function createInterview({ employerId, candidateEmail, scheduledFor }) {
   const id = randomUUID();
   const now = new Date();
+  const prefix = process.env.JITSI_ROOM_PREFIX || 'workhouse-interview';
+  const meetingId = `${prefix}-${id}`;
+  const domain = process.env.JITSI_DOMAIN || 'https://meet.jit.si';
+  const meetingLink = `${domain}/${meetingId}`;
   const interview = {
     id,
-    applicationId,
     employerId,
-    applicantId,
-    interviewDate: new Date(interviewDate),
+    candidateEmail,
+    scheduledFor: new Date(scheduledFor),
+    meetingId,
+    meetingLink,
     status: 'scheduled',
+    notes: [],
     createdAt: now,
     updatedAt: now,
   };
   interviews.set(id, interview);
-const interviews = [];
-let idCounter = 1;
-
-function createInterview({ interviewerId, candidateId, scheduledFor }) {
-  const interview = {
-    id: idCounter++,
-    interviewerId: Number(interviewerId),
-    candidateId: Number(candidateId),
-    scheduledFor: new Date(scheduledFor),
-    notes: [],
-    status: 'scheduled',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  };
-  interviews.push(interview);
   return interview;
 }
 
@@ -39,12 +30,12 @@ function getInterviewById(id) {
   return interviews.get(id);
 }
 
-function getInterviewsByApplicant(applicantId) {
-  return Array.from(interviews.values()).filter(i => i.applicantId === applicantId);
+function listInterviewsForUser(email) {
+  return Array.from(interviews.values()).filter((i) => i.candidateEmail === email);
 }
 
-function getInterviewsByEmployer(employerId) {
-  return Array.from(interviews.values()).filter(i => i.employerId === employerId);
+function listInterviewsForEmployer(employerId) {
+  return Array.from(interviews.values()).filter((i) => i.employerId === employerId);
 }
 
 function updateInterviewStatus(id, status) {
@@ -52,27 +43,23 @@ function updateInterviewStatus(id, status) {
   if (!interview) return null;
   interview.status = status;
   interview.updatedAt = new Date();
-  interviews.set(id, interview);
-=======
-  return interviews.find(i => i.id === Number(id));
+  return interview;
 }
 
-function addNoteToInterview(id, text) {
-  const interview = getInterviewById(id);
+function addNoteToInterview(id, { text, authorId }) {
+  const interview = interviews.get(id);
   if (!interview) return null;
-  interview.notes.push({ text, createdAt: new Date() });
+  interview.notes.push({ id: randomUUID(), text, authorId, createdAt: new Date() });
   interview.updatedAt = new Date();
   return interview;
 }
 
 module.exports = {
-  scheduleInterview,
-  getInterviewById,
-  getInterviewsByApplicant,
-  getInterviewsByEmployer,
-  updateInterviewStatus,
-  interviews,
   createInterview,
   getInterviewById,
+  listInterviewsForUser,
+  listInterviewsForEmployer,
+  updateInterviewStatus,
   addNoteToInterview,
 };
+

--- a/backend/routes/interviews.js
+++ b/backend/routes/interviews.js
@@ -4,6 +4,8 @@ const {
   getUserInterviewsHandler,
   getEmployerInterviewsHandler,
   updateInterviewStatusHandler,
+  getInterviewHandler,
+  addNoteHandler,
 } = require('../controllers/interview');
 const auth = require('../middleware/auth');
 const requireRole = require('../middleware/requireRole');
@@ -12,6 +14,7 @@ const {
   scheduleInterviewSchema,
   interviewIdParamSchema,
   statusUpdateSchema,
+  noteSchema,
 } = require('../validation/interview');
 
 const router = express.Router();
@@ -25,6 +28,18 @@ router.get('/user', auth, getUserInterviewsHandler);
 // Get interviews for employer
 router.get('/employer', auth, requireRole('employer', 'admin'), getEmployerInterviewsHandler);
 
+// Get single interview
+router.get('/:interviewId', auth, validate(interviewIdParamSchema, 'params'), getInterviewHandler);
+
+// Add note
+router.post(
+  '/:interviewId/notes',
+  auth,
+  validate(interviewIdParamSchema, 'params'),
+  validate(noteSchema),
+  addNoteHandler
+);
+
 // Update interview status
 router.put(
   '/:interviewId/status',
@@ -33,19 +48,6 @@ router.put(
   validate(statusUpdateSchema),
   updateInterviewStatusHandler
 );
-const { authenticate } = require('../middleware/auth');
-const validate = require('../middleware/validate');
-const { scheduleInterviewSchema, noteSchema } = require('../validation/interview');
-const {
-  scheduleInterviewHandler,
-  getInterviewHandler,
-  addNoteHandler,
-} = require('../controllers/interview');
-
-const router = express.Router();
-
-router.post('/schedule', authenticate, validate(scheduleInterviewSchema), scheduleInterviewHandler);
-router.get('/:id', authenticate, getInterviewHandler);
-router.post('/:id/notes', authenticate, validate(noteSchema), addNoteHandler);
 
 module.exports = router;
+

--- a/backend/services/interview.js
+++ b/backend/services/interview.js
@@ -1,6 +1,9 @@
 const {
   createInterview,
   getInterviewById,
+  listInterviewsForUser,
+  listInterviewsForEmployer,
+  updateInterviewStatus,
   addNoteToInterview,
 } = require('../models/interview');
 
@@ -12,12 +15,27 @@ function getInterview(id) {
   return getInterviewById(id);
 }
 
-function addNote(id, text) {
-  return addNoteToInterview(id, text);
+function listUserInterviews(email) {
+  return listInterviewsForUser(email);
+}
+
+function listEmployerInterviews(employerId) {
+  return listInterviewsForEmployer(employerId);
+}
+
+function setInterviewStatus(id, status) {
+  return updateInterviewStatus(id, status);
+}
+
+function addNote(id, text, authorId) {
+  return addNoteToInterview(id, { text, authorId });
 }
 
 module.exports = {
   scheduleInterview,
   getInterview,
+  listUserInterviews,
+  listEmployerInterviews,
+  setInterviewStatus,
   addNote,
 };

--- a/backend/validation/interview.js
+++ b/backend/validation/interview.js
@@ -1,9 +1,8 @@
 const Joi = require('joi');
 
 const scheduleInterviewSchema = Joi.object({
-  applicationId: Joi.string().uuid().required(),
-  applicantId: Joi.string().uuid().required(),
-  interviewDate: Joi.date().iso().required(),
+  candidateEmail: Joi.string().email().required(),
+  scheduledFor: Joi.date().iso().required(),
 });
 
 const interviewIdParamSchema = Joi.object({
@@ -12,9 +11,6 @@ const interviewIdParamSchema = Joi.object({
 
 const statusUpdateSchema = Joi.object({
   status: Joi.string().valid('scheduled', 'completed', 'cancelled').required(),
-  interviewerId: Joi.number().required(),
-  candidateId: Joi.number().required(),
-  scheduledFor: Joi.date().iso().required(),
 });
 
 const noteSchema = Joi.object({

--- a/frontend/components/InterviewForm.jsx
+++ b/frontend/components/InterviewForm.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import '../styles/InterviewForm.css';
 
 export default function InterviewForm({ onSchedule }) {
-  const [form, setForm] = useState({ candidate: '', datetime: '' });
+  const [form, setForm] = useState({ candidateEmail: '', scheduledFor: '' });
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -13,7 +13,7 @@ export default function InterviewForm({ onSchedule }) {
   const handleSubmit = (e) => {
     e.preventDefault();
     onSchedule(form);
-    setForm({ candidate: '', datetime: '' });
+    setForm({ candidateEmail: '', scheduledFor: '' });
   };
 
   return (
@@ -21,11 +21,11 @@ export default function InterviewForm({ onSchedule }) {
       <Stack spacing={3}>
         <FormControl isRequired>
           <FormLabel>Candidate Email</FormLabel>
-          <Input name="candidate" value={form.candidate} onChange={handleChange} />
+          <Input name="candidateEmail" value={form.candidateEmail} onChange={handleChange} />
         </FormControl>
         <FormControl isRequired>
           <FormLabel>Date &amp; Time</FormLabel>
-          <Input type="datetime-local" name="datetime" value={form.datetime} onChange={handleChange} />
+          <Input type="datetime-local" name="scheduledFor" value={form.scheduledFor} onChange={handleChange} />
         </FormControl>
         <Button colorScheme="teal" type="submit">Schedule</Button>
       </Stack>

--- a/frontend/components/InterviewList.jsx
+++ b/frontend/components/InterviewList.jsx
@@ -1,4 +1,5 @@
 import { Box, Button, Heading, HStack, Text, VStack } from '@chakra-ui/react';
+import { Link } from 'react-router-dom';
 import '../styles/InterviewList.css';
 
 export default function InterviewList({ interviews, onStatus }) {
@@ -11,16 +12,21 @@ export default function InterviewList({ interviews, onStatus }) {
       {interviews.map((iv) => (
         <Box key={iv.id} p={4} borderWidth="1px" borderRadius="md">
           <HStack justify="space-between">
-            <Heading size="sm">{iv.candidate}</Heading>
-            <Text>{new Date(iv.datetime).toLocaleString()}</Text>
+            <Heading size="sm">{iv.candidateEmail}</Heading>
+            <Text>{new Date(iv.scheduledFor).toLocaleString()}</Text>
           </HStack>
           <HStack mt={2} justify="space-between">
             <Text>Status: {iv.status}</Text>
-            {onStatus && (
-              <Button size="sm" onClick={() => onStatus(iv.id, 'completed')}>
-                Mark Complete
+            <HStack>
+              <Button size="sm" as={Link} to={`/interviews/${iv.id}`} colorScheme="blue">
+                Join
               </Button>
-            )}
+              {onStatus && (
+                <Button size="sm" onClick={() => onStatus(iv.id, 'completed')}>
+                  Mark Complete
+                </Button>
+              )}
+            </HStack>
           </HStack>
         </Box>
       ))}

--- a/frontend/env.js
+++ b/frontend/env.js
@@ -4,6 +4,7 @@ window.env = {
   API_BASE_URL: apiBase,
   AVATAR_API: import.meta.env.VITE_AVATAR_API,
   JITSI_DOMAIN: import.meta.env.VITE_JITSI_DOMAIN,
+  JITSI_ROOM_PREFIX: import.meta.env.VITE_JITSI_ROOM_PREFIX,
   CLASSROOM_DEFAULT_ROOM: import.meta.env.VITE_CLASSROOM_DEFAULT_ROOM,
   ADVICE_API: apiBase + (import.meta.env.VITE_ADVICE_API || '/advice'),
   WORLD_TIME_API: apiBase + (import.meta.env.VITE_WORLD_TIME_API || '/worldtime'),

--- a/frontend/pages/InterviewSession.jsx
+++ b/frontend/pages/InterviewSession.jsx
@@ -1,0 +1,79 @@
+import { ChakraProvider, Box, Heading, Button, Text, Textarea, useToast } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import NavMenu from '../components/NavMenu';
+import { getInterview, addNote } from '../api/interviews.js';
+import '../styles/InterviewSession.css';
+
+export default function InterviewSession() {
+  const { interviewId } = useParams();
+  const [interview, setInterview] = useState(null);
+  const [inSession, setInSession] = useState(false);
+  const [note, setNote] = useState('');
+  const toast = useToast();
+  const domain = window.env?.JITSI_DOMAIN || 'https://meet.jit.si';
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await getInterview(interviewId);
+        setInterview(data);
+      } catch (err) {
+        toast({ title: 'Failed to load interview', status: 'error' });
+      }
+    }
+    load();
+  }, [interviewId, toast]);
+
+  const handleSaveNote = async () => {
+    try {
+      await addNote(interviewId, note);
+      setNote('');
+      toast({ title: 'Note saved', status: 'success' });
+    } catch (err) {
+      toast({ title: 'Failed to save note', status: 'error' });
+    }
+  };
+
+  return (
+    <ChakraProvider>
+      <NavMenu />
+      <Box className="interview-session" p={4}>
+        <Heading mb={4}>Virtual Interview</Heading>
+        {interview && (
+          <Text mb={4}>
+            Scheduled for: {new Date(interview.scheduledFor).toLocaleString()}
+          </Text>
+        )}
+        {!inSession ? (
+          <Button colorScheme="blue" onClick={() => setInSession(true)}>
+            Join Interview
+          </Button>
+        ) : (
+          <Box className="video-container" mb={4}>
+            <iframe
+              title="Interview"
+              src={interview ? `${domain}/${interview.meetingId}` : ''}
+              allow="camera; microphone; fullscreen; display-capture"
+              style={{ width: '100%', height: '500px', border: 0 }}
+            />
+          </Box>
+        )}
+        <Box mt={4}>
+          <Heading size="md" mb={2}>
+            Notes
+          </Heading>
+          <Textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder="Enter notes"
+          />
+          <Button mt={2} colorScheme="teal" onClick={handleSaveNote}>
+            Save Note
+          </Button>
+        </Box>
+      </Box>
+    </ChakraProvider>
+  );
+}
+

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -61,6 +61,7 @@ import EducationDashboard from '../pages/EducationDashboard.jsx';
 import WorkspaceDashboard from '../pages/WorkspaceDashboard.jsx';
 import JobPostManagement from '../pages/JobPostManagement.jsx';
 import VirtualInterview from '../pages/VirtualInterview.jsx';
+import InterviewSession from '../pages/InterviewSession.jsx';
 
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 import { ProfileProvider } from './context/ProfileContext.jsx';
@@ -105,6 +106,7 @@ export default function App() {
     { path: '/applications-interviews', element: <PlaceholderPage title="Application & Interview Management" />, protected: true },
     { path: '/headhunter/dashboard', element: <PlaceholderPage title="Headhunter Dashboard" />, protected: true },
     { path: '/interviews', element: <VirtualInterview />, protected: true },
+    { path: '/interviews/:interviewId', element: <InterviewSession />, protected: true },
     { path: '/job-posts', element: <JobPostManagement />, protected: true },
     { path: '/gigs', element: <PlaceholderPage title="Gigs Dashboard" />, protected: true },
     { path: '/gigs/manage', element: <PlaceholderPage title="Gig Creation & Management" />, protected: true },

--- a/frontend/styles/InterviewSession.css
+++ b/frontend/styles/InterviewSession.css
@@ -1,0 +1,11 @@
+.interview-session {
+  width: 100%;
+}
+
+.video-container {
+  width: 100%;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  overflow: hidden;
+}
+


### PR DESCRIPTION
## Summary
- implement backend model and routes for virtual interviews with Jitsi meeting links
- add React pages for scheduling, listing, and joining interviews with notes
- configure Jitsi domain and room prefix in environment files

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68933bfd2e3083208b3530978cba7f45