### PR TITLE
Add freelancer search and proposal invoice management pages

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -76,6 +76,7 @@
     <link rel="stylesheet" href="styles/ProposalInvoiceManagement.css" />
     <link rel="stylesheet" href="styles/ProposalCard.css" />
     <link rel="stylesheet" href="styles/InvoiceForm.css" />
+    <link rel="stylesheet" href="styles/FreelancerSearchPage.css" />
     <link rel="stylesheet" href="views/course_module_management.css" />
     <link rel="stylesheet" href="views/schedule_calendar.css" />
     <link rel="stylesheet" href="views/course_purchase.css" />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -62,7 +62,8 @@ import FileResourceManagement from '../pages/FileResourceManagement.jsx';
 import InSessionNetworking from '../pages/InSessionNetworking.jsx';
 import NetworkingSessions from '../pages/NetworkingSessions.jsx';
 import ProjectManagement from '../pages/ProjectManagement.jsx';
-import ProposalInvoiceManagement from '../pages/ProposalInvoiceManagement.jsx';
+import ProposalInvoiceManagementPage from './pages/ProposalInvoiceManagementPage.jsx';
+import FreelancerSearchPage from './pages/FreelancerSearchPage.jsx';
 import SettingsPage from '../pages/SettingsPage.jsx';
 import SystemSettingsEmployeeManagement from '../pages/SystemSettingsEmployeeManagement.jsx';
 import PaymentTimesheetManagement from '../pages/PaymentTimesheetManagement.jsx';
@@ -129,10 +130,11 @@ export default function App() {
     { path: '/ads/:adId/edit', element: <AdCreateEdit />, protected: true },
 
     // Contracts & Freelancing
+    { path: '/freelancers', element: <FreelancerSearchPage />, protected: true },
     { path: '/freelance', element: <FreelanceDashboardPage />, protected: true },
     { path: '/contracts', element: <ContractManagementPage />, protected: true },
     { path: '/contracts/new', element: <ContractFormPage />, protected: true },
-    { path: '/proposals-invoices', element: <ProposalInvoiceManagement />, protected: true },
+    { path: '/proposals-invoices', element: <ProposalInvoiceManagementPage />, protected: true },
     { path: '/services', element: <ServiceSearchPage />, protected: true },
     { path: '/services/new', element: <ServiceCreationPage />, protected: true },
     { path: '/services/:id', element: <ServiceDetailPage />, protected: true },
@@ -204,7 +206,6 @@ export default function App() {
     { path: '/admin/system-settings', element: <SystemSettingsEmployeeManagement />, admin: true },
     { path: '/affiliates', element: <AffiliateManagementPage />, protected: true },
     { path: '/sim-dashboard', element: <SimDashboardPage />, protected: true },
-    { path: '/proposal-invoices', element: <ProposalInvoiceManagement />, protected: true },
 
     // Fallback
     { path: '*', element: <Navigate to="/" replace /> }

--- a/frontend/src/api/contracts.js
+++ b/frontend/src/api/contracts.js
@@ -24,3 +24,18 @@ export async function terminateContract(contractId, reason) {
   const { data } = await apiClient.put(`/contracts/${contractId}/terminate`, { reason });
   return data;
 }
+
+export async function fetchProposals(contractId) {
+  const { data } = await apiClient.get(`/contracts/${contractId}/proposals`);
+  return data;
+}
+
+export async function fetchInvoices(contractId) {
+  const { data } = await apiClient.get(`/contracts/${contractId}/invoices`);
+  return data;
+}
+
+export async function submitInvoice(contractId, invoice) {
+  const { data } = await apiClient.post(`/contracts/${contractId}/invoices`, invoice);
+  return data;
+}

--- a/frontend/src/api/freelancers.js
+++ b/frontend/src/api/freelancers.js
@@ -1,0 +1,6 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function searchFreelancers(params = {}) {
+  const { data } = await apiClient.get('/freelancers/search', { params });
+  return data.freelancers;
+}

--- a/frontend/src/components/InvoiceForm.jsx
+++ b/frontend/src/components/InvoiceForm.jsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { Box, Input, Button } from '@chakra-ui/react';
+import '../../styles/InvoiceForm.css';
+
+export default function InvoiceForm({ onSubmit }) {
+  const [amount, setAmount] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit({ amount: parseFloat(amount), description });
+    setAmount('');
+    setDescription('');
+  };
+
+  return (
+    <Box as="form" className="invoice-form" onSubmit={handleSubmit} mt={4}>
+      <Input
+        placeholder="Amount"
+        value={amount}
+        onChange={(e) => setAmount(e.target.value)}
+        type="number"
+        step="0.01"
+        mb={2}
+      />
+      <Input
+        placeholder="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        mb={2}
+      />
+      <Button type="submit" colorScheme="teal">Submit Invoice</Button>
+    </Box>
+  );
+}

--- a/frontend/src/components/ProposalCard.jsx
+++ b/frontend/src/components/ProposalCard.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Box, Text } from '@chakra-ui/react';
+import '../../styles/ProposalCard.css';
+
+export default function ProposalCard({ proposal }) {
+  return (
+    <Box className="proposal-card" p={4} borderWidth="1px" borderRadius="md">
+      <Text fontWeight="bold">Freelancer: {proposal.freelancerId}</Text>
+      <Text>Status: {proposal.status}</Text>
+      {proposal.proposalText && <Text mt={2}>{proposal.proposalText}</Text>}
+    </Box>
+  );
+}

