### PR TITLE
feat: add service order management

### DIFF
--- a/backend/controllers/serviceProviderOrders.js
+++ b/backend/controllers/serviceProviderOrders.js
@@ -1,11 +1,18 @@
 const Order = require('../models/order');
 
 exports.createOrder = (req, res) => {
-  const { buyerId, sellerId, serviceId, status, description } = req.body;
+  const { buyerId, sellerId, serviceId, status, description, scheduledDate } = req.body;
   if (!buyerId || !sellerId || !serviceId) {
     return res.status(400).json({ error: 'buyerId, sellerId and serviceId are required' });
   }
-  const order = Order.createOrder({ buyerId, sellerId, serviceId, status, description });
+  const order = Order.createOrder({
+    buyerId,
+    sellerId,
+    serviceId,
+    status,
+    description,
+    scheduledDate,
+  });
   res.status(201).json(order);
 };
 

--- a/backend/models/order.js
+++ b/backend/models/order.js
@@ -3,7 +3,14 @@ const { randomUUID } = require('crypto');
 // In-memory storage for service provider orders
 const orders = [];
 
-function createOrder({ buyerId, sellerId, serviceId, status = 'pending', description = '' }) {
+function createOrder({
+  buyerId,
+  sellerId,
+  serviceId,
+  status = 'pending',
+  description = '',
+  scheduledDate = new Date(),
+}) {
   const order = {
     id: randomUUID(),
     buyerId,
@@ -11,6 +18,7 @@ function createOrder({ buyerId, sellerId, serviceId, status = 'pending', descrip
     serviceId,
     status,
     description,
+    scheduledDate: new Date(scheduledDate),
     createdAt: new Date(),
     updatedAt: new Date(),
   };
@@ -29,6 +37,9 @@ function getOrderById(id) {
 function updateOrder(id, updates) {
   const order = getOrderById(id);
   if (!order) return null;
+  if (updates.scheduledDate) {
+    updates.scheduledDate = new Date(updates.scheduledDate);
+  }
   Object.assign(order, updates, { updatedAt: new Date() });
   return order;
 }

--- a/frontend/src/api/orders.js
+++ b/frontend/src/api/orders.js
@@ -14,3 +14,13 @@ export async function updateOrder(id, updates) {
   const { data } = await apiClient.put(`/service-providers/orders/${id}`, updates);
   return data;
 }
+
+export async function createOrder(order) {
+  const { data } = await apiClient.post('/service-providers/orders', order);
+  return data;
+}
+
+export async function deleteOrder(id) {
+  const { data } = await apiClient.delete(`/service-providers/orders/${id}`);
+  return data;
+}

--- a/frontend/src/components/OrderDetail.jsx
+++ b/frontend/src/components/OrderDetail.jsx
@@ -1,7 +1,25 @@
-import { Modal, ModalOverlay, ModalContent, ModalHeader, ModalCloseButton, ModalBody, ModalFooter, Button, Text } from '@chakra-ui/react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Text,
+  Select,
+} from '@chakra-ui/react';
+import { useState, useEffect } from 'react';
 import '../styles/OrderDetail.css';
 
-function OrderDetail({ order, isOpen, onClose }) {
+function OrderDetail({ order, isOpen, onClose, onUpdate }) {
+  const [status, setStatus] = useState('pending');
+
+  useEffect(() => {
+    setStatus(order?.status || 'pending');
+  }, [order]);
+
   if (!order) return null;
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="md">
@@ -12,10 +30,36 @@ function OrderDetail({ order, isOpen, onClose }) {
         <ModalBody>
           <Text><strong>ID:</strong> {order.id}</Text>
           <Text><strong>Service:</strong> {order.serviceId}</Text>
-          <Text><strong>Status:</strong> {order.status}</Text>
-          {order.description && <Text><strong>Description:</strong> {order.description}</Text>}
+          <Text>
+            <strong>Scheduled:</strong>{' '}
+            {new Date(order.scheduledDate || order.createdAt).toLocaleDateString()}
+          </Text>
+          <Select
+            mt={2}
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+          >
+            <option value="pending">Pending</option>
+            <option value="in_progress">In Progress</option>
+            <option value="completed">Completed</option>
+            <option value="cancelled">Cancelled</option>
+          </Select>
+          {order.description && (
+            <Text mt={2}>
+              <strong>Description:</strong> {order.description}
+            </Text>
+          )}
         </ModalBody>
         <ModalFooter>
+          {onUpdate && (
+            <Button
+              colorScheme="teal"
+              mr={3}
+              onClick={() => onUpdate(order.id, { status })}
+            >
+              Save
+            </Button>
+          )}
           <Button onClick={onClose}>Close</Button>
         </ModalFooter>
       </ModalContent>

--- a/frontend/src/nav/menu.js
+++ b/frontend/src/nav/menu.js
@@ -38,6 +38,7 @@ export const menu = [
       { label: 'New Contract', path: '/contracts/new' },
       { label: 'Services', path: '/services' },
       { label: 'New Service', path: '/services/new' },
+      { label: 'Service Orders', path: '/service-orders' },
       { label: 'Tasks', path: '/tasks' },
       { label: 'Tasks Workflow', path: '/tasks-workflow' },
       { label: 'Schedule', path: '/schedule' },

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -34,6 +34,9 @@ export default function DashboardPage() {
       <Button mb={4} colorScheme="teal" onClick={() => navigate('/feed')}>
         View Live Feed
       </Button>
+      <Button mb={4} colorScheme="teal" onClick={() => navigate('/service-orders')}>
+        Manage Service Orders
+      </Button>
       <SimpleGrid columns={[1, 3]} spacing={4}>
         {'totalSpend' in data && (
       <NavBar />

--- a/frontend/src/pages/ServiceOrderManagementPage.jsx
+++ b/frontend/src/pages/ServiceOrderManagementPage.jsx
@@ -1,23 +1,43 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Heading, Tabs, TabList, TabPanels, Tab, TabPanel, Spinner } from '@chakra-ui/react';
+import {
+  Box,
+  Heading,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  Spinner,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+import Calendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
 import '../styles/ServiceOrderManagementPage.css';
 import { getServices } from '../api/services.js';
-import { getOrders } from '../api/orders.js';
+import {
+  getOrders,
+  updateOrder,
+} from '../api/orders.js';
 import ServiceList from '../components/ServiceList.jsx';
 import OrderList from '../components/OrderList.jsx';
+import OrderDetail from '../components/OrderDetail.jsx';
 
 function ServiceOrderManagementPage() {
   const [services, setServices] = useState([]);
   const [orders, setOrders] = useState([]);
+  const [selectedOrder, setSelectedOrder] = useState(null);
   const [loadingServices, setLoadingServices] = useState(true);
   const [loadingOrders, setLoadingOrders] = useState(true);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const navigate = useNavigate();
   const userId = localStorage.getItem('userId');
 
   useEffect(() => {
     async function fetchData() {
       try {
         const [serviceData, orderData] = await Promise.all([
-          getServices(userId),
+          getServices({ sellerId: userId }),
           getOrders(userId),
         ]);
         setServices(serviceData);
@@ -32,6 +52,16 @@ function ServiceOrderManagementPage() {
     if (userId) fetchData();
   }, [userId]);
 
+  const handleUpdateOrder = async (id, updates) => {
+    try {
+      const updated = await updateOrder(id, updates);
+      setOrders((prev) => prev.map((o) => (o.id === updated.id ? updated : o)));
+      onClose();
+    } catch (err) {
+      console.error('Failed to update order', err);
+    }
+  };
+
   return (
     <Box className="service-order-page" p={4}>
       <Heading size="md" mb={4}>
@@ -44,13 +74,52 @@ function ServiceOrderManagementPage() {
         </TabList>
         <TabPanels>
           <TabPanel>
-            {loadingServices ? <Spinner /> : <ServiceList services={services} />}
+            {loadingServices ? (
+              <Spinner />
+            ) : (
+              <ServiceList
+                services={services}
+                onSelect={(service) => navigate(`/services/${service.id}`)}
+              />
+            )}
           </TabPanel>
           <TabPanel>
-            {loadingOrders ? <Spinner /> : <OrderList orders={orders} />}
+            {loadingOrders ? (
+              <Spinner />
+            ) : (
+              <OrderList
+                orders={orders}
+                onSelect={(order) => {
+                  setSelectedOrder(order);
+                  onOpen();
+                }}
+              />
+            )}
           </TabPanel>
         </TabPanels>
       </Tabs>
+      <Box mt={8} className="calendar-wrapper">
+        <Calendar
+          tileClassName={({ date }) =>
+            orders.some(
+              (order) =>
+                new Date(order.scheduledDate || order.createdAt).toDateString() ===
+                date.toDateString()
+            )
+              ? 'order-date'
+              : undefined
+          }
+        />
+      </Box>
+      <OrderDetail
+        order={selectedOrder}
+        isOpen={isOpen}
+        onClose={() => {
+          setSelectedOrder(null);
+          onClose();
+        }}
+        onUpdate={handleUpdateOrder}
+      />
     </Box>
   );
 }

--- a/frontend/src/styles/ServiceOrderManagementPage.css
+++ b/frontend/src/styles/ServiceOrderManagementPage.css
@@ -1,3 +1,13 @@
 .service-order-page {
   width: 100%;
 }
+
+.calendar-wrapper {
+  max-width: 350px;
+}
+
+.order-date {
+  background: #3182ce !important;
+  color: #fff !important;
+  border-radius: 50%;
+}


### PR DESCRIPTION
## Summary
- implement combined service and order management page with calendar and order detail modal
- support order creation/update on backend including scheduled dates
- add service order APIs and navigation links

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68934e59abc883209b919e3be14d635a