### PR TITLE
feat: add chat widget and employment dashboard updates

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -76,6 +76,7 @@ import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 import { ProfileProvider } from './context/ProfileContext.jsx';
 import { TaskProvider } from './context/TaskContext.jsx';
 import { AffiliateProvider } from './context/AffiliateContext.jsx';
+import ChatWidget from './components/ChatWidget.jsx';
 
 function Protected({ children }) {
   const { user, loading } = useAuth();
@@ -233,6 +234,7 @@ export default function App() {
                     })}
                   </Routes>
                 </Box>
+                <ChatWidget />
               </AffiliateProvider>
             </TaskProvider>
           </ProfileProvider>

--- a/frontend/src/api/jobs.js
+++ b/frontend/src/api/jobs.js
@@ -1,0 +1,11 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function listPublicJobs() {
+  const { data } = await apiClient.get('/jobs');
+  return data;
+}
+
+export async function getPublicJob(jobId) {
+  const { data } = await apiClient.get(`/jobs/${jobId}`);
+  return data;
+}

--- a/frontend/src/components/ChatWidget.jsx
+++ b/frontend/src/components/ChatWidget.jsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, Flex, Text, Input, Button } from '@chakra-ui/react';
+import { fetchConversations, fetchMessages, sendMessage } from '../api/communications.js';
+import { useAuth } from '../context/AuthContext.jsx';
+import '../styles/ChatWidget.css';
+
+export default function ChatWidget({ defaultOpen = false }) {
+  const { user } = useAuth();
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const [conversations, setConversations] = useState([]);
+  const [active, setActive] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [text, setText] = useState('');
+  const endRef = useRef(null);
+
+  useEffect(() => {
+    if (isOpen && user) {
+      loadConversations();
+    }
+  }, [isOpen, user]);
+
+  if (!user) return null;
+
+  async function loadConversations() {
+    try {
+      const data = await fetchConversations();
+      setConversations(data);
+    } catch (err) {
+      console.error('Failed to load conversations', err);
+    }
+  }
+
+  async function openConversation(id) {
+    setActive(id);
+    try {
+      const data = await fetchMessages(id);
+      setMessages(data);
+      scrollToEnd();
+    } catch (err) {
+      console.error('Failed to load messages', err);
+    }
+  }
+
+  function scrollToEnd() {
+    setTimeout(() => endRef.current?.scrollIntoView({ behavior: 'smooth' }), 0);
+  }
+
+  async function handleSend() {
+    if (!text.trim() || !active) return;
+    try {
+      await sendMessage({ conversationId: active, content: text });
+      setText('');
+      const data = await fetchMessages(active);
+      setMessages(data);
+      scrollToEnd();
+    } catch (err) {
+      console.error('Failed to send message', err);
+    }
+  }
+
+  if (!isOpen) {
+    return (
+      <Box className="chat-widget" onClick={() => setIsOpen(true)}>
+        <Text color="white" fontWeight="bold">Chat</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box className="chat-widget-window">
+      <Flex className="chat-header" justify="space-between" align="center" bg="teal.500" color="white" p={2}>
+        <Text>Messages</Text>
+        <Button size="xs" onClick={() => setIsOpen(false)}>Close</Button>
+      </Flex>
+      <Flex className="chat-body" flex="1">
+        <Box className="conversation-list" w="35%" borderRight="1px solid #ccc" overflowY="auto">
+          {conversations.map((c) => (
+            <Box
+              key={c.id}
+              p={2}
+              className={`conversation-item ${active === c.id ? 'active' : ''}`}
+              onClick={() => openConversation(c.id)}
+            >
+              <Text noOfLines={1}>{c.participants?.filter(p => p !== user.id).join(', ') || c.id}</Text>
+            </Box>
+          ))}
+        </Box>
+        <Flex className="message-section" direction="column" flex="1">
+          <Box className="messages" flex="1" overflowY="auto" p={2}>
+            {messages.map((m) => (
+              <Box key={m.id} mb={2}>
+                <Text fontSize="sm"><strong>{m.senderId}:</strong> {m.content}</Text>
+              </Box>
+            ))}
+            <div ref={endRef} />
+          </Box>
+          <Flex p={2} borderTop="1px solid #ccc">
+            <Input
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              mr={2}
+              placeholder="Type a message"
+            />
+            <Button colorScheme="teal" onClick={handleSend}>Send</Button>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/frontend/src/pages/EmploymentDashboardPage.jsx
+++ b/frontend/src/pages/EmploymentDashboardPage.jsx
@@ -16,21 +16,28 @@ import {
   CardBody,
   Spinner,
 } from '@chakra-ui/react';
-import { getOverview, getJobs, getJob } from '../api/employment.js';
+import { getOverview, getJobs as getEmployerJobs, getJob as getEmployerJob } from '../api/employment.js';
+import { listPublicJobs, getPublicJob } from '../api/jobs.js';
 import '../styles/EmploymentDashboardPage.css';
 
 export default function EmploymentDashboardPage() {
   const [mode, setMode] = useState('seeker');
   const [overview, setOverview] = useState(null);
-  const [jobs, setJobs] = useState([]);
+  const [seekerJobs, setSeekerJobs] = useState([]);
+  const [employerJobs, setEmployerJobs] = useState([]);
   const [selected, setSelected] = useState(null);
 
   useEffect(() => {
     (async () => {
       try {
-        const [ov, js] = await Promise.all([getOverview(), getJobs()]);
+        const [publicJobs, employerList, ov] = await Promise.all([
+          listPublicJobs(),
+          getEmployerJobs(),
+          getOverview(),
+        ]);
+        setSeekerJobs(publicJobs);
+        setEmployerJobs(employerList);
         setOverview(ov);
-        setJobs(js);
       } catch (err) {
         console.error('Failed to load employment data', err);
       }
@@ -39,7 +46,7 @@ export default function EmploymentDashboardPage() {
 
   async function showJob(id) {
     try {
-      const job = await getJob(id);
+      const job = mode === 'seeker' ? await getPublicJob(id) : await getEmployerJob(id);
       setSelected(job);
     } catch (err) {
       console.error('Failed to load job', err);
@@ -76,7 +83,7 @@ export default function EmploymentDashboardPage() {
         <TabPanels>
           <TabPanel>
             <SimpleGrid columns={[1, 2]} spacing={4}>
-              {jobs.map((job) => (
+              {seekerJobs.map((job) => (
                 <Card key={job.id} className="job-card" onClick={() => showJob(job.id)}>
                   <CardBody>
                     <Heading size="md">{job.title}</Heading>
@@ -85,18 +92,17 @@ export default function EmploymentDashboardPage() {
                 </Card>
               ))}
             </SimpleGrid>
-            {selected && (
+            {selected && mode === 'seeker' && (
               <Box mt={6} p={4} borderWidth="1px" borderRadius="md">
                 <Heading size="md" mb={2}>{selected.title}</Heading>
-                <Text>Views: {selected.views}</Text>
-                <Text>Applications: {selected.applications}</Text>
-                <Text>Hires: {selected.hires}</Text>
+                <Text>Description: {selected.description}</Text>
+                {selected.location && <Text>Location: {selected.location}</Text>}
               </Box>
             )}
           </TabPanel>
           <TabPanel>
             <SimpleGrid columns={[1, 2]} spacing={4}>
-              {jobs.map((job) => (
+              {employerJobs.map((job) => (
                 <Card key={job.id} className="job-card" onClick={() => showJob(job.id)}>
                   <CardBody>
                     <Heading size="md">{job.title}</Heading>
@@ -106,7 +112,7 @@ export default function EmploymentDashboardPage() {
                 </Card>
               ))}
             </SimpleGrid>
-            {selected && (
+            {selected && mode === 'employer' && (
               <Box mt={6} p={4} borderWidth="1px" borderRadius="md">
                 <Heading size="md" mb={2}>{selected.title}</Heading>
                 <Text>Status: {selected.status}</Text>

--- a/frontend/src/styles/ChatWidget.css
+++ b/frontend/src/styles/ChatWidget.css
@@ -1,0 +1,43 @@
+.chat-widget {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: #319795;
+  color: #fff;
+  padding: 12px 16px;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  z-index: 1000;
+}
+
+.chat-widget-window {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 360px;
+  height: 480px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0,0,0,0.15);
+  display: flex;
+  flex-direction: column;
+  z-index: 1000;
+}
+
+.chat-header {
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+}
+
+.conversation-list .conversation-item {
+  cursor: pointer;
+}
+
+.conversation-list .conversation-item.active {
+  background: #E6FFFA;
+}
+
+.messages {
+  background: #F7FAFC;
+}


### PR DESCRIPTION
## Summary
- add reusable ChatWidget component and style
- integrate global chat widget into app
- enhance employment dashboard with public job listings and employer analytics

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68934dedc41483209e76910e584e130f