### PR TITLE
Add volunteer opportunity search page

### DIFF
--- a/backend/models/opportunity.js
+++ b/backend/models/opportunity.js
@@ -19,7 +19,6 @@ function create({
   experienceLevel = '',
   status = 'open',
 }) {
-function create({ organizationId, title, description, location = '', remote = false, commitmentTime = '', urgency = 'normal', requirements = '', multimedia = [], isFeatured = false, status = 'open' }) {
   const id = randomUUID();
   const now = new Date();
   const opportunity = {
@@ -33,16 +32,15 @@ function create({ organizationId, title, description, location = '', remote = fa
     urgency,
     requirements,
     multimedia,
-    status,
-    views: 0,
-    applications: 0,
-    matches: 0,
     isFeatured,
     category,
     duration,
     compensation,
     experienceLevel,
     status,
+    views: 0,
+    applications: 0,
+    matches: 0,
     deleted: false,
     createdAt: now,
     updatedAt: now,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -71,6 +71,7 @@ import WorkspaceDashboard from '../pages/WorkspaceDashboard.jsx';
 import JobPostManagement from '../pages/JobPostManagement.jsx';
 import VirtualInterview from '../pages/VirtualInterview.jsx';
 import InterviewSession from '../pages/InterviewSession.jsx';
+import VolunteerOpportunitySearchPage from './pages/VolunteerOpportunitySearchPage.jsx';
 
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 import { ProfileProvider } from './context/ProfileContext.jsx';
@@ -158,7 +159,7 @@ export default function App() {
 
     // Volunteering
     { path: '/volunteering', element: <PlaceholderPage title="Volunteering Dashboard" />, protected: true },
-    { path: '/volunteer/opportunities', element: <PlaceholderPage title="Volunteer Opportunities" />, protected: true },
+    { path: '/volunteer/opportunities', element: <VolunteerOpportunitySearchPage />, protected: true },
 
     // Networking
     { path: '/networking', element: <PlaceholderPage title="Networking Dashboard" />, protected: true },

--- a/frontend/src/api/opportunities.js
+++ b/frontend/src/api/opportunities.js
@@ -5,6 +5,16 @@ export async function getOpportunityDashboard() {
   return res.data;
 }
 
+export async function listOpportunities(params = {}) {
+  const res = await apiClient.get('/opportunities', { params });
+  return res.data;
+}
+
+export async function getOpportunity(id) {
+  const res = await apiClient.get(`/opportunities/${id}`);
+  return res.data;
+}
+
 export async function createOpportunity(data) {
   const res = await apiClient.post('/opportunities', data);
   return res.data;

--- a/frontend/src/components/VolunteerOpportunityCard.jsx
+++ b/frontend/src/components/VolunteerOpportunityCard.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Box, Heading, Text, Badge, IconButton } from '@chakra-ui/react';
+import { StarIcon } from '@chakra-ui/icons';
+import '../styles/VolunteerOpportunityCard.css';
+
+export default function VolunteerOpportunityCard({ opportunity, onOpen, onBookmark, bookmarked }) {
+  return (
+    <Box
+      className="volunteer-op-card"
+      borderWidth="1px"
+      borderRadius="md"
+      p={4}
+      position="relative"
+      onClick={() => onOpen(opportunity)}
+      cursor="pointer"
+      _hover={{ boxShadow: 'md' }}
+    >
+      <IconButton
+        aria-label="bookmark"
+        icon={<StarIcon />}
+        size="sm"
+        className="bookmark-btn"
+        colorScheme={bookmarked ? 'yellow' : 'gray'}
+        variant={bookmarked ? 'solid' : 'outline'}
+        onClick={(e) => {
+          e.stopPropagation();
+          onBookmark(opportunity);
+        }}
+      />
+      <Heading size="md" mb={2} pr={8}>
+        {opportunity.title}
+      </Heading>
+      {opportunity.organizationId && (
+        <Text fontSize="sm" mb={1} className="org-name">
+          {opportunity.organizationId}
+        </Text>
+      )}
+      {opportunity.location && <Text fontSize="sm">{opportunity.location}</Text>}
+      {opportunity.commitmentTime && (
+        <Badge mt={2}>{opportunity.commitmentTime}</Badge>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/pages/VolunteerOpportunitySearchPage.jsx
+++ b/frontend/src/pages/VolunteerOpportunitySearchPage.jsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Flex,
+  Input,
+  Select,
+  Button,
+  SimpleGrid,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalCloseButton,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+import VolunteerOpportunityCard from '../components/VolunteerOpportunityCard.jsx';
+import { listOpportunities, getOpportunity } from '../api/opportunities.js';
+import { submitApplication } from '../api/applications.js';
+import { getBookmarks, toggleBookmark, isBookmarked } from '../utils/bookmarks.js';
+import '../styles/VolunteerOpportunitySearchPage.css';
+
+export default function VolunteerOpportunitySearchPage() {
+  const [filters, setFilters] = useState({ keyword: '', location: '', availability: '', duration: '' });
+  const [opportunities, setOpportunities] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [bookmarks, setBookmarks] = useState(getBookmarks());
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function load() {
+    try {
+      const params = { keyword: filters.keyword };
+      if (filters.location) params.location = filters.location;
+      if (filters.availability) params.commitmentTime = filters.availability;
+      if (filters.duration) params.duration = filters.duration;
+      const data = await listOpportunities(params);
+      setOpportunities(data.opportunities || []);
+    } catch (err) {
+      console.error('Failed to load opportunities', err);
+    }
+  }
+
+  async function openDetails(op) {
+    try {
+      const data = await getOpportunity(op.id);
+      setSelected(data);
+    } catch (err) {
+      console.error('Failed to fetch opportunity', err);
+    }
+  }
+
+  async function handleApply(id) {
+    try {
+      await submitApplication({ opportunityId: id, message: '' });
+      alert('Application submitted');
+    } catch (err) {
+      console.error('Failed to apply', err);
+      alert('Failed to apply');
+    }
+  }
+
+  function handleBookmark(opportunity) {
+    const updated = toggleBookmark(opportunity);
+    setBookmarks(updated);
+  }
+
+  return (
+    <Box className="volunteer-opportunity-search" p={4}>
+      <Flex className="search-controls" wrap="wrap" gap={4} mb={4}>
+        <Input
+          placeholder="Keyword"
+          value={filters.keyword}
+          onChange={e => setFilters(f => ({ ...f, keyword: e.target.value }))}
+        />
+        <Input
+          placeholder="Location"
+          value={filters.location}
+          onChange={e => setFilters(f => ({ ...f, location: e.target.value }))}
+          maxW="200px"
+        />
+        <Select
+          placeholder="Availability"
+          value={filters.availability}
+          onChange={e => setFilters(f => ({ ...f, availability: e.target.value }))}
+          maxW="180px"
+        >
+          <option value="part-time">Part-Time</option>
+          <option value="full-time">Full-Time</option>
+        </Select>
+        <Select
+          placeholder="Duration"
+          value={filters.duration}
+          onChange={e => setFilters(f => ({ ...f, duration: e.target.value }))}
+          maxW="180px"
+        >
+          <option value="short">Short-Term</option>
+          <option value="medium">Medium-Term</option>
+          <option value="long">Long-Term</option>
+        </Select>
+        <Button colorScheme="teal" onClick={load}>
+          Search
+        </Button>
+      </Flex>
+      <SimpleGrid columns={[1, 2, 3]} spacing={4}>
+        {opportunities.map(op => (
+          <VolunteerOpportunityCard
+            key={op.id}
+            opportunity={op}
+            onOpen={openDetails}
+            onBookmark={handleBookmark}
+            bookmarked={isBookmarked(op.id)}
+          />
+        ))}
+      </SimpleGrid>
+      <Modal isOpen={!!selected} onClose={() => setSelected(null)} size="xl">
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>{selected?.title}</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            {selected && (
+              <VStack align="stretch" spacing={3} className="opportunity-details">
+                {selected.location && <Text>Location: {selected.location}</Text>}
+                {selected.commitmentTime && <Text>Commitment: {selected.commitmentTime}</Text>}
+                {selected.duration && <Text>Duration: {selected.duration}</Text>}
+                {selected.description && <Text>{selected.description}</Text>}
+                {selected.requirements && (
+                  <Text>Requirements: {selected.requirements}</Text>
+                )}
+                <Flex gap={2} pt={2} pb={4}>
+                  <Button colorScheme="teal" onClick={() => handleApply(selected.id)}>
+                    Apply Now
+                  </Button>
+                  <Button onClick={() => handleBookmark(selected)}>
+                    {isBookmarked(selected.id) ? 'Unsave' : 'Save for Later'}
+                  </Button>
+                </Flex>
+              </VStack>
+            )}
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </Box>
+  );
+}
+

--- a/frontend/src/styles/VolunteerOpportunityCard.css
+++ b/frontend/src/styles/VolunteerOpportunityCard.css
@@ -1,0 +1,13 @@
+.volunteer-op-card {
+  background: var(--chakra-colors-white);
+}
+
+.bookmark-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+.org-name {
+  color: var(--chakra-colors-gray-600);
+}

--- a/frontend/src/styles/VolunteerOpportunitySearchPage.css
+++ b/frontend/src/styles/VolunteerOpportunitySearchPage.css
@@ -1,0 +1,7 @@
+.volunteer-opportunity-search .search-controls {
+  gap: 1rem;
+}
+
+.volunteer-opportunity-search .opportunity-details {
+  font-size: 0.9rem;
+}

--- a/frontend/src/utils/bookmarks.js
+++ b/frontend/src/utils/bookmarks.js
@@ -1,0 +1,24 @@
+const STORAGE_KEY = 'volunteerBookmarks';
+
+export function getBookmarks() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function isBookmarked(id) {
+  return getBookmarks().some(b => b.id === id);
+}
+
+export function toggleBookmark(opportunity) {
+  const bookmarks = getBookmarks();
+  const exists = bookmarks.some(b => b.id === opportunity.id);
+  const updated = exists
+    ? bookmarks.filter(b => b.id !== opportunity.id)
+    : [...bookmarks, opportunity];
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+  return updated;
+}


### PR DESCRIPTION
## Summary
- fix opportunity data model to properly export CRUD helpers
- extend opportunities API client with list & detail functions
- add volunteer opportunity search UI with bookmark and apply features

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68934ea6692883209f62f6ec565cd5ae