### PR TITLE
feat: add resume analysis and onboarding enhancements

### DIFF
--- a/backend/controllers/resume.js
+++ b/backend/controllers/resume.js
@@ -1,4 +1,4 @@
-const { storeCv, generateCv, storeCoverLetter, generateCoverLetter, getResume } = require('../services/resume');
+const { storeCv, generateCv, storeCoverLetter, generateCoverLetter, getResume, analyzeCvText } = require('../services/resume');
 
 async function uploadCv(req, res) {
   try {
@@ -52,4 +52,15 @@ async function fetchResume(req, res) {
   }
 }
 
-module.exports = { uploadCv, createCv, createCoverLetter, uploadCoverLetter, fetchResume };
+async function analyzeCv(req, res) {
+  const { content } = req.body;
+  try {
+    const analysis = await analyzeCvText(content || '');
+    res.json(analysis);
+  } catch (err) {
+    console.error('CV analysis failed', err);
+    res.status(500).json({ error: 'Failed to analyze CV' });
+  }
+}
+
+module.exports = { uploadCv, createCv, createCoverLetter, uploadCoverLetter, fetchResume, analyzeCv };

--- a/backend/database/resume.sql
+++ b/backend/database/resume.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS resumes (
+  id SERIAL PRIMARY KEY,
+  user_id VARCHAR(255) NOT NULL,
+  cv TEXT,
+  cv_filename TEXT,
+  cover_letter TEXT,
+  cover_letter_filename TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/routes/resume.js
+++ b/backend/routes/resume.js
@@ -2,13 +2,14 @@ const express = require('express');
 const multer = require('multer');
 const path = require('path');
 const auth = require('../middleware/auth');
-const { uploadCv, createCv, createCoverLetter, uploadCoverLetter, fetchResume } = require('../controllers/resume');
+const { uploadCv, createCv, createCoverLetter, uploadCoverLetter, fetchResume, analyzeCv } = require('../controllers/resume');
 
 const router = express.Router();
 const upload = multer({ dest: path.join(__dirname, '../uploads') });
 
 router.post('/cv/upload', auth, upload.single('cv'), uploadCv);
 router.post('/cv/generate', auth, createCv);
+router.post('/cv/analyze', auth, analyzeCv);
 router.post('/cover-letter/upload', auth, upload.single('coverLetter'), uploadCoverLetter);
 router.post('/cover-letter/generate', auth, createCoverLetter);
 router.get('/', auth, fetchResume);

--- a/backend/services/resume.js
+++ b/backend/services/resume.js
@@ -1,6 +1,46 @@
 const { saveCv, getCv, saveCoverLetter, getCoverLetter } = require('../models/resume');
 const { generateText } = require('../utils/aiClient');
 
+const KEYWORDS = ['team', 'leadership', 'communication', 'project', 'experience', 'management'];
+
+function countSyllables(word) {
+  word = word.toLowerCase();
+  if (word.length <= 3) return 1;
+  word = word.replace(/(?:[^laeiouy]es|ed|[^laeiouy]e)$/i, '');
+  word = word.replace(/^y/, '');
+  const matches = word.match(/[aeiouy]{1,2}/g);
+  return matches ? matches.length : 1;
+}
+
+function analyzeText(content) {
+  const words = content.toLowerCase().match(/\b[^\s]+\b/g) || [];
+  const wordCount = words.length;
+  const sentences = content.match(/[.!?]+/g);
+  const sentenceCount = sentences ? sentences.length : 1;
+  const syllableCount = words.reduce((sum, w) => sum + countSyllables(w), 0);
+  const keywordMatches = KEYWORDS.filter(k => words.includes(k)).length;
+  const keywordDensity = wordCount ? (keywordMatches / wordCount) * 100 : 0;
+  const readability = wordCount ? 206.835 - 1.015 * (wordCount / sentenceCount) - 84.6 * (syllableCount / wordCount) : 0;
+
+  const suggestions = [];
+  if (keywordDensity < 2) {
+    suggestions.push('Consider adding industry keywords like leadership or project management.');
+  }
+  if (readability < 60) {
+    suggestions.push('Simplify sentences to improve readability.');
+  }
+  if (wordCount < 100) {
+    suggestions.push('Expand on your experience with more detail.');
+  }
+
+  return {
+    wordCount,
+    keywordDensity: Number(keywordDensity.toFixed(2)),
+    readability: Number(readability.toFixed(2)),
+    suggestions,
+  };
+}
+
 async function storeCv(userId, file) {
   const record = {
     userId,
@@ -41,4 +81,8 @@ async function getResume(userId) {
   return { cv: getCv(userId), coverLetter: getCoverLetter(userId) };
 }
 
-module.exports = { storeCv, generateCv, storeCoverLetter, generateCoverLetter, getResume };
+async function analyzeCvText(content) {
+  return analyzeText(content);
+}
+
+module.exports = { storeCv, generateCv, storeCoverLetter, generateCoverLetter, getResume, analyzeCvText };

--- a/backend/tests/resume.test.js
+++ b/backend/tests/resume.test.js
@@ -8,4 +8,10 @@ describe('resume routes', () => {
     expect(content).toMatch(/express\.Router\(/);
     expect(content).toMatch(/module\.exports\s*=\s*router/);
   });
+
+  test('should include CV analysis route', () => {
+    const filePath = path.join(__dirname, '../routes/resume.js');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect(content).toContain("router.post('/cv/analyze'");
+  });
 });

--- a/frontend/api/resume.js
+++ b/frontend/api/resume.js
@@ -33,5 +33,14 @@
     return res.json();
   }
 
-  global.resumeAPI = { uploadCv, generateCv, uploadCoverLetter, generateCoverLetter };
+  async function analyzeCv(content){
+    const res = await apiFetch('/resume/cv/analyze', {
+      method: 'POST',
+      body: JSON.stringify({ content })
+    });
+    if(!res.ok) throw new Error('Failed to analyze CV');
+    return res.json();
+  }
+
+  global.resumeAPI = { uploadCv, generateCv, uploadCoverLetter, generateCoverLetter, analyzeCv };
 })(window);

