### PR TITLE
feat: startup profile management and network search

### DIFF
--- a/backend/models/connection.js
+++ b/backend/models/connection.js
@@ -3,7 +3,7 @@ const { randomUUID } = require('crypto');
 // In-memory storage for connections
 const connections = new Map();
 
-function createConnection({ ownerId, name, role, company = '', status = 'active', notes = '' }) {
+function createConnection({ ownerId, name, role = '', company = '', status = 'active', notes = '', tags = [] }) {
   const id = randomUUID();
   const now = new Date();
   const connection = {
@@ -14,6 +14,7 @@ function createConnection({ ownerId, name, role, company = '', status = 'active'
     company,
     status,
     notes,
+    tags,
     lastInteraction: now,
     createdAt: now,
     updatedAt: now,
@@ -23,7 +24,7 @@ function createConnection({ ownerId, name, role, company = '', status = 'active'
 }
 
 function listConnectionsByOwner(ownerId) {
-  return Array.from(connections.values()).filter(c => c.ownerId === ownerId);
+  return Array.from(connections.values()).filter((c) => c.ownerId === ownerId);
 }
 
 function getConnection(id) {
@@ -48,41 +49,5 @@ module.exports = {
   getConnection,
   updateConnection,
   removeConnection,
-};
-// In-memory storage for user connections
-const connections = [];
-
-function addConnection(userId, { name = '', title = '', tags = [], status = 'new' }) {
-  const connection = {
-    id: randomUUID(),
-    userId,
-    name,
-    title,
-    tags,
-    status,
-    activity: [],
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  };
-  connections.push(connection);
-  return connection;
-}
-
-function getConnectionsByUser(userId) {
-  return connections.filter((c) => c.userId === userId);
-}
-
-function updateConnection(id, updates) {
-  const connection = connections.find((c) => c.id === id);
-  if (!connection) return null;
-  Object.assign(connection, updates, { updatedAt: new Date() });
-  return connection;
-}
-
-module.exports = {
-  connections,
-  addConnection,
-  getConnectionsByUser,
-  updateConnection,
 };
 

--- a/backend/models/startupProfile.js
+++ b/backend/models/startupProfile.js
@@ -3,11 +3,23 @@ const { randomUUID } = require('crypto');
 const startupProfiles = [];
 
 function upsertStartupProfile(userId, data) {
-  let profile = startupProfiles.find(p => p.userId === userId);
+  let profile = startupProfiles.find((p) => p.userId === userId);
   if (!profile) {
     profile = {
       id: randomUUID(),
       userId,
+      businessName: '',
+      tagline: '',
+      category: '',
+      location: '',
+      goals: '',
+      logoUrl: '',
+      pitchDeckUrl: '',
+      introVideoUrl: '',
+      fundingLinks: [],
+      mentorshipNeeds: '',
+      businessPlanUrl: '',
+      planVisibility: 'public',
       planDownloads: 0,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -19,7 +31,7 @@ function upsertStartupProfile(userId, data) {
 }
 
 function getStartupProfile(userId) {
-  return startupProfiles.find(p => p.userId === userId) || null;
+  return startupProfiles.find((p) => p.userId === userId) || null;
 }
 
 module.exports = {

--- a/backend/routes/connections.js
+++ b/backend/routes/connections.js
@@ -15,11 +15,5 @@ router.get('/', auth, listConnectionsHandler);
 router.get('/:connectionId', auth, getConnectionHandler);
 router.put('/:connectionId', auth, updateConnectionHandler);
 router.delete('/:connectionId', auth, deleteConnectionHandler);
-const router = express.Router();
-const connectionController = require('../controllers/connectionController');
-
-router.get('/user/:userId', connectionController.getConnections);
-router.post('/user/:userId', connectionController.addConnection);
-router.put('/:id', connectionController.updateConnection);
 
 module.exports = router;

--- a/backend/validation/connection.js
+++ b/backend/validation/connection.js
@@ -2,18 +2,20 @@ const Joi = require('joi');
 
 const createConnectionSchema = Joi.object({
   name: Joi.string().min(2).max(100).required(),
-  role: Joi.string().max(100).required(),
+  role: Joi.string().max(100).default('contact'),
   company: Joi.string().max(100).allow('', null).default(''),
   status: Joi.string()
     .valid('active', 'pending', 'reengage', 'archived')
     .default('active'),
   notes: Joi.string().allow('').default(''),
+  tags: Joi.array().items(Joi.string().trim()).default([]),
 });
 
 const updateConnectionSchema = Joi.object({
   status: Joi.string().valid('active', 'pending', 'reengage', 'archived'),
   notes: Joi.string().allow(''),
   lastInteraction: Joi.date(),
+  tags: Joi.array().items(Joi.string().trim()),
 });
 
 module.exports = { createConnectionSchema, updateConnectionSchema };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,8 @@ import SignupPage from './pages/SignupPage.jsx';
 import ProfilePage from './pages/ProfilePage.jsx';
 import ProfileCustomizationPage from './pages/ProfileCustomizationPage.jsx';
 import ConnectionManagementPage from './pages/ConnectionManagementPage.jsx';
+import SearchConnectionPage from './pages/SearchConnectionPage.jsx';
+import StartupProfilePlanPage from './pages/StartupProfilePlanPage.jsx';
 import NotificationSettingsPage from './pages/NotificationSettingsPage.jsx';
 import OrderManagementPage from './pages/OrderManagementPage.jsx';
 import ServiceCreationPage from './pages/ServiceCreationPage.jsx';
@@ -184,7 +186,8 @@ export default function App() {
     { path: '/analytics', element: <AnalyticsAuditPage />, protected: true },
 
     // Startup Ecosystem
-    { path: '/startups/profile-plan', element: <PlaceholderPage title="Startup Profile & Plan" />, protected: true },
+    { path: '/startups/profile-plan', element: <StartupProfilePlanPage />, protected: true },
+    { path: '/startups/search', element: <SearchConnectionPage />, protected: true },
 
     // Workspace & Projects
     { path: '/workspace', element: <WorkspaceDashboard />, protected: true },

--- a/frontend/src/api/connections.js
+++ b/frontend/src/api/connections.js
@@ -1,12 +1,12 @@
 import apiClient from '../utils/apiClient.js';
 
-export async function getConnections(userId) {
-  const { data } = await apiClient.get(`/connections/user/${userId}`);
+export async function getConnections() {
+  const { data } = await apiClient.get('/connections');
   return data;
 }
 
-export async function addConnection(userId, connection) {
-  const { data } = await apiClient.post(`/connections/user/${userId}`, connection);
+export async function addConnection(connection) {
+  const { data } = await apiClient.post('/connections', connection);
   return data;
 }
 

--- a/frontend/src/api/startups.js
+++ b/frontend/src/api/startups.js
@@ -1,0 +1,13 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function getStartupProfile() {
+  const { data } = await apiClient.get('/startups/profile');
+  return data;
+}
+
+export async function updateStartupProfile(profile) {
+  const { data } = await apiClient.put('/startups/profile', profile);
+  return data;
+}
+
+export default { getStartupProfile, updateStartupProfile };

--- a/frontend/src/nav/menu.js
+++ b/frontend/src/nav/menu.js
@@ -55,6 +55,7 @@ export const menu = [
       { label: 'Content Library', path: '/content-library' },
       { label: 'Stats', path: '/stats' },
       { label: 'Startup Profile', path: '/startups/profile-plan' },
+      { label: 'Startup Search', path: '/startups/search' },
       { label: 'Financial & Media Setup', path: '/setup/financial-media' },
       { label: 'Onboarding Documents', path: '/onboarding/documents' }
     ]

--- a/frontend/src/pages/ConnectionManagementPage.jsx
+++ b/frontend/src/pages/ConnectionManagementPage.jsx
@@ -15,20 +15,19 @@ import '../styles/ConnectionManagementPage.css';
 
 export default function ConnectionManagementPage() {
   const [connections, setConnections] = useState([]);
-  const [form, setForm] = useState({ name: '', title: '', tags: '' });
-  const userId = localStorage.getItem('userId') || 'default-user';
+  const [form, setForm] = useState({ name: '', role: '', tags: '' });
 
   useEffect(() => {
     async function fetchConnections() {
       try {
-        const data = await getConnections(userId);
+        const data = await getConnections();
         setConnections(data);
       } catch (err) {
         console.error('Failed to load connections', err);
       }
     }
     fetchConnections();
-  }, [userId]);
+  }, []);
 
   const handleAdd = async () => {
     if (!form.name) return;
@@ -37,13 +36,13 @@ export default function ConnectionManagementPage() {
         .split(',')
         .map((t) => t.trim())
         .filter((t) => t);
-      const newConn = await addConnection(userId, {
+      const newConn = await addConnection({
         name: form.name,
-        title: form.title,
+        role: form.role,
         tags,
       });
       setConnections((prev) => [...prev, newConn]);
-      setForm({ name: '', title: '', tags: '' });
+      setForm({ name: '', role: '', tags: '' });
     } catch (err) {
       console.error('Failed to add connection', err);
     }
@@ -69,9 +68,9 @@ export default function ConnectionManagementPage() {
           mr={2}
         />
         <Input
-          placeholder="Title"
-          value={form.title}
-          onChange={(e) => setForm({ ...form, title: e.target.value })}
+          placeholder="Role"
+          value={form.role}
+          onChange={(e) => setForm({ ...form, role: e.target.value })}
           mr={2}
         />
         <Input
@@ -90,7 +89,7 @@ export default function ConnectionManagementPage() {
             <Flex justify="space-between" align="center">
               <Box>
                 <Heading size="sm">{conn.name}</Heading>
-                <Text fontSize="sm">{conn.title}</Text>
+                <Text fontSize="sm">{conn.role}</Text>
                 <Flex mt={2} wrap="wrap">
                   {conn.tags &&
                     conn.tags.map((tag) => (

--- a/frontend/src/pages/StartupProfilePlanPage.jsx
+++ b/frontend/src/pages/StartupProfilePlanPage.jsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Heading,
+  Input,
+  Select,
+  Stack,
+  Textarea,
+  useToast,
+} from '@chakra-ui/react';
+import { getStartupProfile, updateStartupProfile } from '../api/startups.js';
+import '../styles/StartupProfilePlanPage.css';
+
+export default function StartupProfilePlanPage() {
+  const [profile, setProfile] = useState({
+    businessName: '',
+    tagline: '',
+    category: '',
+    location: '',
+    goals: '',
+    logoUrl: '',
+    pitchDeckUrl: '',
+    introVideoUrl: '',
+    fundingLinks: '',
+    mentorshipNeeds: '',
+    businessPlanUrl: '',
+    planVisibility: 'public',
+  });
+  const toast = useToast();
+
+  useEffect(() => {
+    async function loadProfile() {
+      try {
+        const data = await getStartupProfile();
+        if (data) {
+          setProfile({
+            ...data,
+            fundingLinks: (data.fundingLinks || []).join(','),
+          });
+        }
+      } catch (err) {
+        console.error('Failed to load profile', err);
+      }
+    }
+    loadProfile();
+  }, []);
+
+  const handleChange = (e) => {
+    setProfile({ ...profile, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async () => {
+    try {
+      const payload = {
+        ...profile,
+        fundingLinks: profile.fundingLinks
+          .split(',')
+          .map((l) => l.trim())
+          .filter((l) => l),
+      };
+      await updateStartupProfile(payload);
+      toast({ title: 'Profile saved', status: 'success' });
+    } catch (err) {
+      console.error('Failed to save profile', err);
+      toast({ title: 'Save failed', status: 'error' });
+    }
+  };
+
+  return (
+    <Box className="startup-profile-page" p={4}>
+      <Heading mb={6}>Startup Profile & Plan</Heading>
+      <Stack spacing={4}>
+        <FormControl>
+          <FormLabel>Business Name</FormLabel>
+          <Input name="businessName" value={profile.businessName} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Tagline</FormLabel>
+          <Input name="tagline" value={profile.tagline} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Category</FormLabel>
+          <Input name="category" value={profile.category} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Location</FormLabel>
+          <Input name="location" value={profile.location} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Business Goals</FormLabel>
+          <Textarea name="goals" value={profile.goals} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Logo URL</FormLabel>
+          <Input name="logoUrl" value={profile.logoUrl} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Pitch Deck URL</FormLabel>
+          <Input name="pitchDeckUrl" value={profile.pitchDeckUrl} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Intro Video URL</FormLabel>
+          <Input name="introVideoUrl" value={profile.introVideoUrl} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>External Funding Links (comma separated)</FormLabel>
+          <Input name="fundingLinks" value={profile.fundingLinks} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Mentorship Needs</FormLabel>
+          <Textarea name="mentorshipNeeds" value={profile.mentorshipNeeds} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Business Plan URL</FormLabel>
+          <Input name="businessPlanUrl" value={profile.businessPlanUrl} onChange={handleChange} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Plan Visibility</FormLabel>
+          <Select name="planVisibility" value={profile.planVisibility} onChange={handleChange}>
+            <option value="public">Public</option>
+            <option value="private">Private</option>
+            <option value="invite">Invite-Only</option>
+          </Select>
+        </FormControl>
+        <Button alignSelf="flex-start" colorScheme="teal" onClick={handleSubmit}>
+          Save Profile
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/src/styles/StartupProfilePlanPage.css
+++ b/frontend/src/styles/StartupProfilePlanPage.css
@@ -1,0 +1,4 @@
+.startup-profile-page {
+  max-width: 800px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- add full startup profile & business plan management page with API
- secure connection routes with tag support and auth-based frontend
- expose startup search & connect in router and navigation

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689359408e1c8320a1da776fd007f6e3