### PR TITLE
chore: expand stage plan to 60 steps

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,131 +1,211 @@
 # Frontend Pages Stages
 
-Stage 1: Onboarding and Account Setup
+Stage 1: Onboarding and Account Setup (Part 1)
 - Homepage Before Login - Main Landing Page Design
 - Sign Up/Login Pages
+
+Stage 2: Onboarding and Account Setup (Part 2)
 - Combined Sign-Up and User Information Page
 - Financials & Media Setup Page
+
+Stage 3: Onboarding and Account Setup (Part 3)
 - Combined CV & Cover Letter Upload/Creation Page
 
-Stage 2: Post-Login and Profile Customization
+Stage 4: Post-Login and Profile Customization (Part 1)
 - Login Page
 - Combined Homepage After Login & Main Home Page
+
+Stage 5: Post-Login and Profile Customization (Part 2)
 - Live Feed Section
 - Main Profile Page
+
+Stage 6: Post-Login and Profile Customization (Part 3)
 - Profile Customization Page
 
-Stage 3: Messaging and Employment Hub
+Stage 7: Messaging and Employment Hub (Part 1)
 - Combined Pop-Up Chat and Full Inbox Page
 - Employment Dashboard (Job-Seeker and Company-Side)
+
+Stage 8: Messaging and Employment Hub (Part 2)
 - Combined Job Listings and Details Page
 - Combined Application and Interview Management Page (Job-Seeker and Employer)
+
+Stage 9: Messaging and Employment Hub (Part 3)
 - Headhunter Dashboard
 
-Stage 4: Interviewing and Gig Management
+Stage 10: Interviewing and Gig Management (Part 1)
 - Virtual Interview Page
 - Job Post Creation and Management Page
+
+Stage 11: Interviewing and Gig Management (Part 2)
 - Combined Gigs Dashboard (Gig Seller and Buyer)
 - Combined Order Management Page (Gig Seller and Buyer)
+
+Stage 12: Interviewing and Gig Management (Part 3)
 - Gig Creation and Management Page
 
-Stage 5: Gig Purchases and Contracts
+Stage 13: Gig Purchases and Contracts (Part 1)
 - Product Page (Buyer View)
 - Payment Page
+
+Stage 14: Gig Purchases and Contracts (Part 2)
 - Gig Search and Discovery Page
 - Combined Dashboard (Client and Freelancer)
+
+Stage 15: Gig Purchases and Contracts (Part 3)
 - Contract Management Page (Client and Freelancer)
 
-Stage 6: Freelance Tools and Education Overview
+Stage 16: Freelance Tools and Education Overview (Part 1)
 - Freelancer Search
 - Proposal and Invoice Management Page
+
+Stage 17: Freelance Tools and Education Overview (Part 2)
 - Payment and Timesheet Management Page
 - Contract Creation and Editing Page
+
+Stage 18: Freelance Tools and Education Overview (Part 3)
 - Combined Education Dashboard (Student and Teacher)
 
-Stage 7: Education and Service Management
+Stage 19: Education and Service Management (Part 1)
 - Combined Classroom Page (Student and Teacher)
 - Combined Course and Module Management Page (Student and Teacher)
+
+Stage 20: Education and Service Management (Part 2)
 - Schedule and Calendar Page (Student and Teacher)
 - Course Purchase and Details Page (Student)
+
+Stage 21: Education and Service Management (Part 3)
 - Combined Service and Order Management Page (Seller and Buyer)
 
-Stage 8: Service Creation and Task Setup
+Stage 22: Service Creation and Task Setup (Part 1)
 - Service Creation and Editing Page (Seller)
 - Search and Service Details Page (Buyer)
+
+Stage 23: Service Creation and Task Setup (Part 2)
 - Calendar Page (Seller and Buyer)
 - Combined Task Dashboard (Creator and Tasker)
+
+Stage 24: Service Creation and Task Setup (Part 3)
 - Task Creation and Management Page (Creator)
 
-Stage 9: Task Execution and Opportunities
+Stage 25: Task Execution and Opportunities (Part 1)
 - Task Search and Details Page (Tasker)
 - Task and Schedule Management Page (Tasker)
+
+Stage 26: Task Execution and Opportunities (Part 2)
 - Combined Experience Dashboard (Providers and Participants)
 - Combined Opportunity Management Page (Providers and Participants)
+
+Stage 27: Task Execution and Opportunities (Part 3)
 - Opportunity Search and Details Page (Global View)
 
-Stage 10: Progress Tracking and Volunteering
+Stage 28: Progress Tracking and Volunteering (Part 1)
 - Participant and Provider Progress Page
 - Combined Volunteering Dashboard (Volunteers and Employers)
