### PR TITLE
feat: add content library playback pages

### DIFF
--- a/backend/models/expertAccess.js
+++ b/backend/models/expertAccess.js
@@ -24,13 +24,15 @@ function getWebinars() {
   return Array.from(webinars.values());
 }
 
-function seedWebinar({ title, scheduledAt, description }) {
+function seedWebinar({ title, scheduledAt, description, videoUrl, jitsiRoom }) {
   const id = randomUUID();
   const webinar = {
     id,
     title,
     scheduledAt: new Date(scheduledAt),
     description: description || '',
+    videoUrl: videoUrl || '',
+    jitsiRoom: jitsiRoom || '',
     createdAt: new Date(),
   };
   webinars.set(id, webinar);
@@ -80,4 +82,6 @@ seedWebinar({
   title: 'Industry Trends Webinar',
   scheduledAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
   description: 'Overview of upcoming industry trends and insights.',
+  videoUrl: 'https://samplelib.com/lib/preview/mp4/sample-5s.mp4',
+  jitsiRoom: 'IndustryTrendsWebinar'
 });

--- a/backend/models/podcastAnalytics.js
+++ b/backend/models/podcastAnalytics.js
@@ -27,6 +27,10 @@ podcasts.set(samplePodcastId, {
   podcastId: samplePodcastId,
   seriesId: sampleSeriesId,
   ownerId,
+  title: 'Sample Podcast',
+  description: 'Introductory episode with insights.',
+  thumbnail: 'https://via.placeholder.com/150',
+  audioUrl: 'https://samplelib.com/lib/preview/mp3/sample-3s.mp3',
   engagement: {
     listens: 0,
     avgListenDuration: 1700,
@@ -119,6 +123,8 @@ function recordListen(podcastId) {
   }
   podcast.engagement.listens = (podcast.engagement.listens || 0) + 1;
   return podcast.engagement.listens;
+}
+
 function getAllPodcasts() {
   return Array.from(podcasts.values());
 }

--- a/backend/services/contentLibrary.js
+++ b/backend/services/contentLibrary.js
@@ -9,12 +9,15 @@ async function getContentLibrary() {
     title: p.title || 'Podcast',
     description: p.description || '',
     thumbnail: p.thumbnail || null,
+    audioUrl: p.audioUrl || '',
   }));
   const webinars = expertAccessModel.getWebinars().map(w => ({
     id: w.id,
     title: w.title,
     description: w.description || '',
     scheduledAt: w.scheduledAt,
+    videoUrl: w.videoUrl || '',
+    jitsiRoom: w.jitsiRoom || '',
   }));
   return { podcasts, webinars };
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,7 @@ import SupportDisputePage from './pages/SupportDisputePage.jsx';
 import ContractManagementPage from './pages/ContractManagementPage.jsx';
 import ContractFormPage from './pages/ContractFormPage.jsx';
 import ContentLibraryPage from './pages/ContentLibraryPage.jsx';
+import ContentDetailPage from './pages/ContentDetailPage.jsx';
 import CreatorAnalyticsPage from './pages/CreatorAnalyticsPage.jsx';
 import LivePlaybackPage from './pages/LivePlaybackPage.jsx';
 import AffiliateManagementPage from './pages/AffiliateManagementPage.jsx';
@@ -171,6 +172,8 @@ export default function App() {
     { path: '/creator/analytics', element: <CreatorAnalyticsPage />, protected: true },
     { path: '/content/manage', element: <PlaceholderPage title="Content Creation & Management" />, protected: true },
     { path: '/content-library', element: <ContentLibraryPage />, protected: true },
+    { path: '/content-library/:type/:id', element: <ContentDetailPage />, protected: true },
+    { path: '/content-library/:type/:id/play', element: <LivePlaybackPage />, protected: true },
     { path: '/live', element: <LivePlaybackPage />, protected: true },
     { path: '/billing', element: <BillingSubscription />, protected: true },
     { path: '/analytics', element: <AnalyticsAuditPage />, protected: true },

--- a/frontend/src/pages/ContentDetailPage.jsx
+++ b/frontend/src/pages/ContentDetailPage.jsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link as RouterLink } from 'react-router-dom';
+import { Box, Heading, Text, Button, Spinner } from '@chakra-ui/react';
+import { fetchContentDetails } from '../api/contentLibrary.js';
+import '../styles/ContentDetailPage.css';
+
+export default function ContentDetailPage() {
+  const { type, id } = useParams();
+  const [content, setContent] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await fetchContentDetails(type, id);
+        setContent(data);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [type, id]);
+
+  if (loading) {
+    return (
+      <Box p={4} textAlign="center">
+        <Spinner />
+      </Box>
+    );
+  }
+
+  if (!content) {
+    return <Box p={4}>Content not found.</Box>;
+  }
+
+  return (
+    <Box className="content-detail" p={4}>
+      <Heading mb={2}>{content.title}</Heading>
+      {content.description && <Text mb={4}>{content.description}</Text>}
+      <Button
+        as={RouterLink}
+        to={`/content-library/${type}/${id}/play`}
+        colorScheme="teal"
+      >
+        {type === 'podcast' ? 'Play Podcast' : 'Join Webinar'}
+      </Button>
+    </Box>
+  );
+}

--- a/frontend/src/pages/ContentLibraryPage.jsx
+++ b/frontend/src/pages/ContentLibraryPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Heading, Input, Select, SimpleGrid, Image, Text, Spinner } from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router-dom';
 import { fetchContentLibrary } from '../api/contentLibrary.js';
 import '../styles/ContentLibraryPage.css';
 
