### PR TITLE
feat: add education scheduling and course purchase pages

### DIFF
--- a/.env
+++ b/.env
@@ -45,3 +45,5 @@ VITE_ANALYTICS_ENDPOINT=/analytics/content/performance
 VITE_AUDIT_RESULTS_ENDPOINT=/security/compliance/audit-results
 VITE_CLASSROOM_DEFAULT_ROOM=WorkhouseClassroom
 VITE_RECAPTCHA_SITE_KEY=
+VITE_EDU_SCHEDULE_ENDPOINT=/education/schedule
+VITE_COURSES_ENDPOINT=/courses

--- a/backend/validation/course.js
+++ b/backend/validation/course.js
@@ -43,6 +43,8 @@ const moduleSchema = Joi.object({
 
 const moduleIdParamSchema = Joi.object({
   moduleId: Joi.string().uuid().required(),
+});
+
 const purchaseSchema = Joi.object({
   userId: Joi.string().uuid().required(),
   paymentMethod: Joi.string().max(50).required(),

--- a/frontend/pages/EducationDashboard.jsx
+++ b/frontend/pages/EducationDashboard.jsx
@@ -18,6 +18,8 @@ import {
 } from '@chakra-ui/react';
 import NavMenu from '../components/NavMenu';
 import { fetchEducationOverview } from '../api/education';
+import { Link as RouterLink } from 'react-router-dom';
+import { Link } from '@chakra-ui/react';
 import '../styles/EducationDashboard.css';
 
 export default function EducationDashboard() {
@@ -51,7 +53,9 @@ export default function EducationDashboard() {
               <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
                 {overview.map((course) => (
                   <Box key={course.id} className="course-card" p={4} borderWidth="1px" borderRadius="md">
-                    <Heading size="md" mb={2}>{course.title}</Heading>
+                    <Heading size="md" mb={2}>
+                      <Link as={RouterLink} to={`/courses/${course.id}`}>{course.title}</Link>
+                    </Heading>
                     <Progress value={course.enrollments ? (course.completions / course.enrollments) * 100 : 0} mb={2} />
                     <Text fontSize="sm">Completions: {course.completions} / {course.enrollments}</Text>
                   </Box>
@@ -62,7 +66,9 @@ export default function EducationDashboard() {
               <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
                 {overview.map((course) => (
                   <Stat key={course.id} className="overview-card" p={4} borderWidth="1px" borderRadius="md">
-                    <StatLabel>{course.title}</StatLabel>
+                    <StatLabel>
+                      <Link as={RouterLink} to={`/courses/${course.id}`}>{course.title}</Link>
+                    </StatLabel>
                     <StatNumber>{course.enrollments} enrolled</StatNumber>
                     <Text>Average Score: {course.averageScore}</Text>
                   </Stat>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,6 +26,9 @@ import OpportunityManagementPage from './pages/OpportunityManagementPage.jsx';
 import VolunteerTrackingPage from './pages/VolunteerTrackingPage.jsx';
 import ClassroomPage from './pages/ClassroomPage.jsx';
 import ScheduleCalendarPage from './pages/ScheduleCalendarPage.jsx';
+import EducationSchedulePage from './pages/EducationSchedulePage.jsx';
+import CourseListPage from './pages/CourseListPage.jsx';
+import CourseDetailPage from './pages/CourseDetailPage.jsx';
 import ArticlePage from './pages/ArticlePage.jsx';
 import DisputeDashboardPage from './pages/DisputeDashboardPage.jsx';
 import DisputeFormPage from './pages/DisputeFormPage.jsx';
@@ -141,9 +144,10 @@ export default function App() {
 
     // Education & Services
     { path: '/education', element: <EducationDashboard />, protected: true },
-    { path: '/education/schedule', element: <ScheduleCalendarPage />, protected: true },
+    { path: '/education/schedule', element: <EducationSchedulePage />, protected: true },
     { path: '/education/courses', element: <PlaceholderPage title="Course & Module Management" />, protected: true },
-    { path: '/courses', element: <PlaceholderPage title="Course Purchase & Details" />, protected: true },
+    { path: '/courses', element: <CourseListPage />, protected: true },
+    { path: '/courses/:courseId', element: <CourseDetailPage />, protected: true },
     { path: '/classroom/:id', element: <ClassroomPage />, protected: true },
 
     // Tasks & Experiences

--- a/frontend/src/api/courses.js
+++ b/frontend/src/api/courses.js
@@ -1,0 +1,15 @@
+import apiClient from '../utils/apiClient.js';
+
+const endpoint = import.meta.env.VITE_COURSES_ENDPOINT || '/courses';
+
+export function listCourses() {
+  return apiClient.get(endpoint).then(res => res.data);
+}
+
+export function getCourse(id) {
+  return apiClient.get(`${endpoint}/${id}`).then(res => res.data);
+}
+
+export function purchaseCourse(id, data) {
+  return apiClient.post(`${endpoint}/${id}/purchase`, data).then(res => res.data);
+}

--- a/frontend/src/api/educationSchedule.js
+++ b/frontend/src/api/educationSchedule.js
@@ -1,0 +1,11 @@
+import apiClient from '../utils/apiClient.js';
+
+const endpoint = import.meta.env.VITE_EDU_SCHEDULE_ENDPOINT || '/education/schedule';
+
+export function listEvents() {
+  return apiClient.get(endpoint).then(res => res.data);
+}
+
+export function createEvent(data) {
+  return apiClient.post(endpoint, data).then(res => res.data);
+}

--- a/frontend/src/pages/CourseDetailPage.jsx
+++ b/frontend/src/pages/CourseDetailPage.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Heading, Text, Button, FormControl, FormLabel, Input, useToast } from '@chakra-ui/react';
+import { useParams } from 'react-router-dom';
+import '../styles/CourseDetailPage.css';
+import { getCourse, purchaseCourse } from '../api/courses.js';
+import { useAuth } from '../context/AuthContext.jsx';
+
+export default function CourseDetailPage() {
+  const { courseId } = useParams();
+  const { user } = useAuth();
+  const [course, setCourse] = useState(null);
+  const [paymentMethod, setPaymentMethod] = useState('credit');
+  const [promoCode, setPromoCode] = useState('');
+  const toast = useToast();
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await getCourse(courseId);
+        setCourse(data);
+      } catch (err) {
+        toast({ title: 'Failed to load course', status: 'error' });
+      }
+    }
+    load();
+  }, [courseId, toast]);
+
+  async function handlePurchase() {
+    try {
+      await purchaseCourse(courseId, {
+        userId: user.id,
+        paymentMethod,
+        amount: course.price,
+        promoCode: promoCode || undefined
+      });
+      toast({ title: 'Course purchased successfully', status: 'success' });
+    } catch (err) {
+      toast({ title: err.message || 'Purchase failed', status: 'error' });
+    }
+  }
+
+  if (!course) {
+    return <Box className="course-detail-page" p={4}>Loading...</Box>;
+  }
+
+  return (
+    <Box className="course-detail-page" p={4}>
+      <Heading mb={2}>{course.title}</Heading>
+      <Text mb={2}>{course.description}</Text>
+      <Text mb={2}>Price: ${course.price}</Text>
+      <FormControl mb={3}>
+        <FormLabel>Payment Method</FormLabel>
+        <Input value={paymentMethod} onChange={(e) => setPaymentMethod(e.target.value)} />
+      </FormControl>
+      <FormControl mb={3}>
+        <FormLabel>Promo Code</FormLabel>
+        <Input value={promoCode} onChange={(e) => setPromoCode(e.target.value)} />
+      </FormControl>
+      <Button colorScheme="teal" onClick={handlePurchase}>Buy Now</Button>
+    </Box>
+  );
+}

--- a/frontend/src/pages/CourseListPage.jsx
+++ b/frontend/src/pages/CourseListPage.jsx
@@ -1,0 +1,38 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Heading, SimpleGrid, Text, Button } from '@chakra-ui/react';
+import { Link } from 'react-router-dom';
+import '../styles/CourseListPage.css';
+import { listCourses } from '../api/courses.js';
+
+export default function CourseListPage() {
+  const [courses, setCourses] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await listCourses();
+        setCourses(data);
+      } catch (err) {
+        console.error('Failed to load courses', err);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <Box className="course-list-page" p={4}>
+      <Heading mb={4}>Courses</Heading>
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
+        {courses.map((course) => (
+          <Box key={course.id} className="course-card" p={4} borderWidth="1px" borderRadius="md">
+            <Heading size="md" mb={2}>{course.title}</Heading>
+            <Text mb={2}>{course.description}</Text>
+            <Button as={Link} to={`/courses/${course.id}`} colorScheme="teal">
+              View Details
+            </Button>
+          </Box>
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/frontend/src/pages/EducationSchedulePage.jsx
+++ b/frontend/src/pages/EducationSchedulePage.jsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  Button,
+  List,
+  ListItem,
+  Text,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  useDisclosure,
+  useToast
+} from '@chakra-ui/react';
+import Calendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+import '../styles/EducationSchedulePage.css';
+import { listEvents, createEvent } from '../api/educationSchedule.js';
+import { useAuth } from '../context/AuthContext.jsx';
+
+export default function EducationSchedulePage() {
+  const { user } = useAuth();
+  const [events, setEvents] = useState([]);
+  const [date, setDate] = useState(new Date());
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [form, setForm] = useState({ title: '', description: '', start: '', end: '', courseId: '', type: 'class' });
+  const toast = useToast();
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await listEvents();
+        setEvents(data);
+      } catch (err) {
+        toast({ title: 'Failed to load schedule', status: 'error' });
+      }
+    }
+    load();
+  }, [toast]);
+
+  const dailyEvents = events.filter((e) => new Date(e.start).toDateString() === date.toDateString());
+
+  async function handleAdd() {
+    try {
+      const payload = {
+        ...form,
+        start: new Date(form.start).toISOString(),
+        end: new Date(form.end).toISOString()
+      };
+      const created = await createEvent(payload);
+      setEvents((prev) => [...prev, created]);
+      setForm({ title: '', description: '', start: '', end: '', courseId: '', type: 'class' });
+      onClose();
+      toast({ title: 'Event created', status: 'success' });
+    } catch (err) {
+      toast({ title: err.message || 'Failed to create event', status: 'error' });
+    }
+  }
+
+  return (
+    <Box className="education-schedule-page" p={4}>
+      <Heading mb={4}>Education Schedule</Heading>
+      <Calendar onChange={setDate} value={date} />
+      {user && user.role === 'teacher' && (
+        <Button mt={4} colorScheme="teal" onClick={onOpen}>
+          Add Event
+        </Button>
+      )}
+
+      <Heading size="md" mt={6}>
+        Events on {date.toDateString()}
+      </Heading>
+      <List spacing={2} mt={2}>
+        {dailyEvents.length === 0 && <Text>No events.</Text>}
+        {dailyEvents.map((ev) => (
+          <ListItem key={ev.id} className="event-item">
+            {new Date(ev.start).toLocaleTimeString()} - {new Date(ev.end).toLocaleTimeString()} {ev.title && `| ${ev.title}`} ({ev.type})
+          </ListItem>
+        ))}
+      </List>
+
+      <Modal isOpen={isOpen} onClose={onClose} size="lg">
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>New Event</ModalHeader>
+          <ModalBody>
+            <FormControl mb={3}>
+              <FormLabel>Title</FormLabel>
+              <Input value={form.title} onChange={(e) => setForm({ ...form, title: e.target.value })} />
+            </FormControl>
+            <FormControl mb={3}>
+              <FormLabel>Description</FormLabel>
+              <Input value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} />
+            </FormControl>
+            <FormControl mb={3}>
+              <FormLabel>Course ID</FormLabel>
+              <Input value={form.courseId} onChange={(e) => setForm({ ...form, courseId: e.target.value })} />
+            </FormControl>
+            <FormControl mb={3}>
+              <FormLabel>Type</FormLabel>
+              <Select value={form.type} onChange={(e) => setForm({ ...form, type: e.target.value })}>
+                <option value="class">Class</option>
+                <option value="assignment">Assignment</option>
+                <option value="exam">Exam</option>
+                <option value="event">Event</option>
+              </Select>
+            </FormControl>
+            <FormControl mb={3}>
+              <FormLabel>Start Time</FormLabel>
+              <Input type="datetime-local" value={form.start} onChange={(e) => setForm({ ...form, start: e.target.value })} />
+            </FormControl>
+            <FormControl>
+              <FormLabel>End Time</FormLabel>
+              <Input type="datetime-local" value={form.end} onChange={(e) => setForm({ ...form, end: e.target.value })} />
+            </FormControl>
+          </ModalBody>
+          <ModalFooter>
+            <Button mr={3} onClick={onClose}>
+              Cancel
+            </Button>
+            <Button colorScheme="teal" onClick={handleAdd}>
+              Save
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </Box>
+  );
+}

--- a/frontend/src/styles/CourseDetailPage.css
+++ b/frontend/src/styles/CourseDetailPage.css
@@ -1,0 +1,4 @@
+.course-detail-page {
+  max-width: 600px;
+  margin: 0 auto;
+}

--- a/frontend/src/styles/CourseListPage.css
+++ b/frontend/src/styles/CourseListPage.css
@@ -1,0 +1,8 @@
+.course-list-page {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.course-card {
+  background: #fff;
+}

--- a/frontend/src/styles/EducationSchedulePage.css
+++ b/frontend/src/styles/EducationSchedulePage.css
@@ -1,0 +1,9 @@
+.education-schedule-page {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.education-schedule-page .event-item {
+  padding: 4px 0;
+  border-bottom: 1px solid #eee;
+}


### PR DESCRIPTION
## Summary
- add education schedule page with calendar and teacher-driven event creation
- implement course catalog and detail purchase flow
- fix course validation schema and wire new routes and env settings

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68934e4ece5c8320959f3b8e3f8aac0f