### PR TITLE
feat: enable profile customization schema and improve dashboard

### DIFF
--- a/.env
+++ b/.env
@@ -43,5 +43,7 @@ VITE_GIG_PLACEHOLDER_URL=/gigs/placeholder
 VITE_FILE_IO_API=/files
 VITE_ANALYTICS_ENDPOINT=/analytics/content/performance
 VITE_AUDIT_RESULTS_ENDPOINT=/security/compliance/audit-results
+VITE_IMGBB_UPLOAD_URL=https://api.imgbb.com/1/upload
+VITE_IMGBB_API_KEY=
 VITE_CLASSROOM_DEFAULT_ROOM=WorkhouseClassroom
 VITE_RECAPTCHA_SITE_KEY=

--- a/.env.example
+++ b/.env.example
@@ -46,5 +46,7 @@ VITE_GIG_PLACEHOLDER_URL=/gigs/placeholder
 VITE_FILE_IO_API=/files
 VITE_ANALYTICS_ENDPOINT=/analytics/content/performance
 VITE_AUDIT_RESULTS_ENDPOINT=/security/compliance/audit-results
+VITE_IMGBB_UPLOAD_URL=https://api.imgbb.com/1/upload
+VITE_IMGBB_API_KEY=
 VITE_CLASSROOM_DEFAULT_ROOM=WorkhouseClassroom
 VITE_RECAPTCHA_SITE_KEY=

--- a/backend/validation/profile.js
+++ b/backend/validation/profile.js
@@ -56,6 +56,8 @@ const updateProfileSchema = Joi.object({
   skills: Joi.array().items(Joi.string()),
   visibility: visibilitySchema,
   theme: themeSchema,
+  fullName: Joi.string(),
+  location: Joi.string(),
 }).min(1);
 
 const portfolioItemSchema = Joi.object({

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,5 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Heading, SimpleGrid, Stat, StatLabel, StatNumber, Spinner, Button } from '@chakra-ui/react';
+import {
+  Box,
+  Heading,
+  SimpleGrid,
+  Stat,
+  StatLabel,
+  StatNumber,
+  Spinner,
+  Button
+} from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/DashboardPage.css';
 import { getDashboard } from '../api/dashboard.js';
@@ -29,36 +38,16 @@ export default function DashboardPage() {
   if (!data) return <Box p={4}>Unable to load dashboard.</Box>;
 
   return (
-    <Box className="dashboard-page">
+    <Box className="dashboard-page" p={4}>
       <Heading mb={4}>Welcome back, {user?.name || user?.username}</Heading>
+      <Button mb={4} colorScheme="purple" onClick={() => navigate('/profile/customize')}>
+        Customize Profile
+      </Button>
       <Button mb={4} colorScheme="teal" onClick={() => navigate('/feed')}>
         View Live Feed
       </Button>
       <SimpleGrid columns={[1, 3]} spacing={4}>
         {'totalSpend' in data && (
-      <NavBar />
-      <NavMenu />
-      <Box p={4}>
-        <Heading mb={4}>Welcome back, {user?.name || user?.username}</Heading>
-        <Button mb={4} colorScheme="purple" onClick={() => navigate('/install')}>
-          Run Installation Wizard
-        </Button>
-        <Button mb={4} colorScheme="teal" onClick={() => navigate('/feed')}>
-          View Live Feed
-        </Button>
-        <SimpleGrid columns={[1, 3]} spacing={4}>
-          {'totalSpend' in data && (
-            <Stat>
-              <StatLabel>Total Spend</StatLabel>
-              <StatNumber>${data.totalSpend}</StatNumber>
-            </Stat>
-          )}
-          {'totalEarnings' in data && (
-            <Stat>
-              <StatLabel>Total Earnings</StatLabel>
-              <StatNumber>${data.totalEarnings}</StatNumber>
-            </Stat>
-          )}
           <Stat>
             <StatLabel>Total Spend</StatLabel>
             <StatNumber>${data.totalSpend}</StatNumber>
@@ -82,3 +71,4 @@ export default function DashboardPage() {
     </Box>
   );
 }
+


### PR DESCRIPTION
## Summary
- extend profile validation to support fullName and location
- configure image upload environment variables
- clean up dashboard and add shortcut to profile customization

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68934d90e0388320981629e35a1c99ae