+
+Stage 29: Progress Tracking and Volunteering (Part 2)
 - Combined Opportunity Search and Details Page (Volunteers)
+
+Stage 30: Progress Tracking and Volunteering (Part 3)
 - Combined Application and Volunteer Tracking Page (Volunteers and Employers)
 
-Stage 11: Volunteering Management and Networking
+Stage 31: Volunteering Management and Networking (Part 1)
 - Opportunity Management Page (Employers)
 - Combined Networking Dashboard (Participants and Companies)
+
+Stage 32: Volunteering Management and Networking (Part 2)
 - Combined Session Listings and Details Page (Participants and Companies)
+
+Stage 33: Volunteering Management and Networking (Part 3)
 - In-Session Networking Page
 
-Stage 12: Session Control and Creator Tools
+Stage 34: Session Control and Creator Tools (Part 1)
 - Session Management Page (Companies)
 - Profile and Connection Management Page (Shared)
+
+Stage 35: Session Control and Creator Tools (Part 2)
 - Combined Creator Dashboard (Podcasts and Webinars)
+
+Stage 36: Session Control and Creator Tools (Part 3)
 - Combined Content Creation and Management Page (Podcasts and Webinars)
 
-Stage 13: Content Library and Analytics
+Stage 37: Content Library and Analytics (Part 1)
 - Combined Content Library and Details Page (Podcasts and Webinars)
 - Live/Playback Room Page (Podcasts and Webinars)
+
+Stage 38: Content Library and Analytics (Part 2)
 - Profile and Analytics Page (Creators/Hosts)
+
+Stage 39: Content Library and Analytics (Part 3)
 - Combined Ads Dashboard and Campaign Management Page
 
-Stage 14: Advertising and Startup Overview
+Stage 40: Advertising and Startup Overview (Part 1)
 - Ad Creation and Editing Page
 - Combined Billing, Analytics, and Ad Library Page
+
+Stage 41: Advertising and Startup Overview (Part 2)
 - Shared User Interaction Page
+
+Stage 42: Advertising and Startup Overview (Part 3)
 - Combined Dashboard (Startups, Investors, Mentors)
 
-Stage 15: Startup Collaboration
+Stage 43: Startup Collaboration (Part 1)
 - Profile and Plan Management Page (Startups)
 - Search and Connection Page (Startups, Investors, Mentors)
+
+Stage 44: Startup Collaboration (Part 2)
 - Connection and Relationship Management Page
+
+Stage 45: Startup Collaboration (Part 3)
 - Live Engagement and Analytics Page
 
-Stage 16: Workspace Operations
+Stage 46: Workspace Operations (Part 1)
 - Combined Workspace Dashboard (Projects, Teams, Financials, and Tasks)
 - Project Creation and Management Page
+
+Stage 47: Workspace Operations (Part 2)
 - Unified Schedule and Calendar Page
+
+Stage 48: Workspace Operations (Part 3)
 - Task and Workflow Management Page
 
-Stage 17: Resources and Account Management
+Stage 49: Resources and Account Management (Part 1)
 - File and Resource Management Page
 - Combined Settings Page
+
+Stage 50: Resources and Account Management (Part 2)
 - Message Notifications and Settings Page – Design Brief
+
+Stage 51: Resources and Account Management (Part 3)
 - Combined Billing and Subscription Page
 
-Stage 18: Analytics and Blogging
+Stage 52: Analytics and Blogging (Part 1)
 - Combined Stats and Analytics Page
 - Combined Blog Homepage and Categories Page
+
+Stage 53: Analytics and Blogging (Part 2)
 - Article Page
+
+Stage 54: Analytics and Blogging (Part 3)
 - Combined Dispute Dashboard (Disputor and Disputee)
 
-Stage 19: Dispute Resolution and Support
+Stage 55: Dispute Resolution and Support (Part 1)
 - Dispute Management Page (Details and Resolution Tools)
 - Dispute Creation and Response Form Page
+
+Stage 56: Dispute Resolution and Support (Part 2)
 - Role-Based Combined Admin Dashboard
+
+Stage 57: Dispute Resolution and Support (Part 3)
 - Unified Support and Dispute Management Page
 
-Stage 20: Administration and Affiliate
+Stage 58: Administration and Affiliate (Part 1)
 - User and Content Management Page with Role-Specific Access
 - Combined Analytics and Audit Page
+
+Stage 59: Administration and Affiliate (Part 2)
 - System Settings and Employee Management Page
+
+Stage 60: Administration and Affiliate (Part 3)
 - Affiliate management
 


### PR DESCRIPTION
## Summary
- Split the frontend staging plan into 60 smaller stages by dividing each original stage into three parts
- Keeps every existing task but distributes them across more granular steps for easier planning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68934b028c248320869421ec8f6ce1dc