### PR TITLE
feat: enhance onboarding auth pages

### DIFF
--- a/backend/controllers/auth.js
+++ b/backend/controllers/auth.js
@@ -1,6 +1,7 @@
 const { register, login, resetPassword, verifyToken } = require('../services/auth');
 const { createProfile } = require('../services/profile');
 const verifyRecaptcha = require('../utils/verifyRecaptcha');
+const securityService = require('../services/security');
 
 async function registerHandler(req, res) {
   const { username, password, role, fullName, email, phone, location, bio, expertise, recaptchaToken } = req.validatedBody;
@@ -18,8 +19,11 @@ async function registerHandler(req, res) {
 }
 
 async function loginHandler(req, res) {
-  const { username, password } = req.validatedBody;
+  const { username, password, code } = req.validatedBody;
   try {
+    if (code) {
+      securityService.verifyMfa(username, code);
+    }
     const result = await login(username, password);
     res.json(result);
   } catch (err) {

--- a/backend/validation/auth.js
+++ b/backend/validation/auth.js
@@ -18,7 +18,8 @@ const registerSchema = Joi.object({
 
 const loginSchema = Joi.object({
   username: Joi.string().required(),
-  password: Joi.string().required()
+  password: Joi.string().required(),
+  code: Joi.string().optional()
 });
 
 module.exports = { registerSchema, loginSchema };

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
 VITE_API_BASE_URL=http://localhost:3000
+VITE_RECAPTCHA_SITE_KEY=your_recaptcha_site_key

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,15 +1,20 @@
 import apiClient from '../utils/apiClient.js';
 
-export async function login({ username, password }) {
-  const { data } = await apiClient.post('/auth/login', { username, password });
+export async function login({ username, password, code }, remember = true) {
+  const { data } = await apiClient.post('/auth/login', { username, password, code });
   const { token } = data;
-  localStorage.setItem('token', token);
+  const storage = remember ? localStorage : sessionStorage;
+  storage.setItem('token', token);
   const meRes = await apiClient.get('/auth/me');
   return meRes.data;
 }
 
 export async function register(payload) {
   await apiClient.post('/auth/register', payload);
+}
+
+export async function resetPassword(username, password) {
+  await apiClient.post('/auth/reset-password', { username, password });
 }
 
 export async function me() {

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -51,9 +51,14 @@ export default function NavBar() {
           </Button>
         </>
       ) : (
-        <Button variant="outline" color="white" onClick={() => navigate('/login')}>
-          Login
-        </Button>
+        <>
+          <Button mr={2} variant="outline" color="white" onClick={() => navigate('/login')}>
+            Login
+          </Button>
+          <Button color="teal.500" bg="white" onClick={() => navigate('/signup')}>
+            Sign Up
+          </Button>
+        </>
       )}
     </Flex>
   );

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -13,11 +13,13 @@ export function AuthProvider({ children }) {
         const data = await fetchMe();
         setUser(data);
         if (data?.id) {
-          localStorage.setItem('userId', data.id);
+          const storage = localStorage.getItem('token') ? localStorage : sessionStorage;
+          storage.setItem('userId', data.id);
         }
       } catch {
         setUser(null);
         localStorage.removeItem('userId');
+        sessionStorage.removeItem('userId');
       } finally {
         setLoading(false);
       }
@@ -25,17 +27,20 @@ export function AuthProvider({ children }) {
     loadUser();
   }, []);
 
-  async function login(username, password) {
-    const data = await apiLogin({ username, password });
+  async function login(username, password, code, remember = true) {
+    const data = await apiLogin({ username, password, code }, remember);
     if (data?.id) {
-      localStorage.setItem('userId', data.id);
+      const storage = remember ? localStorage : sessionStorage;
+      storage.setItem('userId', data.id);
     }
     setUser(data);
   }
 
   function logout() {
     localStorage.removeItem('token');
+    sessionStorage.removeItem('token');
     localStorage.removeItem('userId');
+    sessionStorage.removeItem('userId');
     setUser(null);
   }
 

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -33,7 +33,7 @@ export default function LandingPage() {
   }, []);
 
   return (
-    <Box>
+    <Box className="landing-page">
       <HStack as="header" className="landing-header" justify="space-between" align="center" p={4} boxShadow="sm" position="sticky" top="0" bg="white" zIndex="1000">
         <Heading size="md">Workhouse</Heading>
         <HStack spacing={4}>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -10,16 +10,32 @@ import {
   Input,
   Link,
   Stack,
-  useToast
+  useToast,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  useDisclosure,
+  Text
 } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext.jsx';
+import { resetPassword } from '../api/auth.js';
 import '../styles/LoginPage.css';
 
 export default function LoginPage() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [code, setCode] = useState('');
+  const [remember, setRemember] = useState(true);
+  const [use2FA, setUse2FA] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [newPassword, setNewPassword] = useState('');
   const toast = useToast();
   const navigate = useNavigate();
   const { login } = useAuth();
@@ -27,13 +43,25 @@ export default function LoginPage() {
   async function handleSubmit(e) {
     e.preventDefault();
     setLoading(true);
+    setError('');
     try {
-      await login(username, password);
+      await login(username, password, use2FA ? code : undefined, remember);
       navigate('/dashboard');
     } catch (err) {
-      toast({ title: 'Login failed', status: 'error', description: err.message });
+      setError(err.message);
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function handleReset() {
+    try {
+      await resetPassword(username, newPassword);
+      toast({ title: 'Password updated', status: 'success', duration: 3000, isClosable: true });
+      setNewPassword('');
+      onClose();
+    } catch (err) {
+      toast({ title: err.message, status: 'error', duration: 3000, isClosable: true });
     }
   }
 
@@ -51,15 +79,45 @@ export default function LoginPage() {
               <FormLabel>Password</FormLabel>
               <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
             </FormControl>
-            <Checkbox colorScheme="teal">Remember Me</Checkbox>
+            {use2FA && (
+              <FormControl id="code" isRequired>
+                <FormLabel>2FA Code</FormLabel>
+                <Input value={code} onChange={(e) => setCode(e.target.value)} />
+              </FormControl>
+            )}
+            <Checkbox colorScheme="teal" isChecked={remember} onChange={(e) => setRemember(e.target.checked)}>
+              Remember Me
+            </Checkbox>
+            <Checkbox colorScheme="teal" isChecked={use2FA} onChange={(e) => setUse2FA(e.target.checked)}>
+              Use 2FA
+            </Checkbox>
+            {error && <Text color="red.500">{error}</Text>}
             <Button type="submit" colorScheme="teal" isLoading={loading} loadingText="Logging in">
               Login
             </Button>
-            <Link color="teal.500" href="#">Forgot Password?</Link>
+            <Link color="teal.500" onClick={onOpen}>Forgot Password?</Link>
             <Link color="teal.500" onClick={() => navigate('/signup')}>Create an account</Link>
           </Stack>
         </form>
       </Box>
+
+      <Modal isOpen={isOpen} onClose={onClose} isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Reset Password</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <FormControl mb={4}>
+              <FormLabel>New Password</FormLabel>
+              <Input type="password" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} />
+            </FormControl>
+          </ModalBody>
+          <ModalFooter>
+            <Button colorScheme="teal" mr={3} onClick={handleReset}>Submit</Button>
+            <Button variant="ghost" onClick={onClose}>Cancel</Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </Flex>
   );
 }

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -5,3 +5,28 @@
   justify-content: center;
   align-items: center;
 }
+
+.landing-header a {
+  text-decoration: none;
+}
+
+.hero {
+  background-image: url('https://images.unsplash.com/photo-1521791055366-0d553872125f?auto=format&fit=crop&w=1350&q=80');
+  background-size: cover;
+  background-position: center;
+  color: white;
+  min-height: 60vh;
+}
+
+.testimonial {
+  max-width: 600px;
+}
+
+.landing-footer a {
+  color: #ffffff;
+}
+
+.feature-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+}

--- a/frontend/src/styles/LoginPage.css
+++ b/frontend/src/styles/LoginPage.css
@@ -6,3 +6,7 @@
   justify-content: center;
   background-color: #f7fafc;
 }
+
+.login-page .chakra-stack {
+  width: 100%;
+}

--- a/frontend/src/utils/apiClient.js
+++ b/frontend/src/utils/apiClient.js
@@ -8,7 +8,7 @@ const apiClient = axios.create({
 });
 
 apiClient.interceptors.request.use((config) => {
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem('token') || sessionStorage.getItem('token');
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }


### PR DESCRIPTION
## Summary
- add 2FA, remember-me and password reset modal to login
- improve landing page styling and navbar sign-up link
- support session-based auth tokens and optional MFA in backend

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934d5e8728832091ae8fd7dd32ff6a