### PR TITLE
feat: enhance live feed filtering and dashboard navigation

### DIFF
--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,5 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Heading, SimpleGrid, Stat, StatLabel, StatNumber, Spinner, Button } from '@chakra-ui/react';
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  Stat,
+  StatLabel,
+  StatNumber,
+  Spinner,
+  Button
+} from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/DashboardPage.css';
 import { getDashboard } from '../api/dashboard.js';
@@ -29,36 +38,16 @@ export default function DashboardPage() {
   if (!data) return <Box p={4}>Unable to load dashboard.</Box>;
 
   return (
-    <Box className="dashboard-page">
+    <Box className="dashboard-page" p={4}>
       <Heading mb={4}>Welcome back, {user?.name || user?.username}</Heading>
-      <Button mb={4} colorScheme="teal" onClick={() => navigate('/feed')}>
+      <Button mb={4} colorScheme="teal" onClick={() => navigate('/feed')} mr={2}>
         View Live Feed
       </Button>
-      <SimpleGrid columns={[1, 3]} spacing={4}>
+      <Button mb={4} colorScheme="blue" onClick={() => navigate('/profile')}>
+        View Profile
+      </Button>
+      <SimpleGrid columns={[1, 3]} spacing={4} mt={4}>
         {'totalSpend' in data && (
-      <NavBar />
-      <NavMenu />
-      <Box p={4}>
-        <Heading mb={4}>Welcome back, {user?.name || user?.username}</Heading>
-        <Button mb={4} colorScheme="purple" onClick={() => navigate('/install')}>
-          Run Installation Wizard
-        </Button>
-        <Button mb={4} colorScheme="teal" onClick={() => navigate('/feed')}>
-          View Live Feed
-        </Button>
-        <SimpleGrid columns={[1, 3]} spacing={4}>
-          {'totalSpend' in data && (
-            <Stat>
-              <StatLabel>Total Spend</StatLabel>
-              <StatNumber>${data.totalSpend}</StatNumber>
-            </Stat>
-          )}
-          {'totalEarnings' in data && (
-            <Stat>
-              <StatLabel>Total Earnings</StatLabel>
-              <StatNumber>${data.totalEarnings}</StatNumber>
-            </Stat>
-          )}
           <Stat>
             <StatLabel>Total Spend</StatLabel>
             <StatNumber>${data.totalSpend}</StatNumber>
@@ -82,3 +71,4 @@ export default function DashboardPage() {
     </Box>
   );
 }
+

--- a/frontend/src/pages/LiveFeedPage.jsx
+++ b/frontend/src/pages/LiveFeedPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Heading, VStack, HStack, Textarea, Button, Text, Spinner } from '@chakra-ui/react';
+import { Box, Heading, VStack, HStack, Textarea, Button, Text, Spinner, Select } from '@chakra-ui/react';
 import '../styles/LiveFeedPage.css';
 import { getPosts, createPost, likePost, getEvents } from '../api/liveFeed.js';
 
@@ -7,6 +7,7 @@ export default function LiveFeedPage() {
   const [posts, setPosts] = useState([]);
   const [events, setEvents] = useState([]);
   const [content, setContent] = useState('');
+  const [category, setCategory] = useState('');
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -24,10 +25,21 @@ export default function LiveFeedPage() {
     load();
   }, []);
 
+  const handleCategoryChange = async (e) => {
+    const value = e.target.value;
+    setCategory(value);
+    try {
+      const filtered = await getPosts(value || undefined);
+      setPosts(filtered);
+    } catch (err) {
+      console.error('Failed to filter posts', err);
+    }
+  };
+
   const handlePost = async () => {
     if (!content.trim()) return;
     try {
-      const newPost = await createPost({ content });
+      const newPost = await createPost({ content, category });
       setPosts([newPost, ...posts]);
       setContent('');
     } catch (err) {
@@ -51,9 +63,18 @@ export default function LiveFeedPage() {
       <Heading mb={4}>Live Feed</Heading>
       <VStack align="stretch" spacing={2} mb={6}>
         <Textarea placeholder="Share an update..." value={content} onChange={(e) => setContent(e.target.value)} />
-        <Button alignSelf="flex-end" colorScheme="teal" onClick={handlePost}>
-          Post
-        </Button>
+        <HStack>
+          <Select placeholder="Select category" value={category} onChange={handleCategoryChange}>
+            <option value="employment">Employment</option>
+            <option value="freelancing">Freelancing</option>
+            <option value="education">Education</option>
+            <option value="networking">Networking</option>
+            <option value="local">Local Services</option>
+          </Select>
+          <Button colorScheme="teal" onClick={handlePost}>
+            Post
+          </Button>
+        </HStack>
       </VStack>
       <HStack align="start" spacing={8} alignItems="flex-start">
         <VStack flex="1" spacing={4} align="stretch">


### PR DESCRIPTION
## Summary
- add category filtering and posting to live feed page
- simplify dashboard layout with direct links to feed and profile

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934d85acb88320aff6c4312009fac6