--- a/frontend/src/api/resume.js
+++ b/frontend/src/api/resume.js
@@ -32,3 +32,8 @@ export async function fetchResume() {
   const { data } = await apiClient.get('/resume');
   return data;
 }
+
+export async function analyzeCv(content) {
+  const { data } = await apiClient.post('/resume/cv/analyze', { content });
+  return data;
+}

--- a/frontend/src/components/ProgressIndicator.jsx
+++ b/frontend/src/components/ProgressIndicator.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Box, Progress, Text } from '@chakra-ui/react';
+import '../styles/ProgressIndicator.css';
+
+export default function ProgressIndicator({ step, total }) {
+  const percent = (step / total) * 100;
+  return (
+    <Box className="progress-indicator">
+      <Progress value={percent} mb={2} />
+      <Text className="progress-label">Step {step} of {total}</Text>
+    </Box>
+  );
+}

--- a/frontend/src/pages/OnboardingDocumentsPage.jsx
+++ b/frontend/src/pages/OnboardingDocumentsPage.jsx
@@ -2,10 +2,14 @@ import React, { useState, useEffect } from 'react';
 import {
   Box,
   Button,
+  Flex,
   FormControl,
   FormLabel,
   Heading,
   Input,
+  List,
+  ListItem,
+  Select,
   Text,
   Textarea,
   VStack,
@@ -16,20 +20,37 @@ import {
   generateCv,
   uploadCoverLetter,
   generateCoverLetter,
-  fetchResume
+  fetchResume,
+  analyzeCv
 } from '../api/resume.js';
+import ProgressIndicator from '../components/ProgressIndicator.jsx';
+import { useNavigate } from 'react-router-dom';
 import '../styles/OnboardingDocumentsPage.css';
 
 export default function OnboardingDocumentsPage() {
   const [cvFile, setCvFile] = useState(null);
   const [cvPrompt, setCvPrompt] = useState('');
   const [coverFile, setCoverFile] = useState(null);
-  const [coverPrompt, setCoverPrompt] = useState('');
+  const [coverContent, setCoverContent] = useState('');
+  const [coverIndustry, setCoverIndustry] = useState('');
   const [resume, setResume] = useState({ cv: null, coverLetter: null });
+  const [analysis, setAnalysis] = useState(null);
   const toast = useToast();
+  const navigate = useNavigate();
+
+  const templates = {
+    Technology: 'Dear Hiring Manager,\nI am excited to apply for the software developer role...',
+    Marketing: 'Dear Hiring Manager,\nAs a marketing specialist, I have managed digital campaigns...',
+    Finance: 'Dear Hiring Manager,\nWith a strong background in risk assessment, I will add value to your team...'
+  };
 
   useEffect(() => {
-    fetchResume().then(setResume).catch(() => {});
+    fetchResume().then((data) => {
+      setResume(data);
+      if (data.cv?.content) {
+        analyzeCv(data.cv.content).then(setAnalysis).catch(() => {});
+      }
+    }).catch(() => {});
   }, []);
 
   const handleUploadCv = async () => {
@@ -38,6 +59,10 @@ export default function OnboardingDocumentsPage() {
       await uploadCv(cvFile);
       const data = await fetchResume();
       setResume(data);
+      if (data.cv?.content) {
+        const a = await analyzeCv(data.cv.content);
+        setAnalysis(a);
+      }
       toast({ title: 'CV uploaded', status: 'success', duration: 3000, isClosable: true });
     } catch (err) {
       toast({ title: 'Upload failed', status: 'error', description: err.message });
@@ -48,6 +73,8 @@ export default function OnboardingDocumentsPage() {
     try {
       const { content } = await generateCv(cvPrompt);
       setResume((prev) => ({ ...prev, cv: { content } }));
+      const a = await analyzeCv(content);
+      setAnalysis(a);
     } catch (err) {
       toast({ title: 'Generation failed', status: 'error', description: err.message });
     }
@@ -65,20 +92,28 @@ export default function OnboardingDocumentsPage() {
     }
   };
 
+  const handleTemplateChange = (e) => {
+    const key = e.target.value;
+    setCoverIndustry(key);
+    setCoverContent(templates[key] || '');
+  };
+
   const handleGenerateCover = async () => {
     try {
-      const { content } = await generateCoverLetter(coverPrompt);
+      const { content } = await generateCoverLetter(coverContent);
       setResume((prev) => ({ ...prev, coverLetter: { content } }));
+      setCoverContent(content);
     } catch (err) {
       toast({ title: 'Generation failed', status: 'error', description: err.message });
     }
   };
 
   return (
-    <Box className="documents-page" maxW="xl" mx="auto" p={6}>
+    <Box className="documents-page" p={6}>
+      <ProgressIndicator step={3} total={3} />
       <Heading mb={6} textAlign="center">CV & Cover Letter</Heading>
-      <VStack align="stretch" spacing={6}>
-        <Box>
+      <Flex direction={{ base: 'column', md: 'row' }} gap={6}>
+        <Box flex="1" className="cv-section">
           <Heading size="md" mb={4}>Curriculum Vitae</Heading>
           {resume.cv?.filename && <Text mb={2}>Uploaded: {resume.cv.filename}</Text>}
           {resume.cv?.content && (
@@ -94,25 +129,47 @@ export default function OnboardingDocumentsPage() {
             <Textarea value={cvPrompt} onChange={(e) => setCvPrompt(e.target.value)} />
           </FormControl>
           <Button onClick={handleGenerateCv} mt={2} colorScheme="teal">Generate</Button>
+          {analysis && (
+            <Box mt={4}>
+              <Heading size="sm" mb={2}>ATS Suggestions</Heading>
+              <List spacing={1}>
+                {analysis.suggestions.map((s, i) => (
+                  <ListItem key={i}>{s}</ListItem>
+                ))}
+              </List>
+            </Box>
+          )}
         </Box>
-        <Box>
+        <Box flex="1" className="cover-section">
           <Heading size="md" mb={4}>Cover Letter</Heading>
           {resume.coverLetter?.filename && <Text mb={2}>Uploaded: {resume.coverLetter.filename}</Text>}
-          {resume.coverLetter?.content && (
-            <Textarea value={resume.coverLetter.content} readOnly mb={2} />
-          )}
           <FormControl mb={2}>
             <FormLabel>Upload Cover Letter</FormLabel>
             <Input type="file" onChange={(e) => setCoverFile(e.target.files[0])} />
           </FormControl>
           <Button onClick={handleUploadCover} mr={2} colorScheme="teal">Upload</Button>
           <FormControl mt={4}>
-            <FormLabel>Generate Cover Letter</FormLabel>
-            <Textarea value={coverPrompt} onChange={(e) => setCoverPrompt(e.target.value)} />
+            <FormLabel>Template</FormLabel>
+            <Select placeholder="Select Industry" value={coverIndustry} onChange={handleTemplateChange}>
+              {Object.keys(templates).map((k) => (
+                <option key={k} value={k}>{k}</option>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl mt={4}>
+            <FormLabel>Edit Cover Letter</FormLabel>
+            <Textarea value={coverContent} onChange={(e) => setCoverContent(e.target.value)} h="200px" />
           </FormControl>
           <Button onClick={handleGenerateCover} mt={2} colorScheme="teal">Generate</Button>
+          {coverContent && (
+            <Box mt={4} p={4} borderWidth="1px" borderRadius="md">
+              <Heading size="sm" mb={2}>Preview</Heading>
+              <Text whiteSpace="pre-wrap">{coverContent}</Text>
+            </Box>
+          )}
         </Box>
-      </VStack>
+      </Flex>
+      <Button mt={6} colorScheme="purple" onClick={() => navigate('/dashboard')}>Finish</Button>
     </Box>
   );
 }

--- a/frontend/src/styles/OnboardingDocumentsPage.css
+++ b/frontend/src/styles/OnboardingDocumentsPage.css
@@ -1,3 +1,11 @@
 .documents-page {
-  background-color: #f7fafc;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.cv-section, .cover-section {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }

--- a/frontend/src/styles/ProgressIndicator.css
+++ b/frontend/src/styles/ProgressIndicator.css
@@ -1,0 +1,8 @@
+.progress-indicator {
+  margin-bottom: 1rem;
+}
+
+.progress-label {
+  font-weight: 600;
+  text-align: right;
+}


### PR DESCRIPTION
## Summary
- add backend analysis service and API for CV review
- enhance onboarding documents page with progress, ATS suggestions, and cover letter templates
- introduce reusable progress indicator component and resume table schema

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68934d71df988320a7947675866ace40