@@ -47,7 +48,15 @@ export default function ContentLibraryPage() {
       </Box>
       <SimpleGrid columns={[1, 2, 3]} spacing={4}>
         {items.map(item => (
-          <Box key={`${item.type}-${item.id}`} className="library-card" borderWidth="1px" borderRadius="md" p={3}>
+          <Box
+            as={RouterLink}
+            to={`/content-library/${item.type}/${item.id}`}
+            key={`${item.type}-${item.id}`}
+            className="library-card"
+            borderWidth="1px"
+            borderRadius="md"
+            p={3}
+          >
             {item.thumbnail && <Image src={item.thumbnail} alt={item.title} className="library-thumb" mb={2} />}
             <Heading size="md">{item.title}</Heading>
             {item.description && <Text fontSize="sm" mt={1}>{item.description}</Text>}

--- a/frontend/src/pages/LivePlaybackPage.jsx
+++ b/frontend/src/pages/LivePlaybackPage.jsx
@@ -1,16 +1,33 @@
-import React, { useEffect, useRef } from 'react';
-import { Box, Heading } from '@chakra-ui/react';
-import PodcastPlayer from '../components/PodcastPlayer.jsx';
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, Heading, Spinner } from '@chakra-ui/react';
+import { useParams } from 'react-router-dom';
+import { fetchContentDetails } from '../api/contentLibrary.js';
 import '../styles/LivePlaybackPage.css';
 
 export default function LivePlaybackPage() {
+  const { type, id } = useParams();
+  const [content, setContent] = useState(null);
+  const [loading, setLoading] = useState(true);
   const jitsiRef = useRef(null);
 
   useEffect(() => {
+    async function load() {
+      try {
+        const data = await fetchContentDetails(type, id);
+        setContent(data);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [type, id]);
+
+  useEffect(() => {
+    if (type !== 'webinar' || !content?.jitsiRoom) return;
     const domain = import.meta.env.VITE_JITSI_DOMAIN;
     const load = () => {
       const api = new window.JitsiMeetExternalAPI(domain.replace(/^https?:\/\//, ''), {
-        roomName: 'WorkhouseWebinarDemo',
+        roomName: content.jitsiRoom,
         parentNode: jitsiRef.current,
       });
       return () => api.dispose();
@@ -24,13 +41,30 @@ export default function LivePlaybackPage() {
     script.async = true;
     script.onload = load;
     document.body.appendChild(script);
-  }, []);
+  }, [content, type]);
+
+  if (loading) {
+    return (
+      <Box p={4} textAlign="center">
+        <Spinner />
+      </Box>
+    );
+  }
+
+  if (!content) {
+    return <Box p={4}>Content not found.</Box>;
+  }
 
   return (
     <Box className="live-playback-page" p={4}>
-      <Heading mb={4}>Live Webinar Room</Heading>
-      <Box id="jitsi-container" ref={jitsiRef} className="jitsi-container" mb={8} />
-      <PodcastPlayer />
+      <Heading mb={4}>{content.title}</Heading>
+      {type === 'podcast' ? (
+        <audio controls src={content.audioUrl} className="audio-player" />
+      ) : content.videoUrl ? (
+        <video controls src={content.videoUrl} className="video-player" />
+      ) : (
+        <Box id="jitsi-container" ref={jitsiRef} className="jitsi-container" />
+      )}
     </Box>
   );
 }

--- a/frontend/src/styles/ContentDetailPage.css
+++ b/frontend/src/styles/ContentDetailPage.css
@@ -1,0 +1,3 @@
+.content-detail {
+  background-color: #ffffff;
+}

--- a/frontend/src/styles/LivePlaybackPage.css
+++ b/frontend/src/styles/LivePlaybackPage.css
@@ -6,3 +6,10 @@
   width: 100%;
   height: 400px;
 }
+
+.audio-player,
+.video-player {
+  width: 100%;
+  max-width: 600px;
+  margin-top: 16px;
+}


### PR DESCRIPTION
## Summary
- expose audio and video URLs for library items
- add content detail and playback pages in React
- include basic styling for playback components

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934f00e8b08320b04df264b2174f6d