### PR TITLE
Add volunteer application tracking enhancements

### DIFF
--- a/backend/database/applications.sql
+++ b/backend/database/applications.sql
@@ -4,6 +4,8 @@ CREATE TABLE IF NOT EXISTS applications (
   user_id VARCHAR(255) NOT NULL,
   message TEXT NOT NULL,
   status VARCHAR(20) DEFAULT 'pending',
+  certificate_url TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  completed_at TIMESTAMP
 );

--- a/backend/middleware/applicationOwnership.js
+++ b/backend/middleware/applicationOwnership.js
@@ -1,0 +1,13 @@
+const logger = require('../utils/logger');
+
+module.exports = (req, res, next) => {
+  const userId = req.user?.id || req.user?.username;
+  if (!req.application || req.application.userId !== userId) {
+    logger.error('Unauthorized application access', {
+      userId,
+      applicationId: req.application?.id,
+    });
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+  next();
+};

--- a/backend/models/application.js
+++ b/backend/models/application.js
@@ -12,8 +12,10 @@ function createApplication({ opportunityId, userId, message }) {
     userId,
     message,
     status: 'pending',
+    certificateUrl: null,
     createdAt: now,
     updatedAt: now,
+    completedAt: null,
   };
   applications.set(id, application);
   return application;
@@ -31,13 +33,27 @@ function getApplicationsByOpportunity(opportunityId) {
   return Array.from(applications.values()).filter(app => app.opportunityId === opportunityId);
 }
 
-function updateApplicationStatus(id, status) {
+function updateApplicationStatus(id, status, certificateUrl) {
   const application = applications.get(id);
   if (!application) return null;
   application.status = status;
   application.updatedAt = new Date();
+  if (status === 'completed') {
+    application.completedAt = new Date();
+    if (certificateUrl) application.certificateUrl = certificateUrl;
+  }
   applications.set(id, application);
   return application;
+}
+
+function deleteApplication(id) {
+  return applications.delete(id);
+}
+
+function getCompletedApplicationsByUser(userId) {
+  return Array.from(applications.values()).filter(
+    (app) => app.userId === userId && app.status === 'completed'
+  );
 }
 
 module.exports = {
@@ -46,4 +62,6 @@ module.exports = {
   getApplicationsByUser,
   getApplicationsByOpportunity,
   updateApplicationStatus,
+  deleteApplication,
+  getCompletedApplicationsByUser,
 };

--- a/backend/routes/applications.js
+++ b/backend/routes/applications.js
@@ -4,11 +4,14 @@ const {
   getUserApplicationsHandler,
   getOpportunityApplicationsHandler,
   updateApplicationStatusHandler,
+  deleteApplicationHandler,
+  getCompletedApplicationsHandler,
 } = require('../controllers/application');
 const auth = require('../middleware/auth');
 const validate = require('../middleware/validate');
 const applicationExists = require('../middleware/application');
 const requireRole = require('../middleware/requireRole');
+const applicationOwnership = require('../middleware/applicationOwnership');
 const {
   applicationCreationSchema,
   applicationIdParamSchema,
@@ -23,6 +26,9 @@ router.post('/', auth, requireRole('volunteer', 'admin'), validate(applicationCr
 
 // Get applications for the authenticated volunteer
 router.get('/user', auth, getUserApplicationsHandler);
+
+// Get completed applications for the authenticated volunteer
+router.get('/completed', auth, requireRole('volunteer', 'admin'), getCompletedApplicationsHandler);
 
 // Get applications for a specific opportunity (organization access)
 router.get(
@@ -42,6 +48,17 @@ router.put(
   validate(statusUpdateSchema),
   applicationExists,
   updateApplicationStatusHandler
+);
+
+// Withdraw an application
+router.delete(
+  '/:applicationId',
+  auth,
+  requireRole('volunteer', 'admin'),
+  validate(applicationIdParamSchema, 'params'),
+  applicationExists,
+  applicationOwnership,
+  deleteApplicationHandler
 );
 
 module.exports = router;

--- a/backend/services/application.js
+++ b/backend/services/application.js
@@ -15,8 +15,8 @@ async function listApplicationsForOpportunity(opportunityId) {
   return applicationModel.getApplicationsByOpportunity(opportunityId);
 }
 
-async function updateApplicationStatus(applicationId, status) {
-  const updated = applicationModel.updateApplicationStatus(applicationId, status);
+async function updateApplicationStatus(applicationId, status, certificateUrl) {
+  const updated = applicationModel.updateApplicationStatus(applicationId, status, certificateUrl);
   if (!updated) {
     logger.error('Attempted to update non-existent application', { applicationId });
     return null;
@@ -29,10 +29,26 @@ async function getApplicationById(applicationId) {
   return applicationModel.getApplicationById(applicationId);
 }
 
+async function deleteApplication(applicationId) {
+  const removed = applicationModel.deleteApplication(applicationId);
+  if (removed) {
+    logger.info('Application withdrawn', { applicationId });
+  } else {
+    logger.error('Attempted to withdraw non-existent application', { applicationId });
+  }
+  return removed;
+}
+
+async function listCompletedApplicationsForUser(userId) {
+  return applicationModel.getCompletedApplicationsByUser(userId);
+}
+
 module.exports = {
   applyForOpportunity,
   listApplicationsForUser,
   listApplicationsForOpportunity,
   updateApplicationStatus,
   getApplicationById,
+  deleteApplication,
+  listCompletedApplicationsForUser,
 };

--- a/backend/validation/application.js
+++ b/backend/validation/application.js
@@ -14,7 +14,10 @@ const opportunityIdParamSchema = Joi.object({
 });
 
 const statusUpdateSchema = Joi.object({
-  status: Joi.string().valid('pending', 'accepted', 'rejected').required(),
+  status: Joi.string()
+    .valid('pending', 'accepted', 'rejected', 'completed')
+    .required(),
+  certificateUrl: Joi.string().uri().optional(),
 });
 
 module.exports = {

--- a/frontend/src/api/applications.js
+++ b/frontend/src/api/applications.js
@@ -14,12 +14,24 @@ export async function fetchOpportunityApplications(opportunityId) {
   return data;
 }
 
-export async function updateApplicationStatus(applicationId, status) {
-  const { data } = await apiClient.put(`/applications/${applicationId}/status`, { status });
+export async function updateApplicationStatus(applicationId, status, certificateUrl) {
+  const { data } = await apiClient.put(`/applications/${applicationId}/status`, {
+    status,
+    certificateUrl,
+  });
   return data;
 }
 
 export async function submitApplication(payload) {
   const { data } = await apiClient.post('/applications', payload);
   return data;
+}
+
+export async function fetchCompletedApplications() {
+  const { data } = await apiClient.get('/applications/completed');
+  return data;
+}
+
+export async function deleteApplication(applicationId) {
+  await apiClient.delete(`/applications/${applicationId}`);
 }

--- a/frontend/src/components/OpportunityCard.jsx
+++ b/frontend/src/components/OpportunityCard.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Box, Heading, Text, Flex, Badge, Button } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
 import '../styles/OpportunityCard.css';
 
 export default function OpportunityCard({ opportunity, onEdit, onDelete, onDuplicate, onStatusChange }) {
+  const navigate = useNavigate();
   return (
     <Box className="opportunity-card" borderWidth="1px" borderRadius="md" p={4} mb={4}>
       <Flex justify="space-between" align="center" mb={2}>
@@ -17,6 +19,13 @@ export default function OpportunityCard({ opportunity, onEdit, onDelete, onDupli
         <Button size="sm" onClick={() => onStatusChange(opportunity, 'closed')}>Close</Button>
         <Button size="sm" onClick={() => onDuplicate(opportunity.id)}>Duplicate</Button>
         <Button size="sm" colorScheme="red" onClick={() => onDelete(opportunity.id)}>Delete</Button>
+        <Button
+          size="sm"
+          colorScheme="teal"
+          onClick={() => navigate(`/volunteer-applications?opportunityId=${opportunity.id}`)}
+        >
+          Applications
+        </Button>
       </Flex>
     </Box>
   );

--- a/frontend/src/pages/VolunteerTrackingPage.jsx
+++ b/frontend/src/pages/VolunteerTrackingPage.jsx
@@ -16,14 +16,18 @@ import {
   Badge,
   Button,
   Input,
-  Stack
+  Stack,
+  Link
 } from '@chakra-ui/react';
 import {
   fetchUserApplications,
   fetchOpportunityApplications,
-  updateApplicationStatus
+  fetchCompletedApplications,
+  updateApplicationStatus,
+  deleteApplication
 } from '../api/applications.js';
 import { useAuth } from '../context/AuthContext.jsx';
+import { useSearchParams } from 'react-router-dom';
 import '../styles/VolunteerTrackingPage.css';
 
 export default function VolunteerTrackingPage() {
@@ -31,12 +35,23 @@ export default function VolunteerTrackingPage() {
   const [userApps, setUserApps] = useState([]);
   const [opportunityId, setOpportunityId] = useState('');
   const [orgApps, setOrgApps] = useState([]);
+  const [completedApps, setCompletedApps] = useState([]);
+  const [searchParams] = useSearchParams();
 
   useEffect(() => {
     if (user) {
       loadUserApps();
+      loadCompleted();
     }
   }, [user]);
+
+  useEffect(() => {
+    const id = searchParams.get('opportunityId');
+    if (id) {
+      setOpportunityId(id);
+      loadOrgApps(id);
+    }
+  }, [searchParams]);
 
   async function loadUserApps() {
     try {
@@ -57,12 +72,30 @@ export default function VolunteerTrackingPage() {
     }
   }
 
+  async function loadCompleted() {
+    try {
+      const data = await fetchCompletedApplications();
+      setCompletedApps(data);
+    } catch (err) {
+      console.error('Failed to load completed applications', err);
+    }
+  }
+
   async function handleStatus(id, status) {
     try {
       await updateApplicationStatus(id, status);
       setOrgApps(apps => apps.map(a => (a.id === id ? { ...a, status } : a)));
     } catch (err) {
       console.error('Failed to update status', err);
+    }
+  }
+
+  async function handleWithdraw(id) {
+    try {
+      await deleteApplication(id);
+      setUserApps(apps => apps.filter(a => a.id !== id));
+    } catch (err) {
+      console.error('Failed to withdraw application', err);
     }
   }
 
@@ -73,6 +106,7 @@ export default function VolunteerTrackingPage() {
         <TabList mb="1em">
           <Tab>My Applications</Tab>
           <Tab>Opportunity Applications</Tab>
+          <Tab>Completed Volunteering</Tab>
         </TabList>
         <TabPanels>
           <TabPanel>
@@ -82,6 +116,7 @@ export default function VolunteerTrackingPage() {
                   <Th>Opportunity</Th>
                   <Th>Status</Th>
                   <Th>Submitted</Th>
+                  <Th>Actions</Th>
                 </Tr>
               </Thead>
               <Tbody>
@@ -92,6 +127,11 @@ export default function VolunteerTrackingPage() {
                       <Badge colorScheme={statusColor(app.status)}>{app.status}</Badge>
                     </Td>
                     <Td>{new Date(app.createdAt).toLocaleDateString()}</Td>
+                    <Td>
+                      <Button size="xs" colorScheme="red" onClick={() => handleWithdraw(app.id)}>
+                        Withdraw
+                      </Button>
+                    </Td>
                   </Tr>
                 ))}
               </Tbody>
@@ -104,7 +144,7 @@ export default function VolunteerTrackingPage() {
                 value={opportunityId}
                 onChange={e => setOpportunityId(e.target.value)}
               />
-              <Button onClick={loadOrgApps}>Load</Button>
+              <Button onClick={() => loadOrgApps(opportunityId)}>Load</Button>
             </Stack>
             <Table size="sm" className="volunteer-table">
               <Thead>
@@ -146,6 +186,34 @@ export default function VolunteerTrackingPage() {
               </Tbody>
             </Table>
           </TabPanel>
+          <TabPanel>
+            <Table size="sm" className="volunteer-table">
+              <Thead>
+                <Tr>
+                  <Th>Opportunity</Th>
+                  <Th>Completed</Th>
+                  <Th>Certificate</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {completedApps.map((app) => (
+                  <Tr key={app.id}>
+                    <Td>{app.opportunityId}</Td>
+                    <Td>{app.completedAt ? new Date(app.completedAt).toLocaleDateString() : ''}</Td>
+                    <Td>
+                      {app.certificateUrl ? (
+                        <Link href={app.certificateUrl} isExternal color="teal.500">
+                          Download
+                        </Link>
+                      ) : (
+                        'N/A'
+                      )}
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </TabPanel>
         </TabPanels>
       </Tabs>
     </Box>
@@ -158,6 +226,8 @@ function statusColor(status) {
       return 'green';
     case 'rejected':
       return 'red';
+    case 'completed':
+      return 'green';
     default:
       return 'yellow';
   }


### PR DESCRIPTION
## Summary
- support withdrawal and completion tracking for volunteer applications
- expose `/applications/completed` and DELETE `/applications/:id` API routes
- extend volunteer tracking UI with completed activities, withdraw actions and direct links from opportunities

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934eb02fa08320ad8357004704e17a