### PR TITLE
Add global opportunity search page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,6 +24,7 @@ import TaskWorkflowPage from './pages/TaskWorkflowPage.jsx';
 import ExperienceDashboardPage from './pages/ExperienceDashboardPage.jsx';
 import OpportunityManagementPage from './pages/OpportunityManagementPage.jsx';
 import VolunteerTrackingPage from './pages/VolunteerTrackingPage.jsx';
+import OpportunitySearchPage from './pages/OpportunitySearchPage.jsx';
 import ClassroomPage from './pages/ClassroomPage.jsx';
 import ScheduleCalendarPage from './pages/ScheduleCalendarPage.jsx';
 import ArticlePage from './pages/ArticlePage.jsx';
@@ -153,6 +154,7 @@ export default function App() {
     { path: '/tasks/schedule', element: <TaskSchedulePage />, protected: true },
     { path: '/tasks-workflow', element: <TaskWorkflowPage />, protected: true },
     { path: '/experience', element: <ExperienceDashboardPage />, protected: true },
+    { path: '/opportunities', element: <OpportunitySearchPage />, protected: true },
     { path: '/opportunities/manage', element: <OpportunityManagementPage />, protected: true },
     { path: '/volunteer-applications', element: <VolunteerTrackingPage />, protected: true },
 

--- a/frontend/src/api/opportunities.js
+++ b/frontend/src/api/opportunities.js
@@ -5,6 +5,16 @@ export async function getOpportunityDashboard() {
   return res.data;
 }
 
+export async function listOpportunities(params = {}) {
+  const res = await apiClient.get('/opportunities', { params });
+  return res.data;
+}
+
+export async function getOpportunity(id) {
+  const res = await apiClient.get(`/opportunities/${id}`);
+  return res.data;
+}
+
 export async function createOpportunity(data) {
   const res = await apiClient.post('/opportunities', data);
   return res.data;

--- a/frontend/src/components/OpportunityDetailModal.jsx
+++ b/frontend/src/components/OpportunityDetailModal.jsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Text,
+  Stack,
+  Badge
+} from '@chakra-ui/react';
+import '../styles/OpportunityDetailModal.css';
+import { getOpportunity } from '../api/opportunities.js';
+
+export default function OpportunityDetailModal({ opportunityId, isOpen, onClose }) {
+  const [opportunity, setOpportunity] = useState(null);
+
+  useEffect(() => {
+    if (opportunityId && isOpen) {
+      getOpportunity(opportunityId)
+        .then(setOpportunity)
+        .catch((err) => console.error('Failed to load opportunity', err));
+    }
+  }, [opportunityId, isOpen]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="xl">
+      <ModalOverlay />
+      <ModalContent className="opportunity-detail-modal">
+        <ModalHeader>{opportunity?.title || 'Opportunity Details'}</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          {opportunity ? (
+            <Stack spacing={3}>
+              <Text>{opportunity.description}</Text>
+              <Badge>{opportunity.location || (opportunity.remote ? 'Remote' : 'N/A')}</Badge>
+              {opportunity.requirements && (
+                <Text fontSize="sm">Requirements: {opportunity.requirements}</Text>
+              )}
+              {typeof opportunity.compensation !== 'undefined' && (
+                <Text fontSize="sm">Compensation: {opportunity.compensation}</Text>
+              )}
+            </Stack>
+          ) : (
+            <Text>Loading...</Text>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={onClose}>Close</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/frontend/src/components/OpportunitySearchCard.jsx
+++ b/frontend/src/components/OpportunitySearchCard.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Box, Heading, Text, Badge, Button } from '@chakra-ui/react';
+import '../styles/OpportunitySearchCard.css';
+
+export default function OpportunitySearchCard({ opportunity, onSelect }) {
+  return (
+    <Box className="opportunity-search-card" borderWidth="1px" borderRadius="md" p={4} mb={4} _hover={{ boxShadow: 'md' }}>
+      <Heading size="md" mb={1}>{opportunity.title}</Heading>
+      <Text fontSize="sm" noOfLines={2} mb={2}>{opportunity.description}</Text>
+      <Badge>{opportunity.location || (opportunity.remote ? 'Remote' : 'N/A')}</Badge>
+      <Button mt={3} size="sm" colorScheme="teal" onClick={() => onSelect(opportunity.id)}>
+        View Details
+      </Button>
+    </Box>
+  );
+}

--- a/frontend/src/nav/menu.js
+++ b/frontend/src/nav/menu.js
@@ -24,6 +24,7 @@ export const menu = [
       { label: 'Gigs', path: '/gigs' },
       { label: 'Manage Gigs', path: '/gigs/manage' },
       { label: 'Discover Gigs', path: '/gigs/search' },
+      { label: 'Opportunities', path: '/opportunities' },
       { label: 'Opportunity Management', path: '/opportunities/manage' },
       { label: 'Volunteer Opportunities', path: '/volunteer/opportunities' },
       { label: 'Volunteer Tracking', path: '/volunteer-applications' },

--- a/frontend/src/pages/ExperienceDashboardPage.jsx
+++ b/frontend/src/pages/ExperienceDashboardPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Heading, SimpleGrid, Spinner, Text, VStack } from '@chakra-ui/react';
+import { Box, Heading, SimpleGrid, Spinner, Text, VStack, Button } from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router-dom';
 import StatCard from '../components/StatCard.jsx';
 import '../styles/ExperienceDashboardPage.css';
 import { fetchExperienceDashboard } from '../api/experience.js';
@@ -29,6 +30,9 @@ export default function ExperienceDashboardPage() {
     <Box className="experience-dashboard-page" p={4}>
       <VStack spacing={6} align="stretch">
         <Heading size="lg">Experience Dashboard</Heading>
+        <Button as={RouterLink} to="/opportunities" colorScheme="teal" alignSelf="flex-start">
+          Find Opportunities
+        </Button>
         <SimpleGrid columns={[1, 2, 3]} spacing={4}>
           {Object.entries(data.quickStats).map(([label, value]) => (
             <StatCard key={label} label={label} value={value} />

--- a/frontend/src/pages/OpportunitySearchPage.jsx
+++ b/frontend/src/pages/OpportunitySearchPage.jsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Heading,
+  Input,
+  Button,
+  VStack,
+  SimpleGrid,
+  useDisclosure,
+  Text
+} from '@chakra-ui/react';
+import OpportunitySearchCard from '../components/OpportunitySearchCard.jsx';
+import OpportunityDetailModal from '../components/OpportunityDetailModal.jsx';
+import { listOpportunities } from '../api/opportunities.js';
+import '../styles/OpportunitySearchPage.css';
+
+export default function OpportunitySearchPage() {
+  const [keyword, setKeyword] = useState('');
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [selectedId, setSelectedId] = useState(null);
+
+  async function handleSearch() {
+    try {
+      setLoading(true);
+      const data = await listOpportunities({ keyword });
+      setResults(data.opportunities || []);
+    } catch (err) {
+      console.error('Search failed', err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleSelect(id) {
+    setSelectedId(id);
+    onOpen();
+  }
+
+  return (
+    <Box className="opportunity-search-page" p={4}>
+      <Heading mb={4}>Search Opportunities</Heading>
+      <VStack spacing={4} align="stretch" mb={6}>
+        <Input
+          placeholder="Search by keyword"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+        />
+        <Button colorScheme="teal" onClick={handleSearch} isLoading={loading}>
+          Search
+        </Button>
+      </VStack>
+      {results.length === 0 ? (
+        <Text>No opportunities found.</Text>
+      ) : (
+        <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
+          {results.map((op) => (
+            <OpportunitySearchCard key={op.id} opportunity={op} onSelect={handleSelect} />
+          ))}
+        </SimpleGrid>
+      )}
+      <OpportunityDetailModal
+        opportunityId={selectedId}
+        isOpen={isOpen}
+        onClose={onClose}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/styles/OpportunityDetailModal.css
+++ b/frontend/src/styles/OpportunityDetailModal.css
@@ -1,0 +1,4 @@
+.opportunity-detail-modal {
+  max-height: 80vh;
+  overflow-y: auto;
+}

--- a/frontend/src/styles/OpportunitySearchCard.css
+++ b/frontend/src/styles/OpportunitySearchCard.css
@@ -1,0 +1,7 @@
+.opportunity-search-card {
+  transition: background-color 0.2s ease;
+}
+
+.opportunity-search-card:hover {
+  background-color: #f7fafc;
+}

--- a/frontend/src/styles/OpportunitySearchPage.css
+++ b/frontend/src/styles/OpportunitySearchPage.css
@@ -1,0 +1,4 @@
+.opportunity-search-page {
+  max-width: 800px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- add API helpers for listing and retrieving opportunities
- build Opportunity Search page with detail modal
- integrate page into nav menu and experience dashboard

## Testing
- `npm test` (frontend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68934f9ce06c83208d6f79d19e2a8c89