### PR TITLE
Fix task API and calendar role handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,4 @@ VITE_ANALYTICS_ENDPOINT=/analytics/content/performance
 VITE_AUDIT_RESULTS_ENDPOINT=/security/compliance/audit-results
 VITE_CLASSROOM_DEFAULT_ROOM=WorkhouseClassroom
 VITE_RECAPTCHA_SITE_KEY=
+VITE_CALENDAR_ENDPOINT=/service-providers/calendar

--- a/frontend/src/api/calendar.js
+++ b/frontend/src/api/calendar.js
@@ -1,9 +1,10 @@
 import apiClient from '../utils/apiClient.js';
 
-const endpoint = import.meta.env.VITE_CALENDAR_ENDPOINT || '/service-providers/calendar';
+const endpoint =
+  import.meta.env.VITE_CALENDAR_ENDPOINT || '/service-providers/calendar';
 
-export function fetchEvents(userId) {
-  return apiClient.get(endpoint, { params: { userId } }).then((res) => res.data);
+export function fetchEvents(params = {}) {
+  return apiClient.get(endpoint, { params }).then((res) => res.data);
 }
 
 export function createEvent(data) {

--- a/frontend/src/api/tasks.js
+++ b/frontend/src/api/tasks.js
@@ -1,33 +1,49 @@
 import apiClient from '../utils/apiClient.js';
 
-export async function getTasks(params = {}) {
-  const { data } = await apiClient.get('/workspace/tasks', { params });
-  return data;
+// Flexible task listing helper
+// - listTasks(params)
+// - listTasks(projectId, params)
+export function listTasks(arg1, arg2) {
+  if (typeof arg1 === 'object') {
+    return apiClient
+      .get('/workspace/tasks', { params: arg1 })
+      .then((res) => res.data);
+  }
+  const projectId = arg1;
+  const params = arg2 || {};
+  const url = projectId
+    ? `/workspace/projects/${projectId}/tasks`
+    : '/workspace/tasks';
+  return apiClient.get(url, { params }).then((res) => res.data);
 }
+
+export const getTasks = (params = {}) => listTasks(params);
 
 export async function getTask(taskId) {
   const { data } = await apiClient.get(`/workspace/tasks/${taskId}`);
   return data;
-export async function getTasks(assignee) {
-  const { data } = await apiClient.get('/workspace/tasks', { params: { assignee } });
-  return data;
-export function listTasks(projectId, params = {}) {
-  const url = projectId ? `/workspace/projects/${projectId}/tasks` : '/workspace/tasks';
-  return apiClient.get(url, { params }).then(res => res.data);
 }
 
 export function createTask(data) {
-  return apiClient.post('/workspace/tasks/create', data).then(res => res.data);
+  return apiClient
+    .post('/workspace/tasks/create', data)
+    .then((res) => res.data);
 }
 
 export function updateTask(taskId, updates) {
-  return apiClient.put(`/workspace/tasks/update/${taskId}`, updates).then(res => res.data);
+  return apiClient
+    .put(`/workspace/tasks/update/${taskId}`, updates)
+    .then((res) => res.data);
 }
 
 export function deleteTask(taskId) {
-  return apiClient.delete(`/workspace/tasks/delete/${taskId}`);
+  return apiClient
+    .delete(`/workspace/tasks/delete/${taskId}`)
+    .then((res) => res.data);
 }
 
 export function assignTask(payload) {
-  return apiClient.post('/workspace/tasks/assign', payload).then(res => res.data);
+  return apiClient
+    .post('/workspace/tasks/assign', payload)
+    .then((res) => res.data);
 }

--- a/frontend/src/pages/ScheduleCalendarPage.jsx
+++ b/frontend/src/pages/ScheduleCalendarPage.jsx
@@ -32,7 +32,9 @@ function ScheduleCalendarPage() {
 
   useEffect(() => {
     if (user) {
-      fetchEvents(user.id).then(setEvents).catch(console.error);
+      const params =
+        user.role === 'seller' ? { sellerId: user.id } : { buyerId: user.id };
+      fetchEvents(params).then(setEvents).catch(console.error);
     }
   }, [user]);
 
@@ -43,11 +45,15 @@ function ScheduleCalendarPage() {
   async function handleAdd() {
     try {
       const payload = {
-        sellerId: user.id,
         title: form.title,
         startTime: form.startTime,
         endTime: form.endTime,
       };
+      if (user.role === 'seller') {
+        payload.sellerId = user.id;
+      } else {
+        payload.buyerId = user.id;
+      }
       const newEvent = await createEvent(payload);
       setEvents((prev) => [...prev, newEvent]);
       setForm({ title: '', startTime: '', endTime: '' });

--- a/frontend/src/pages/TaskSchedulePage.jsx
+++ b/frontend/src/pages/TaskSchedulePage.jsx
@@ -13,7 +13,7 @@ import {
   Spinner,
 } from '@chakra-ui/react';
 import { useAuth } from '../context/AuthContext.jsx';
-import { getTasks } from '../api/tasks.js';
+import { listTasks } from '../api/tasks.js';
 import '../styles/TaskSchedulePage.css';
 
 export default function TaskSchedulePage() {
@@ -24,7 +24,7 @@ export default function TaskSchedulePage() {
   useEffect(() => {
     async function load() {
       try {
-        const data = await getTasks(user?.id);
+        const data = await listTasks({ assignee: user.id });
         setTasks(data);
       } catch (err) {
         console.error('Failed to load tasks', err);


### PR DESCRIPTION
## Summary
- fix tasks API module with flexible listTasks helper
- allow calendar endpoints to accept seller or buyer params
- wire schedule page to role-based calendar events and new task listing

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68934e7015a08320988854521dde40ef