### PR TITLE
feat: add gig dashboard and order management

### DIFF
--- a/backend/controllers/gig.js
+++ b/backend/controllers/gig.js
@@ -1,4 +1,5 @@
 const { createGig, listGigs, getGig, updateGig, removeGig, searchGigs } = require('../services/gig');
+const Order = require('../models/order');
 const { gigSchema } = require('../validation/gig');
 const logger = require('../utils/logger');
 
@@ -66,6 +67,29 @@ async function searchGigsHandler(req, res) {
   }
 }
 
+async function createGigOrderHandler(req, res) {
+  const { gigId } = req.params;
+  const buyerId = req.user?.id || req.user?.username || 'anonymous';
+  const { description = '' } = req.body;
+  try {
+    const gig = await getGig(gigId);
+    if (!gig) {
+      return res.status(404).json({ error: 'Gig not found' });
+    }
+    const order = Order.createOrder({
+      buyerId,
+      sellerId: gig.ownerId,
+      gigId,
+      status: 'pending',
+      description,
+    });
+    res.status(201).json(order);
+  } catch (err) {
+    logger.error('Failed to create gig order', { error: err.message });
+    res.status(500).json({ error: 'Failed to create gig order' });
+  }
+}
+
 module.exports = {
   createGigHandler,
   listGigsHandler,
@@ -73,4 +97,5 @@ module.exports = {
   updateGigHandler,
   deleteGigHandler,
   searchGigsHandler,
+  createGigOrderHandler,
 };

--- a/backend/controllers/serviceProviderOrders.js
+++ b/backend/controllers/serviceProviderOrders.js
@@ -1,11 +1,11 @@
 const Order = require('../models/order');
 
 exports.createOrder = (req, res) => {
-  const { buyerId, sellerId, serviceId, status, description } = req.body;
-  if (!buyerId || !sellerId || !serviceId) {
-    return res.status(400).json({ error: 'buyerId, sellerId and serviceId are required' });
+  const { buyerId, sellerId, serviceId, gigId, status, description } = req.body;
+  if (!buyerId || !sellerId || (!serviceId && !gigId)) {
+    return res.status(400).json({ error: 'buyerId, sellerId and serviceId or gigId are required' });
   }
-  const order = Order.createOrder({ buyerId, sellerId, serviceId, status, description });
+  const order = Order.createOrder({ buyerId, sellerId, serviceId, gigId, status, description });
   res.status(201).json(order);
 };
 

--- a/backend/models/order.js
+++ b/backend/models/order.js
@@ -1,14 +1,15 @@
 const { randomUUID } = require('crypto');
 
-// In-memory storage for service provider orders
+// In-memory storage for orders
 const orders = [];
 
-function createOrder({ buyerId, sellerId, serviceId, status = 'pending', description = '' }) {
+function createOrder({ buyerId, sellerId, serviceId = null, gigId = null, status = 'pending', description = '' }) {
   const order = {
     id: randomUUID(),
     buyerId,
     sellerId,
     serviceId,
+    gigId,
     status,
     description,
     createdAt: new Date(),

--- a/backend/routes/gigs.js
+++ b/backend/routes/gigs.js
@@ -7,6 +7,7 @@ const {
   updateGigHandler,
   deleteGigHandler,
   searchGigsHandler,
+  createGigOrderHandler,
 } = require('../controllers/gig');
 const { getMyGigsHandler, getAppliedGigsHandler } = require('../controllers/gigs');
 const auth = require('../middleware/auth');
@@ -19,6 +20,7 @@ router.get('/search', auth, validate(gigSearchSchema, 'query'), searchGigsHandle
 router.get('/my-gigs', auth, getMyGigsHandler);
 router.get('/applied', auth, getAppliedGigsHandler);
 router.get('/:gigId', auth, getGigHandler);
+router.post('/:gigId/order', auth, createGigOrderHandler);
 router.put('/:gigId', auth, updateGigHandler);
 router.delete('/:gigId', auth, deleteGigHandler);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ import ServiceOrderManagementPage from './pages/ServiceOrderManagementPage.jsx';
 import ServiceSearchPage from './pages/ServiceSearchPage.jsx';
 import GigSearchPage from './pages/GigSearchPage.jsx';
 import GigDetailPage from './pages/GigDetailPage.jsx';
+import GigsDashboardPage from './pages/GigsDashboardPage.jsx';
 import TaskDashboardPage from './pages/TaskDashboardPage.jsx';
 import TaskManagementPage from './pages/TaskManagementPage.jsx';
 import TaskSearchPage from './pages/TaskSearchPage.jsx';
@@ -118,7 +119,7 @@ export default function App() {
     { path: '/interviews', element: <VirtualInterview />, protected: true },
     { path: '/interviews/:interviewId', element: <InterviewSession />, protected: true },
     { path: '/job-posts', element: <JobPostManagement />, protected: true },
-    { path: '/gigs', element: <PlaceholderPage title="Gigs Dashboard" />, protected: true },
+    { path: '/gigs', element: <GigsDashboardPage />, protected: true },
     { path: '/gigs/manage', element: <PlaceholderPage title="Gig Creation & Management" />, protected: true },
     { path: '/gigs/search', element: <GigSearchPage />, protected: true },
     { path: '/gigs/:id', element: <GigDetailPage />, protected: true },

--- a/frontend/src/api/gigs.js
+++ b/frontend/src/api/gigs.js
@@ -5,6 +5,16 @@ export async function searchGigs(params = {}) {
   return data;
 }
 
+export async function getMyGigs() {
+  const { data } = await apiClient.get('/gigs/my-gigs');
+  return data;
+}
+
+export async function getAppliedGigs() {
+  const { data } = await apiClient.get('/gigs/applied');
+  return data;
+}
+
 export async function getGig(id) {
   const { data } = await apiClient.get(`/gigs/${id}`);
   return data;

--- a/frontend/src/api/orders.js
+++ b/frontend/src/api/orders.js
@@ -14,3 +14,8 @@ export async function updateOrder(id, updates) {
   const { data } = await apiClient.put(`/service-providers/orders/${id}`, updates);
   return data;
 }
+
+export async function createOrder(payload) {
+  const { data } = await apiClient.post('/service-providers/orders', payload);
+  return data;
+}

--- a/frontend/src/pages/GigsDashboardPage.jsx
+++ b/frontend/src/pages/GigsDashboardPage.jsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Heading, Stack, Text, Switch, Table, Thead, Tbody, Tr, Th, Td, Button } from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router-dom';
+import { getMyGigs, getAppliedGigs } from '../api/gigs.js';
+import '../styles/GigsDashboardPage.css';
+
+function GigsDashboardPage() {
+  const [mode, setMode] = useState('seller');
+  const [gigs, setGigs] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = mode === 'seller' ? await getMyGigs() : await getAppliedGigs();
+        setGigs(data);
+      } catch (err) {
+        console.error('Failed to load gigs', err);
+      }
+    }
+    load();
+  }, [mode]);
+
+  return (
+    <Box className="gigs-dashboard-page" p={4}>
+      <Heading size="lg" mb={4}>Gigs Dashboard</Heading>
+      <Stack direction="row" align="center" mb={4}>
+        <Text>Buyer</Text>
+        <Switch colorScheme="teal" isChecked={mode === 'seller'} onChange={(e) => setMode(e.target.checked ? 'seller' : 'buyer')} />
+        <Text>Seller</Text>
+        <Button size="sm" as={RouterLink} to="/gigs/search" colorScheme="teal">Discover</Button>
+      </Stack>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Title</Th>
+            <Th>Status</Th>
+            <Th isNumeric>Orders</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {gigs.map((gig) => (
+            <Tr key={gig.id}>
+              <Td>{gig.title}</Td>
+              <Td>{gig.status}</Td>
+              <Td isNumeric>{gig.orders || 0}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+      {mode === 'seller' && (
+        <Button mt={4} as={RouterLink} to="/gigs/manage" colorScheme="teal">
+          Create New Gig
+        </Button>
+      )}
+    </Box>
+  );
+}
+
+export default GigsDashboardPage;

--- a/frontend/src/pages/OrderManagementPage.jsx
+++ b/frontend/src/pages/OrderManagementPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Heading, Spinner, Select, useDisclosure, Button } from '@chakra-ui/react';
+import { Box, Heading, Spinner, Select, useDisclosure, Button, Stack, Text, Switch } from '@chakra-ui/react';
 import { Link as RouterLink } from 'react-router-dom';
 import '../styles/OrderManagementPage.css';
 import { getOrders } from '../api/orders.js';
@@ -10,6 +10,7 @@ function OrderManagementPage() {
   const [orders, setOrders] = useState([]);
   const [filtered, setFiltered] = useState([]);
   const [statusFilter, setStatusFilter] = useState('');
+  const [role, setRole] = useState('buyer');
   const [selectedOrder, setSelectedOrder] = useState(null);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [loading, setLoading] = useState(true);
@@ -30,10 +31,15 @@ function OrderManagementPage() {
     if (userId) fetchOrders();
   }, [userId]);
 
+  useEffect(() => {
+    let data = orders;
+    data = role === 'buyer' ? data.filter((o) => o.buyerId === userId) : data.filter((o) => o.sellerId === userId);
+    if (statusFilter) data = data.filter((o) => o.status === statusFilter);
+    setFiltered(data);
+  }, [orders, role, statusFilter, userId]);
+
   const handleFilterChange = (e) => {
-    const value = e.target.value;
-    setStatusFilter(value);
-    setFiltered(value ? orders.filter((o) => o.status === value) : orders);
+    setStatusFilter(e.target.value);
   };
 
   const handleSelect = (order) => {
@@ -49,6 +55,11 @@ function OrderManagementPage() {
       <Button as={RouterLink} to="/payments" colorScheme="teal" mb={4}>
         Make Payment
       </Button>
+      <Stack direction="row" align="center" mb={4}>
+        <Text>Buyer</Text>
+        <Switch colorScheme="teal" isChecked={role === 'seller'} onChange={(e) => setRole(e.target.checked ? 'seller' : 'buyer')} />
+        <Text>Seller</Text>
+      </Stack>
       <Select placeholder="Filter by status" value={statusFilter} onChange={handleFilterChange} mb={4}>
         <option value="pending">Pending</option>
         <option value="in_progress">In Progress</option>

--- a/frontend/src/styles/GigsDashboardPage.css
+++ b/frontend/src/styles/GigsDashboardPage.css
@@ -1,0 +1,4 @@
+.gigs-dashboard-page {
+  max-width: 1000px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- support gig-linked orders with new backend endpoint
- add Gigs Dashboard page and buyer/seller order management

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68934dbfd6688320b2166db79315829e