### PR TITLE
feat: add service editing flows

### DIFF
--- a/backend/controllers/serviceProviders.js
+++ b/backend/controllers/serviceProviders.js
@@ -1,18 +1,34 @@
 const Service = require('../models/service');
 
 exports.createService = (req, res) => {
-  const { sellerId, title, description, price, status } = req.body;
+  const { sellerId, title, description, price, status, category, tags } = req.body;
   if (!sellerId || !title) {
     return res.status(400).json({ error: 'sellerId and title are required' });
   }
-  const service = Service.createService({ sellerId, title, description, price, status });
+  const service = Service.createService({
+    sellerId,
+    title,
+    description,
+    price,
+    status,
+    category,
+    tags,
+  });
   res.status(201).json(service);
 };
 
 exports.listServices = (req, res) => {
-  const { sellerId } = req.query;
-  const data = sellerId ? Service.listServicesBySeller(sellerId) : Service.services;
-  res.json(data);
+  const { sellerId, search, category, minPrice, maxPrice } = req.query;
+  if (sellerId) {
+    return res.json(Service.listServicesBySeller(sellerId));
+  }
+  const filters = {
+    search,
+    category,
+    minPrice: minPrice ? Number(minPrice) : undefined,
+    maxPrice: maxPrice ? Number(maxPrice) : undefined,
+  };
+  res.json(Service.listAllServices(filters));
 };
 
 exports.getServiceById = (req, res) => {

--- a/backend/models/resource.js
+++ b/backend/models/resource.js
@@ -1,33 +1,5 @@
 const { randomUUID } = require('crypto');
 
-// In-memory data stores
-const services = [
-  {
-    id: 'svc-1',
-    name: 'Legal Consultation',
-    description: 'Connect with legal experts for startup advice.',
-    price: 200,
-    rating: 4.8,
-    category: 'legal',
-    location: 'remote',
-    image: '/images/legal.jpg',
-    availability: ['2024-09-01', '2024-09-02'],
-  },
-  {
-    id: 'svc-2',
-    name: 'Marketing Strategy',
-    description: 'Professional marketing planning services.',
-    price: 150,
-    rating: 4.6,
-    category: 'marketing',
-    location: 'remote',
-    image: '/images/marketing.jpg',
-    availability: ['2024-09-03'],
-  },
-];
-
-const serviceRequests = new Map();
-
 const resources = new Map([
   [
     'education',
@@ -84,40 +56,6 @@ const mentors = [
 
 const mentorshipApplications = new Map();
 
-function listServices(filters = {}) {
-  const { search, category, minPrice, maxPrice, location } = filters;
-  return services.filter((svc) => {
-    if (search && !svc.name.toLowerCase().includes(search.toLowerCase())) {
-      return false;
-    }
-    if (category && svc.category !== category) {
-      return false;
-    }
-    if (location && svc.location !== location) {
-      return false;
-    }
-    if (minPrice !== undefined && svc.price < minPrice) {
-      return false;
-    }
-    if (maxPrice !== undefined && svc.price > maxPrice) {
-      return false;
-    }
-    return true;
-  });
-}
-
-function getServiceById(id) {
-  return services.find((s) => s.id === id) || null;
-}
-
-function createServiceRequest(userId, serviceId, description = '') {
-  const id = randomUUID();
-  const now = new Date();
-  const request = { id, userId, serviceId, description, status: 'pending', createdAt: now };
-  serviceRequests.set(id, request);
-  return request;
-}
-
 function getResourcesByType(type) {
   return resources.get(type) || [];
 }
@@ -171,9 +109,6 @@ function listMentors() {
 }
 
 module.exports = {
-  listServices,
-  getServiceById,
-  createServiceRequest,
   getResourcesByType,
   isValidResourceType,
   getLegalResourcesByRegion,

--- a/backend/models/service.js
+++ b/backend/models/service.js
@@ -1,17 +1,62 @@
 const { randomUUID } = require('crypto');
 
-const services = [];
+// In-memory service store. In a production system this would be a database
+// table with proper indexing and persistence. For demonstration purposes we
+// seed it with a few example services.
+const services = [
+  {
+    id: 'svc-1',
+    sellerId: 'demo-seller',
+    name: 'Legal Consultation',
+    description: 'Connect with legal experts for startup advice.',
+    price: 200,
+    category: 'legal',
+    tags: [],
+    rating: 4.8,
+    image: '/images/legal.jpg',
+    status: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: 'svc-2',
+    sellerId: 'demo-seller',
+    name: 'Marketing Strategy',
+    description: 'Professional marketing planning services.',
+    price: 150,
+    category: 'marketing',
+    tags: [],
+    rating: 4.6,
+    image: '/images/marketing.jpg',
+    status: 'active',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
 
-function createService({ sellerId, title, description = '', price = 0, status = 'active' }) {
+function createService({
+  sellerId,
+  title,
+  description = '',
+  price = 0,
+  status = 'active',
+  category = '',
+  tags = [],
+}) {
+  const now = new Date();
   const service = {
     id: randomUUID(),
     sellerId,
-    title,
+    name: title,
     description,
     price,
     status,
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    category,
+    tags,
+    rating: 0,
+    image: '',
+    createdAt: now,
+    updatedAt: now,
   };
   services.push(service);
   return service;
@@ -21,6 +66,25 @@ function listServicesBySeller(sellerId) {
   return services.filter((s) => s.sellerId === sellerId);
 }
 
+function listAllServices(filters = {}) {
+  const { search, category, minPrice, maxPrice } = filters;
+  return services.filter((s) => {
+    if (search && !s.name.toLowerCase().includes(search.toLowerCase())) {
+      return false;
+    }
+    if (category && s.category !== category) {
+      return false;
+    }
+    if (minPrice !== undefined && s.price < minPrice) {
+      return false;
+    }
+    if (maxPrice !== undefined && s.price > maxPrice) {
+      return false;
+    }
+    return true;
+  });
+}
+
 function getServiceById(id) {
   return services.find((s) => s.id === id);
 }
@@ -28,7 +92,13 @@ function getServiceById(id) {
 function updateService(id, updates) {
   const service = getServiceById(id);
   if (!service) return null;
-  Object.assign(service, updates, { updatedAt: new Date() });
+  const now = new Date();
+  const data = { ...updates };
+  if (updates.title && !updates.name) {
+    data.name = updates.title;
+    delete data.title;
+  }
+  Object.assign(service, data, { updatedAt: now });
   return service;
 }
 
@@ -40,11 +110,23 @@ function deleteService(id) {
   return null;
 }
 
+const serviceRequests = new Map();
+
+function createServiceRequest(userId, serviceId, description = '') {
+  const id = randomUUID();
+  const now = new Date();
+  const request = { id, userId, serviceId, description, status: 'pending', createdAt: now };
+  serviceRequests.set(id, request);
+  return request;
+}
+
 module.exports = {
   services,
   createService,
   listServicesBySeller,
+   listAllServices,
   getServiceById,
   updateService,
   deleteService,
+   createServiceRequest,
 };

--- a/backend/services/resource.js
+++ b/backend/services/resource.js
@@ -1,17 +1,18 @@
 const resourceModel = require('../models/resource');
+const serviceModel = require('../models/service');
 const logger = require('../utils/logger');
 
 async function listServices(filters = {}) {
-  return resourceModel.listServices(filters);
+  return serviceModel.listAllServices(filters);
 }
 
 async function getServiceById(id) {
-  return resourceModel.getServiceById(id);
+  return serviceModel.getServiceById(id);
 }
 
 async function requestService(userId, data) {
   const { serviceId, description } = data;
-  const request = resourceModel.createServiceRequest(userId, serviceId, description);
+  const request = serviceModel.createServiceRequest(userId, serviceId, description);
   logger.info('Service requested', { requestId: request.id, userId, serviceId });
   return request;
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import ServiceCreationPage from './pages/ServiceCreationPage.jsx';
 import ServiceDetailPage from './pages/ServiceDetailPage.jsx';
 import ServiceOrderManagementPage from './pages/ServiceOrderManagementPage.jsx';
 import ServiceSearchPage from './pages/ServiceSearchPage.jsx';
+import ServiceEditPage from './pages/ServiceEditPage.jsx';
 import GigSearchPage from './pages/GigSearchPage.jsx';
 import GigDetailPage from './pages/GigDetailPage.jsx';
 import TaskDashboardPage from './pages/TaskDashboardPage.jsx';
@@ -135,6 +136,7 @@ export default function App() {
     { path: '/proposals-invoices', element: <ProposalInvoiceManagement />, protected: true },
     { path: '/services', element: <ServiceSearchPage />, protected: true },
     { path: '/services/new', element: <ServiceCreationPage />, protected: true },
+    { path: '/services/:id/edit', element: <ServiceEditPage />, protected: true },
     { path: '/services/:id', element: <ServiceDetailPage />, protected: true },
     { path: '/service-orders', element: <ServiceOrderManagementPage />, protected: true },
     { path: '/payments/timesheets', element: <PaymentTimesheetManagement />, protected: true },

--- a/frontend/src/api/services.js
+++ b/frontend/src/api/services.js
@@ -25,6 +25,11 @@ export async function updateService(id, updates) {
   return data;
 }
 
+export async function deleteService(id) {
+  const { data } = await apiClient.delete(`/service-providers/services/${id}`);
+  return data;
+}
+
 export async function requestService(serviceId, description = '') {
   const { data } = await apiClient.post('/marketplace/services/request', { serviceId, description });
   return data;

--- a/frontend/src/components/ServiceList.jsx
+++ b/frontend/src/components/ServiceList.jsx
@@ -1,20 +1,25 @@
 import React from 'react';
-import { Box, Stack, Text, Button } from '@chakra-ui/react';
+import { Box, Stack, Text, Button, HStack } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
 import '../styles/ServiceList.css';
 
-function ServiceList({ services = [], onSelect }) {
+function ServiceList({ services = [] }) {
+  const navigate = useNavigate();
   return (
     <Stack spacing={3} className="service-list">
       {services.map((service) => (
         <Box key={service.id} className="service-item" borderWidth="1px" borderRadius="lg" p={4}>
-          <Text fontWeight="bold">{service.title}</Text>
+          <Text fontWeight="bold">{service.title || service.name}</Text>
           <Text>Status: {service.status}</Text>
           <Text>Price: ${service.price}</Text>
-          {onSelect && (
-            <Button size="sm" mt={2} onClick={() => onSelect(service)}>
+          <HStack mt={2} spacing={2}>
+            <Button size="sm" onClick={() => navigate(`/services/${service.id}`)}>
               View
             </Button>
-          )}
+            <Button size="sm" colorScheme="blue" onClick={() => navigate(`/services/${service.id}/edit`)}>
+              Edit
+            </Button>
+          </HStack>
         </Box>
       ))}
     </Stack>

--- a/frontend/src/nav/menu.js
+++ b/frontend/src/nav/menu.js
@@ -38,6 +38,7 @@ export const menu = [
       { label: 'New Contract', path: '/contracts/new' },
       { label: 'Services', path: '/services' },
       { label: 'New Service', path: '/services/new' },
+      { label: 'Service Orders', path: '/service-orders' },
       { label: 'Tasks', path: '/tasks' },
       { label: 'Tasks Workflow', path: '/tasks-workflow' },
       { label: 'Schedule', path: '/schedule' },

--- a/frontend/src/styles/ServiceEditPage.css
+++ b/frontend/src/styles/ServiceEditPage.css
@@ -1,0 +1,6 @@
+.service-edit-page {
+  background-color: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}


### PR DESCRIPTION
## Summary
- expand service model and controller for category, tags, and search filters
- add Chakra UI service edit page with CRUD hooks
- expose service management in menu and API utilities

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68934e63c6a48320a459ed8e76cd8efd