### PR TITLE
feat: implement creator dashboard

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -35,6 +35,7 @@ import ContractManagementPage from './pages/ContractManagementPage.jsx';
 import ContractFormPage from './pages/ContractFormPage.jsx';
 import ContentLibraryPage from './pages/ContentLibraryPage.jsx';
 import CreatorAnalyticsPage from './pages/CreatorAnalyticsPage.jsx';
+import CreatorDashboardPage from './pages/CreatorDashboardPage.jsx';
 import LivePlaybackPage from './pages/LivePlaybackPage.jsx';
 import AffiliateManagementPage from './pages/AffiliateManagementPage.jsx';
 import AdsDashboardPage from './pages/AdsDashboardPage.jsx';
@@ -167,7 +168,7 @@ export default function App() {
     { path: '/session-management', element: <PlaceholderPage title="Session Management" />, protected: true },
 
     // Media & Advertising
-    { path: '/creator/dashboard', element: <PlaceholderPage title="Creator Dashboard" />, protected: true },
+    { path: '/creator/dashboard', element: <CreatorDashboardPage />, protected: true },
     { path: '/creator/analytics', element: <CreatorAnalyticsPage />, protected: true },
     { path: '/content/manage', element: <PlaceholderPage title="Content Creation & Management" />, protected: true },
     { path: '/content-library', element: <ContentLibraryPage />, protected: true },

--- a/frontend/src/api/creator.js
+++ b/frontend/src/api/creator.js
@@ -1,0 +1,11 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function getCreatorSeries() {
+  const { data } = await apiClient.get('/podcast-analytics/creator/series');
+  return data;
+}
+
+export async function getCreatorWebinars() {
+  const { data } = await apiClient.get('/webinar-analytics/creator/webinars');
+  return data;
+}

--- a/frontend/src/pages/CreatorDashboardPage.jsx
+++ b/frontend/src/pages/CreatorDashboardPage.jsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Heading, SimpleGrid, Text, Button, Flex, Spinner } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+import { getCreatorSeries, getCreatorWebinars } from '../api/creator.js';
+import { fetchPopularPodcasts } from '../api/podcast.js';
+import '../styles/CreatorDashboardPage.css';
+
+function StatCard({ label, value }) {
+  return (
+    <Box className="stat-card" p={4} borderWidth="1px" borderRadius="md" bg="white">
+      <Heading size="sm" mb={2}>{label}</Heading>
+      <Text fontSize="xl" fontWeight="bold">{value}</Text>
+    </Box>
+  );
+}
+
+export default function CreatorDashboardPage() {
+  const [series, setSeries] = useState([]);
+  const [webinars, setWebinars] = useState([]);
+  const [trending, setTrending] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [s, w, t] = await Promise.all([
+          getCreatorSeries(),
+          getCreatorWebinars(),
+          fetchPopularPodcasts(),
+        ]);
+        setSeries(s);
+        setWebinars(w);
+        setTrending(t?.data || t);
+      } catch (err) {
+        console.error('Failed to load creator dashboard', err);
+        setError('Failed to load dashboard data');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  const totalPlays = series.reduce((sum, s) => sum + (s.listens || 0), 0);
+  const totalAttendees = webinars.reduce((sum, w) => sum + (w.overview?.attendees || 0), 0);
+  const totalRevenue = webinars.reduce((sum, w) => sum + (w.overview?.revenue || 0), 0);
+
+  if (loading) {
+    return (
+      <Box p={4} textAlign="center">
+        <Spinner />
+      </Box>
+    );
+  }
+
+  return (
+    <Box className="creator-dashboard" p={4}>
+      <Heading mb={4}>Creator Dashboard</Heading>
+      {error && <Text color="red.500" mb={4}>{error}</Text>}
+      <SimpleGrid columns={[1, 2, 3]} spacing={4} mb={6}>
+        <StatCard label="Total Plays" value={totalPlays} />
+        <StatCard label="Total Attendees" value={totalAttendees} />
+        <StatCard label="Revenue" value={`$${totalRevenue}`} />
+      </SimpleGrid>
+
+      <Heading size="md" mb={2}>Podcast Series</Heading>
+      <SimpleGrid columns={[1, 2, 3]} spacing={4} mb={6}>
+        {series.map(s => (
+          <Box key={s.seriesId} className="series-card" borderWidth="1px" borderRadius="md" p={4} bg="white">
+            <Heading size="sm" mb={2}>{s.title || 'Untitled Series'}</Heading>
+            <Text>Episodes: {s.episodes || 0}</Text>
+            <Text>Listens: {s.listens || 0}</Text>
+            <Flex mt={2} gap={2} flexWrap="wrap">
+              <Button size="sm" colorScheme="teal" onClick={() => navigate(`/content/manage?type=podcast&seriesId=${s.seriesId}`)}>Edit</Button>
+              <Button size="sm" colorScheme="blue" onClick={() => navigate(`/content/manage?type=podcast&seriesId=${s.seriesId}&action=addEpisode`)}>Add Episode</Button>
+              <Button size="sm" colorScheme="purple" onClick={() => navigate(`/creator/analytics?seriesId=${s.seriesId}`)}>Stats</Button>
+            </Flex>
+          </Box>
+        ))}
+      </SimpleGrid>
+
+      <Heading size="md" mb={2}>Webinars</Heading>
+      <SimpleGrid columns={[1, 2, 3]} spacing={4} mb={6}>
+        {webinars.map(w => (
+          <Box key={w.webinarId} className="series-card" borderWidth="1px" borderRadius="md" p={4} bg="white">
+            <Heading size="sm" mb={2}>{w.title || 'Webinar'}</Heading>
+            <Text>Attendees: {w.overview?.attendees || 0}</Text>
+            <Text>Revenue: ${w.overview?.revenue || 0}</Text>
+            <Flex mt={2} gap={2} flexWrap="wrap">
+              <Button size="sm" colorScheme="teal" onClick={() => navigate(`/content/manage?type=webinar&webinarId=${w.webinarId}`)}>Edit</Button>
+              <Button size="sm" colorScheme="blue" onClick={() => navigate(`/content/manage?type=webinar&action=add`)}>Add Webinar</Button>
+              <Button size="sm" colorScheme="purple" onClick={() => navigate(`/creator/analytics?webinarId=${w.webinarId}`)}>Stats</Button>
+            </Flex>
+          </Box>
+        ))}
+      </SimpleGrid>
+
+      <Heading size="md" mb={2}>Trending Podcasts</Heading>
+      <SimpleGrid columns={[1, 2, 3]} spacing={4}>
+        {trending.slice(0,3).map(p => (
+          <Box key={p.key || p.id || p.url} className="series-card" borderWidth="1px" borderRadius="md" p={4} bg="white">
+            <Text fontWeight="bold">{p.name || p.title || 'Podcast'}</Text>
+          </Box>
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Heading, SimpleGrid, Stat, StatLabel, StatNumber, Spinner, Button } from '@chakra-ui/react';
+import { Box, Heading, SimpleGrid, Stat, StatLabel, StatNumber, Spinner, Button, Flex } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/DashboardPage.css';
 import { getDashboard } from '../api/dashboard.js';
@@ -31,34 +31,13 @@ export default function DashboardPage() {
   return (
     <Box className="dashboard-page">
       <Heading mb={4}>Welcome back, {user?.name || user?.username}</Heading>
-      <Button mb={4} colorScheme="teal" onClick={() => navigate('/feed')}>
-        View Live Feed
-      </Button>
-      <SimpleGrid columns={[1, 3]} spacing={4}>
+      <Flex gap={2} mb={4} flexWrap="wrap">
+        <Button colorScheme="purple" onClick={() => navigate('/install')}>Run Installation Wizard</Button>
+        <Button colorScheme="teal" onClick={() => navigate('/feed')}>View Live Feed</Button>
+        <Button colorScheme="blue" onClick={() => navigate('/creator/dashboard')}>Creator Dashboard</Button>
+      </Flex>
+      <SimpleGrid columns={[1, 2, 3]} spacing={4}>
         {'totalSpend' in data && (
-      <NavBar />
-      <NavMenu />
-      <Box p={4}>
-        <Heading mb={4}>Welcome back, {user?.name || user?.username}</Heading>
-        <Button mb={4} colorScheme="purple" onClick={() => navigate('/install')}>
-          Run Installation Wizard
-        </Button>
-        <Button mb={4} colorScheme="teal" onClick={() => navigate('/feed')}>
-          View Live Feed
-        </Button>
-        <SimpleGrid columns={[1, 3]} spacing={4}>
-          {'totalSpend' in data && (
-            <Stat>
-              <StatLabel>Total Spend</StatLabel>
-              <StatNumber>${data.totalSpend}</StatNumber>
-            </Stat>
-          )}
-          {'totalEarnings' in data && (
-            <Stat>
-              <StatLabel>Total Earnings</StatLabel>
-              <StatNumber>${data.totalEarnings}</StatNumber>
-            </Stat>
-          )}
           <Stat>
             <StatLabel>Total Spend</StatLabel>
             <StatNumber>${data.totalSpend}</StatNumber>

--- a/frontend/src/styles/CreatorDashboardPage.css
+++ b/frontend/src/styles/CreatorDashboardPage.css
@@ -1,0 +1,8 @@
+.creator-dashboard {
+  background-color: #f9f9f9;
+}
+
+.creator-dashboard .stat-card,
+.creator-dashboard .series-card {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}


### PR DESCRIPTION
## Summary
- Add API helpers for creator podcast series and webinars
- Build Creator Dashboard with stats and quick actions
- Link dashboard from main navigation and home dashboard

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934eec81548320bf28178fd790ef98