--- a/frontend/src/nav/menu.js
+++ b/frontend/src/nav/menu.js
@@ -31,6 +31,7 @@ export const menu = [
       { label: 'Workspace Projects', path: '/workspace/projects' },
       { label: 'Workspace Files', path: '/workspace/files' },
       { label: 'Proposals & Invoices', path: '/proposals-invoices' },
+      { label: 'Freelancer Search', path: '/freelancers' },
       { label: 'Orders', path: '/orders' },
       { label: 'Payments', path: '/payments' },
       { label: 'Freelance Dashboard', path: '/freelance' },

--- a/frontend/src/pages/FreelanceDashboardPage.jsx
+++ b/frontend/src/pages/FreelanceDashboardPage.jsx
@@ -8,11 +8,13 @@ import {
   StatNumber,
   Switch,
   FormControl,
-  FormLabel
+  FormLabel,
+  Button
 } from '@chakra-ui/react';
-import '../styles/FreelanceDashboardPage.css';
+import '../../styles/FreelanceDashboardPage.css';
 import { getContracts } from '../api/contracts.js';
 import { getOrders } from '../api/orders.js';
+import { Link } from 'react-router-dom';
 
 export default function FreelanceDashboardPage() {
   const [mode, setMode] = useState('client');
@@ -63,6 +65,14 @@ export default function FreelanceDashboardPage() {
           <StatNumber>{pendingContracts}</StatNumber>
         </Stat>
       </SimpleGrid>
+      <Box mt={6} display="flex" gap={3}>
+        <Button as={Link} to="/freelancers" colorScheme="teal">
+          Find Freelancers
+        </Button>
+        <Button as={Link} to="/proposals-invoices" colorScheme="blue">
+          Manage Proposals & Invoices
+        </Button>
+      </Box>
     </Box>
   );
 }

--- a/frontend/src/pages/FreelancerSearchPage.jsx
+++ b/frontend/src/pages/FreelancerSearchPage.jsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Heading,
+  Input,
+  Button,
+  SimpleGrid,
+  FormControl,
+  FormLabel,
+  NumberInput,
+  NumberInputField,
+  Tag,
+  VStack,
+  Spinner,
+  useToast
+} from '@chakra-ui/react';
+import { searchFreelancers } from '../api/freelancers.js';
+import '../../styles/FreelancerSearchPage.css';
+
+export default function FreelancerSearchPage() {
+  const [filters, setFilters] = useState({
+    query: '',
+    location: '',
+    minRate: '',
+    maxRate: '',
+    minExperience: ''
+  });
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const toast = useToast();
+
+  const handleChange = (e) => {
+    setFilters({ ...filters, [e.target.name]: e.target.value });
+  };
+
+  const handleSearch = async () => {
+    setLoading(true);
+    try {
+      const freelancers = await searchFreelancers(filters);
+      setResults(freelancers);
+    } catch (err) {
+      toast({ title: 'Search failed', status: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box className="freelancer-search-page" p={4}>
+      <Heading mb={4}>Freelancer Search</Heading>
+      <SimpleGrid columns={[1, 2, 5]} spacing={4} mb={4}>
+        <Input placeholder="Keyword" name="query" value={filters.query} onChange={handleChange} />
+        <Input placeholder="Location" name="location" value={filters.location} onChange={handleChange} />
+        <NumberInput min={0} value={filters.minRate} onChange={(v) => setFilters({ ...filters, minRate: v })}>
+          <NumberInputField placeholder="Min Rate" name="minRate" />
+        </NumberInput>
+        <NumberInput min={0} value={filters.maxRate} onChange={(v) => setFilters({ ...filters, maxRate: v })}>
+          <NumberInputField placeholder="Max Rate" name="maxRate" />
+        </NumberInput>
+        <NumberInput min={0} value={filters.minExperience} onChange={(v) => setFilters({ ...filters, minExperience: v })}>
+          <NumberInputField placeholder="Min Experience" name="minExperience" />
+        </NumberInput>
+      </SimpleGrid>
+      <Button onClick={handleSearch} colorScheme="teal" mb={4}>
+        Search
+      </Button>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <SimpleGrid columns={[1, 2, 3]} spacing={4}>
+          {results.map((freelancer) => (
+            <Box key={freelancer.id} className="freelancer-card" borderWidth="1px" borderRadius="md" p={4}>
+              <Heading size="md" mb={2}>{freelancer.fullName}</Heading>
+              <VStack align="start" spacing={1} mb={2}>
+                {(freelancer.skills || []).map((skill) => (
+                  <Tag key={skill}>{skill}</Tag>
+                ))}
+              </VStack>
+              {freelancer.hourlyRate !== undefined && (
+                <Box>Rate: ${freelancer.hourlyRate}/hr</Box>
+              )}
+            </Box>
+          ))}
+        </SimpleGrid>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/pages/ProposalInvoiceManagementPage.jsx
+++ b/frontend/src/pages/ProposalInvoiceManagementPage.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Heading,
+  Input,
+  Button,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  useToast
+} from '@chakra-ui/react';
+import { fetchProposals, fetchInvoices, submitInvoice } from '../api/contracts.js';
+import ProposalCard from '../components/ProposalCard.jsx';
+import InvoiceForm from '../components/InvoiceForm.jsx';
+import '../../styles/ProposalInvoiceManagement.css';
+
+export default function ProposalInvoiceManagementPage() {
+  const [contractId, setContractId] = useState('');
+  const [proposals, setProposals] = useState([]);
+  const [invoices, setInvoices] = useState([]);
+  const toast = useToast();
+
+  const loadData = async () => {
+    if (!contractId) return;
+    try {
+      const [p, i] = await Promise.all([
+        fetchProposals(contractId),
+        fetchInvoices(contractId)
+      ]);
+      setProposals(p);
+      setInvoices(i);
+    } catch {
+      toast({ title: 'Failed to load data', status: 'error' });
+    }
+  };
+
+  const handleInvoiceSubmit = async (data) => {
+    try {
+      await submitInvoice(contractId, data);
+      toast({ title: 'Invoice submitted', status: 'success' });
+      loadData();
+    } catch {
+      toast({ title: 'Submission failed', status: 'error' });
+    }
+  };
+
+  return (
+    <Box className="proposal-invoice-management" p={4}>
+      <Heading mb={4}>Proposal & Invoice Management</Heading>
+      <Box mb={4} display="flex" gap={2}>
+        <Input placeholder="Contract ID" value={contractId} onChange={(e) => setContractId(e.target.value)} />
+        <Button onClick={loadData} colorScheme="teal">Load</Button>
+      </Box>
+      <Tabs>
+        <TabList>
+          <Tab>Proposals</Tab>
+          <Tab>Invoices</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            {proposals.map((p) => (
+              <ProposalCard key={p.id} proposal={p} />
+            ))}
+          </TabPanel>
+          <TabPanel>
+            {invoices.map((inv) => (
+              <Box key={inv.id} className="invoice-item" p={3} borderWidth="1px" borderRadius="md" mb={2}>
+                Amount: ${inv.amount} - {inv.status}
+              </Box>
+            ))}
+            {contractId && <InvoiceForm onSubmit={handleInvoiceSubmit} />}
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Box>
+  );
+}

--- a/frontend/styles/FreelancerSearchPage.css
+++ b/frontend/styles/FreelancerSearchPage.css
@@ -1,0 +1,12 @@
+.freelancer-search-page {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.freelancer-card {
+  transition: box-shadow 0.2s ease;
+}
+
+.freelancer-card:hover {
+  box-shadow: 0 0 8px rgba(0,0,0,0.15);
+}


### PR DESCRIPTION
## Summary
- build Freelancer Search page with filtering and card results
- add Proposal & Invoice Management page tied to contract APIs
- link new tools from Freelance Dashboard and navigation menu

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934e25f8808320abbeaeecbc71b9d6