### PR TITLE
feat: add gig search and detail pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,8 @@ import ServiceCreationPage from './pages/ServiceCreationPage.jsx';
 import ServiceDetailPage from './pages/ServiceDetailPage.jsx';
 import ServiceOrderManagementPage from './pages/ServiceOrderManagementPage.jsx';
 import ServiceSearchPage from './pages/ServiceSearchPage.jsx';
+import GigSearchPage from './pages/GigSearchPage.jsx';
+import GigDetailPage from './pages/GigDetailPage.jsx';
 import TaskDashboardPage from './pages/TaskDashboardPage.jsx';
 import TaskManagementPage from './pages/TaskManagementPage.jsx';
 import TaskSearchPage from './pages/TaskSearchPage.jsx';
@@ -118,8 +120,8 @@ export default function App() {
     { path: '/job-posts', element: <JobPostManagement />, protected: true },
     { path: '/gigs', element: <PlaceholderPage title="Gigs Dashboard" />, protected: true },
     { path: '/gigs/manage', element: <PlaceholderPage title="Gig Creation & Management" />, protected: true },
-    { path: '/gigs/search', element: <ServiceSearchPage />, protected: true },
-    { path: '/gigs/:id', element: <ServiceDetailPage />, protected: true },
+    { path: '/gigs/search', element: <GigSearchPage />, protected: true },
+    { path: '/gigs/:id', element: <GigDetailPage />, protected: true },
     { path: '/orders', element: <OrderManagementPage />, protected: true },
     { path: '/payments', element: <PaymentPage />, protected: true },
     { path: '/ads', element: <AdsDashboardPage />, protected: true },

--- a/frontend/src/api/gigs.js
+++ b/frontend/src/api/gigs.js
@@ -1,0 +1,16 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function searchGigs(params = {}) {
+  const { data } = await apiClient.get('/gigs/search', { params });
+  return data;
+}
+
+export async function getGig(id) {
+  const { data } = await apiClient.get(`/gigs/${id}`);
+  return data;
+}
+
+export async function createGigOrder(gigId, details = {}) {
+  const { data } = await apiClient.post(`/gigs/${gigId}/order`, details);
+  return data;
+}

--- a/frontend/src/pages/GigDetailPage.jsx
+++ b/frontend/src/pages/GigDetailPage.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Image, Text, Heading, Button, VStack } from '@chakra-ui/react';
+import { useParams, useNavigate } from 'react-router-dom';
+import '../styles/GigDetailPage.css';
+import { getGig } from '../api/gigs.js';
+
+export default function GigDetailPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [gig, setGig] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await getGig(id);
+        setGig(data);
+      } catch (err) {
+        console.error('Failed to load gig', err);
+      }
+    }
+    load();
+  }, [id]);
+
+  if (!gig) {
+    return <Box>Loading...</Box>;
+  }
+
+  function handlePurchase() {
+    navigate(`/payments?gigId=${id}&amount=${gig.price}`);
+  }
+
+  return (
+    <Box className="gig-detail-page" p={4}>
+      <VStack spacing={4} align="stretch">
+        <Heading>{gig.title}</Heading>
+        <Image src={gig.image} alt={gig.title} className="detail-image" />
+        <Text>{gig.description}</Text>
+        <Text>Category: {gig.category}</Text>
+        <Text>Price: ${gig.price}</Text>
+        <Text>Rating: {gig.rating}</Text>
+        <Button colorScheme="teal" onClick={handlePurchase}>
+          Purchase
+        </Button>
+      </VStack>
+    </Box>
+  );
+}

--- a/frontend/src/pages/GigSearchPage.jsx
+++ b/frontend/src/pages/GigSearchPage.jsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Input,
+  Select,
+  Button,
+  SimpleGrid,
+  Image,
+  Text,
+  Flex,
+  Slider,
+  SliderTrack,
+  SliderFilledTrack,
+  SliderThumb,
+} from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+import '../styles/GigSearchPage.css';
+import { searchGigs } from '../api/gigs.js';
+
+export default function GigSearchPage() {
+  const [query, setQuery] = useState('');
+  const [category, setCategory] = useState('');
+  const [maxPrice, setMaxPrice] = useState(500);
+  const [gigs, setGigs] = useState([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function load() {
+    try {
+      const data = await searchGigs({ search: query, category, maxPrice });
+      setGigs(data);
+    } catch (err) {
+      console.error('Failed to load gigs', err);
+    }
+  }
+
+  return (
+    <Box className="gig-search-page">
+      <Flex className="search-controls" p={4} wrap="wrap" gap={4}>
+        <Input
+          placeholder="Search gigs"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <Select
+          placeholder="Category"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+          maxW="200px"
+        >
+          <option value="design">Design</option>
+          <option value="development">Development</option>
+          <option value="writing">Writing</option>
+        </Select>
+        <Box className="price-filter" maxW="200px">
+          <Text mb={2}>Max Price: ${maxPrice}</Text>
+          <Slider min={5} max={1000} value={maxPrice} onChange={setMaxPrice}>
+            <SliderTrack>
+              <SliderFilledTrack />
+            </SliderTrack>
+            <SliderThumb />
+          </Slider>
+        </Box>
+        <Button colorScheme="teal" onClick={load}>
+          Search
+        </Button>
+      </Flex>
+      <SimpleGrid columns={[1, 2, 3]} spacing={4} p={4}>
+        {gigs.map((gig) => (
+          <Box
+            key={gig.id}
+            className="gig-card"
+            borderWidth="1px"
+            borderRadius="md"
+            overflow="hidden"
+            onClick={() => navigate(`/gigs/${gig.id}`)}
+            cursor="pointer"
+          >
+            <Image src={gig.image} alt={gig.title} className="gig-image" />
+            <Box p={3}>
+              <Text className="gig-title" fontWeight="bold">
+                {gig.title}
+              </Text>
+              <Text>${gig.price}</Text>
+              <Text>Rating: {gig.rating}</Text>
+            </Box>
+          </Box>
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/frontend/src/styles/GigDetailPage.css
+++ b/frontend/src/styles/GigDetailPage.css
@@ -1,0 +1,5 @@
+.gig-detail-page .detail-image {
+  width: 100%;
+  max-height: 300px;
+  object-fit: cover;
+}

--- a/frontend/src/styles/GigSearchPage.css
+++ b/frontend/src/styles/GigSearchPage.css
@@ -1,0 +1,13 @@
+.gig-search-page .gig-card {
+  transition: box-shadow 0.2s ease;
+}
+
+.gig-search-page .gig-card:hover {
+  box-shadow: 0 0 8px rgba(0,0,0,0.2);
+}
+
+.gig-search-page .gig-image {
+  width: 100%;
+  height: 150px;
+  object-fit: cover;
+}


### PR DESCRIPTION
## Summary
- add gig API client for search and detail lookups
- implement gig search and product detail pages with Chakra UI
- wire gig pages into app routing

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6893443fdebc83209d4e41b5ccbbe714