### PR TITLE
Add host-specific networking session listings

### DIFF
--- a/backend/controllers/event.js
+++ b/backend/controllers/event.js
@@ -62,10 +62,16 @@ async function attendNetworkingEvent(req, res) {
   const result = await eventService.attendNetworkingEvent(req.params.eventId, req.user.id);
   if (!result) return res.status(404).json({ error: 'Event not found' });
   res.json(result);
-  const userId = req.user.id;
-  const hosted = await eventService.listNetworkingEventsForHost(userId);
-  const attending = await eventService.listNetworkingEventsForUser(userId);
-  res.json({ hosted, attending });
+}
+
+async function listNetworkingEventsForHost(req, res) {
+  const events = await eventService.listNetworkingEventsForHost(req.user.id);
+  res.json(events);
+}
+
+async function listNetworkingEventsForUser(req, res) {
+  const events = await eventService.listNetworkingEventsForUser(req.user.id);
+  res.json(events);
 }
 
 async function createWorkshop(req, res) {
@@ -108,6 +114,8 @@ module.exports = {
   getNetworkingEvent,
   listNetworkingEvents,
   attendNetworkingEvent,
+  listNetworkingEventsForHost,
+  listNetworkingEventsForUser,
   createWorkshop,
   getWorkshop,
   submitQuestion,

--- a/backend/models/eventController.js
+++ b/backend/models/eventController.js
@@ -62,7 +62,9 @@ function getQuestions(id) {
 }
 
 function listByType(type) {
-  return Array.from(events.values()).filter(e => e.type === type);
+  return Array.from(events.values()).filter((e) => e.type === type);
+}
+
 function findByHost(hostId) {
   return Array.from(events.values()).filter((e) => e.hostId === hostId);
 }

--- a/backend/routes/events.js
+++ b/backend/routes/events.js
@@ -41,10 +41,11 @@ router.post('/pitch/livestream/:eventId', auth, eventItemExists, validate(livest
 router.get('/pitch/livestream/:eventId', eventItemExists, investorEventController.getPitchLivestream);
 
 router.post('/networking/create', auth, validate(networkingEventSchema), investorEventController.createNetworkingEvent);
-router.get('/networking', investorEventController.listNetworkingEvents);
-router.get('/networking/:eventId', eventItemExists, investorEventController.getNetworkingEvent);
-router.post('/networking/attend/:eventId', auth, eventItemExists, investorEventController.attendNetworkingEvent);
 router.get('/networking', auth, investorEventController.listNetworkingEvents);
+router.get('/networking/host', auth, investorEventController.listNetworkingEventsForHost);
+router.get('/networking/attending', auth, investorEventController.listNetworkingEventsForUser);
+router.get('/networking/:eventId', auth, eventItemExists, investorEventController.getNetworkingEvent);
+router.post('/networking/attend/:eventId', auth, eventItemExists, investorEventController.attendNetworkingEvent);
 
 router.post('/workshop/create', auth, validate(workshopEventSchema), investorEventController.createWorkshop);
 router.get('/workshop/:eventId', eventItemExists, investorEventController.getWorkshop);

--- a/backend/services/event.js
+++ b/backend/services/event.js
@@ -60,6 +60,8 @@ async function attendNetworkingEvent(eventId, userId) {
   eventModel.addAttendee(eventId, userId);
   logger.info('User attending networking event', { eventId, userId });
   return { success: true };
+}
+
 async function listNetworkingEventsForHost(hostId) {
   return eventModel
     .findByHost(hostId)

--- a/frontend/api/networking.js
+++ b/frontend/api/networking.js
@@ -20,10 +20,12 @@ export function fetchNetworkingEvents() {
   return request('/events/networking');
 }
 
+export function fetchHostedNetworkingEvents() {
+  return request('/events/networking/host');
+}
+
 export function attendNetworkingEvent(eventId) {
   return request(`/events/networking/attend/${eventId}`, { method: 'POST' });
-}
-  return res.json().catch(() => ({}));
 }
 
 export function startVideo(sessionId, data = {}) {
@@ -58,13 +60,3 @@ export function getNextOneMinuteMatch(eventId) {
 export function getSessionMetrics(sessionId) {
   return request(`/communication/analytics/${sessionId}`);
 }
-(function(global){
-  async function getNetworkingDashboard() {
-    const res = await apiFetch('/events/networking');
-    if (!res.ok) {
-      throw new Error('Failed to load networking data');
-    }
-    return res.json();
-  }
-  global.networkingAPI = { getNetworkingDashboard };
-})(window);

--- a/frontend/pages/NetworkingSessions.jsx
+++ b/frontend/pages/NetworkingSessions.jsx
@@ -21,19 +21,36 @@ import {
 } from '@chakra-ui/react';
 import NavMenu from '../components/NavMenu';
 import SessionCard from '../components/SessionCard';
-import { fetchNetworkingEvents, attendNetworkingEvent } from '../api/networking';
+import {
+  fetchNetworkingEvents,
+  fetchHostedNetworkingEvents,
+  attendNetworkingEvent,
+} from '../api/networking';
 import '../styles/NetworkingSessions.css';
 
 export default function NetworkingSessions() {
   const [sessions, setSessions] = useState([]);
+  const [hosted, setHosted] = useState([]);
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState(null);
 
   useEffect(() => {
-    fetchNetworkingEvents().then(setSessions).catch(console.error);
+    Promise.all([
+      fetchNetworkingEvents(),
+      fetchHostedNetworkingEvents(),
+    ])
+      .then(([all, hosted]) => {
+        setSessions(all);
+        setHosted(hosted);
+      })
+      .catch(console.error);
   }, []);
 
   const filtered = sessions.filter(s =>
+    s.title.toLowerCase().includes(query.toLowerCase())
+  );
+
+  const filteredHosted = hosted.filter(s =>
     s.title.toLowerCase().includes(query.toLowerCase())
   );
 
@@ -66,14 +83,14 @@ export default function NetworkingSessions() {
           <TabPanels>
             <TabPanel>
               <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
-                {filtered.map(session => (
+                {filtered.map((session) => (
                   <SessionCard key={session.id} session={session} onView={setSelected} />
                 ))}
               </SimpleGrid>
             </TabPanel>
             <TabPanel>
               <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
-                {filtered.map(session => (
+                {filteredHosted.map((session) => (
                   <SessionCard key={session.id} session={session} onView={setSelected} />
                 ))}
               </SimpleGrid>


### PR DESCRIPTION
## Summary
- fix event model and service functions for networking sessions
- add authenticated routes to list hosted and attending networking events
- enhance NetworkingSessions page to load hosted events for company view

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934ecdd86483209842d3899d8f94a4