### PR TITLE
feat: add task and workflow management page

### DIFF
--- a/frontend/components/ProjectCard.jsx
+++ b/frontend/components/ProjectCard.jsx
@@ -1,4 +1,5 @@
-import { Box, Heading, Text, Badge, VStack } from '@chakra-ui/react';
+import { Box, Heading, Text, Badge, VStack, Link as ChakraLink } from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router-dom';
 import '../styles/ProjectCard.css';
 
 export default function ProjectCard({ project }) {
@@ -7,14 +8,20 @@ export default function ProjectCard({ project }) {
   const budget = project.budget || { allocatedBudget: 0, totalSpent: 0, remainingBudget: 0 };
 
   return (
-    <Box borderWidth="1px" borderRadius="lg" p={4} className="project-card">
-      <Heading size="md" mb={2}>{project.name}</Heading>
-      <Text mb={2}>{project.description}</Text>
-      <VStack align="start" spacing={1}>
-        <Badge colorScheme="purple">Tasks: {tasksCount}</Badge>
-        <Badge colorScheme="green">Team: {teamCount}</Badge>
-        <Badge colorScheme="blue">Budget: ${budget.totalSpent}/{budget.allocatedBudget}</Badge>
-      </VStack>
-    </Box>
+    <ChakraLink
+      as={RouterLink}
+      to={`/tasks-workflow?projectId=${project.id}`}
+      _hover={{ textDecoration: 'none' }}
+    >
+      <Box borderWidth="1px" borderRadius="lg" p={4} className="project-card">
+        <Heading size="md" mb={2}>{project.name}</Heading>
+        <Text mb={2}>{project.description}</Text>
+        <VStack align="start" spacing={1}>
+          <Badge colorScheme="purple">Tasks: {tasksCount}</Badge>
+          <Badge colorScheme="green">Team: {teamCount}</Badge>
+          <Badge colorScheme="blue">Budget: ${budget.totalSpent}/{budget.allocatedBudget}</Badge>
+        </VStack>
+      </Box>
+    </ChakraLink>
   );
 }

--- a/frontend/src/components/TaskFilters.jsx
+++ b/frontend/src/components/TaskFilters.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { HStack, FormControl, FormLabel, Select } from '@chakra-ui/react';
+import '../styles/TaskFilters.css';
+
+function TaskFilters({ filters, onChange, team }) {
+  const handleChange = (field) => (e) => {
+    onChange({ ...filters, [field]: e.target.value });
+  };
+
+  return (
+    <HStack spacing={4} className="task-filters">
+      <FormControl w="200px">
+        <FormLabel>Status</FormLabel>
+        <Select value={filters.status} onChange={handleChange('status')}>
+          <option value="">All</option>
+          <option value="pending">Pending</option>
+          <option value="in-progress">In Progress</option>
+          <option value="completed">Completed</option>
+        </Select>
+      </FormControl>
+      <FormControl w="200px">
+        <FormLabel>Assignee</FormLabel>
+        <Select value={filters.assignee} onChange={handleChange('assignee')}>
+          <option value="">All</option>
+          {team.map((member) => (
+            <option key={member.userId} value={member.userId}>
+              {member.userId}
+            </option>
+          ))}
+        </Select>
+      </FormControl>
+    </HStack>
+  );
+}
+
+export default TaskFilters;

--- a/frontend/src/components/TaskForm.jsx
+++ b/frontend/src/components/TaskForm.jsx
@@ -1,23 +1,29 @@
 import React, { useState, useEffect } from 'react';
-import { Box, FormControl, FormLabel, Input, Textarea, Button } from '@chakra-ui/react';
+import { Box, FormControl, FormLabel, Input, Textarea, Button, Select } from '@chakra-ui/react';
 import { useTasks } from '../context/TaskContext.jsx';
 import '../styles/TaskForm.css';
 
-function TaskForm({ projectId, setProjectId, editingTask, onUpdate }) {
-  const { addTask } = useTasks();
+function TaskForm({ projectId, setProjectId, editingTask, onUpdate, team }) {
+  const { addTask, editTask, assign } = useTasks();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [dueDate, setDueDate] = useState('');
+  const [status, setStatus] = useState('pending');
+  const [assignee, setAssignee] = useState('');
 
   useEffect(() => {
     if (editingTask) {
       setTitle(editingTask.title);
       setDescription(editingTask.description || '');
-      setDueDate(editingTask.dueDate ? editingTask.dueDate.substring(0,10) : '');
+      setDueDate(editingTask.dueDate ? editingTask.dueDate.substring(0, 10) : '');
+      setStatus(editingTask.status || 'pending');
+      setAssignee(editingTask.assignee || '');
     } else {
       setTitle('');
       setDescription('');
       setDueDate('');
+      setStatus('pending');
+      setAssignee('');
     }
   }, [editingTask]);
 
@@ -25,9 +31,12 @@ function TaskForm({ projectId, setProjectId, editingTask, onUpdate }) {
     e.preventDefault();
     if (!projectId) return;
     if (editingTask) {
-      await onUpdate({ title, description, dueDate });
+      await onUpdate({ title, description, dueDate, status });
+      if (assignee) await assign(editingTask.id, assignee);
     } else {
-      await addTask({ projectId, title, description, dueDate });
+      const created = await addTask({ projectId, title, description, dueDate });
+      if (assignee) await assign(created.id, assignee);
+      if (status !== 'pending') await editTask(created.id, { status });
     }
   };
 
@@ -48,6 +57,24 @@ function TaskForm({ projectId, setProjectId, editingTask, onUpdate }) {
       <FormControl mb={3}>
         <FormLabel>Due Date</FormLabel>
         <Input type="date" value={dueDate} onChange={(e) => setDueDate(e.target.value)} />
+      </FormControl>
+      <FormControl mb={3}>
+        <FormLabel>Status</FormLabel>
+        <Select value={status} onChange={(e) => setStatus(e.target.value)}>
+          <option value="pending">Pending</option>
+          <option value="in-progress">In Progress</option>
+          <option value="completed">Completed</option>
+        </Select>
+      </FormControl>
+      <FormControl mb={3}>
+        <FormLabel>Assignee</FormLabel>
+        <Select placeholder="Select assignee" value={assignee} onChange={(e) => setAssignee(e.target.value)}>
+          {team.map((member) => (
+            <option key={member.userId} value={member.userId}>
+              {member.userId}
+            </option>
+          ))}
+        </Select>
       </FormControl>
       <Button type="submit" colorScheme="teal">
         {editingTask ? 'Update Task' : 'Create Task'}

--- a/frontend/src/components/TaskList.jsx
+++ b/frontend/src/components/TaskList.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
-import { Table, Thead, Tbody, Tr, Th, Td, Button } from '@chakra-ui/react';
+import { Table, Thead, Tbody, Tr, Th, Td, Button, Badge } from '@chakra-ui/react';
 import { useTasks } from '../context/TaskContext.jsx';
 import '../styles/TaskList.css';
+
+const statusColor = {
+  'pending': 'gray',
+  'in-progress': 'yellow',
+  'completed': 'green'
+};
 
 function TaskList({ onEdit }) {
   const { tasks, removeTask } = useTasks();
@@ -12,6 +18,7 @@ function TaskList({ onEdit }) {
         <Tr>
           <Th>Title</Th>
           <Th>Status</Th>
+          <Th>Assignee</Th>
           <Th>Due Date</Th>
           <Th>Actions</Th>
         </Tr>
@@ -20,7 +27,10 @@ function TaskList({ onEdit }) {
         {tasks.map((task) => (
           <Tr key={task.id}>
             <Td>{task.title}</Td>
-            <Td>{task.status}</Td>
+            <Td>
+              <Badge colorScheme={statusColor[task.status] || 'gray'}>{task.status}</Badge>
+            </Td>
+            <Td>{task.assignee || '-'}</Td>
             <Td>{task.dueDate ? new Date(task.dueDate).toLocaleDateString() : '-'}</Td>
             <Td>
               <Button size="xs" mr={2} onClick={() => onEdit(task)}>Edit</Button>

--- a/frontend/src/components/WorkloadSummary.jsx
+++ b/frontend/src/components/WorkloadSummary.jsx
@@ -1,0 +1,33 @@
+import React, { useMemo } from 'react';
+import { Box, Heading, VStack, Text, Progress } from '@chakra-ui/react';
+import '../styles/WorkloadSummary.css';
+
+function WorkloadSummary({ tasks, team }) {
+  const data = useMemo(() => {
+    if (!team.length) return [];
+    const counts = team.map((member) => ({
+      userId: member.userId,
+      count: tasks.filter((t) => t.assignee === member.userId).length,
+    }));
+    const max = Math.max(1, ...counts.map((c) => c.count));
+    return counts.map((c) => ({ ...c, percent: (c.count / max) * 100 }));
+  }, [tasks, team]);
+
+  if (!data.length) return null;
+
+  return (
+    <Box className="workload-summary" mt={6}>
+      <Heading size="md" mb={3}>Workload Summary</Heading>
+      <VStack spacing={2} align="stretch">
+        {data.map((item) => (
+          <Box key={item.userId}>
+            <Text fontSize="sm" mb={1}>{item.userId} ({item.count} tasks)</Text>
+            <Progress value={item.percent} size="sm" colorScheme="blue" borderRadius="md" />
+          </Box>
+        ))}
+      </VStack>
+    </Box>
+  );
+}
+
+export default WorkloadSummary;

--- a/frontend/src/context/TaskContext.jsx
+++ b/frontend/src/context/TaskContext.jsx
@@ -1,20 +1,21 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
-import { listTasks, createTask, updateTask, deleteTask } from '../api/tasks.js';
+import { listTasks, createTask, updateTask, deleteTask, assignTask as apiAssignTask } from '../api/tasks.js';
 
 const TaskContext = createContext();
 
 export function TaskProvider({ children }) {
   const [tasks, setTasks] = useState([]);
 
-  const fetchTasks = useCallback(async (projectId) => {
+  const fetchTasks = useCallback(async (projectId, params = {}) => {
     if (!projectId) return;
-    const data = await listTasks(projectId);
+    const data = await listTasks(projectId, params);
     setTasks(data);
   }, []);
 
   const addTask = async (task) => {
     const created = await createTask(task);
     setTasks((prev) => [...prev, created]);
+    return created;
   };
 
   const editTask = async (taskId, updates) => {
@@ -27,8 +28,14 @@ export function TaskProvider({ children }) {
     setTasks((prev) => prev.filter((t) => t.id !== taskId));
   };
 
+  const assign = async (taskId, assignee) => {
+    const updated = await apiAssignTask({ taskId, assignee });
+    setTasks((prev) => prev.map((t) => (t.id === taskId ? updated : t)));
+    return updated;
+  };
+
   return (
-    <TaskContext.Provider value={{ tasks, fetchTasks, addTask, editTask, removeTask }}>
+    <TaskContext.Provider value={{ tasks, fetchTasks, addTask, editTask, removeTask, assign }}>
       {children}
     </TaskContext.Provider>
   );

--- a/frontend/src/pages/TaskWorkflowPage.jsx
+++ b/frontend/src/pages/TaskWorkflowPage.jsx
@@ -1,27 +1,42 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Heading, Divider } from '@chakra-ui/react';
+import { useSearchParams } from 'react-router-dom';
 import { useTasks } from '../context/TaskContext.jsx';
 import TaskForm from '../components/TaskForm.jsx';
 import TaskList from '../components/TaskList.jsx';
 import WorkflowForm from '../components/WorkflowForm.jsx';
 import WorkflowList from '../components/WorkflowList.jsx';
+import TaskFilters from '../components/TaskFilters.jsx';
+import WorkloadSummary from '../components/WorkloadSummary.jsx';
 import { listWorkflows } from '../api/workflows.js';
+import { fetchProjectTeam } from '../../api/workspace.js';
 import '../styles/TaskWorkflowPage.css';
 
 function TaskWorkflowPage() {
+  const [searchParams] = useSearchParams();
   const [projectId, setProjectId] = useState('');
   const [editingTask, setEditingTask] = useState(null);
   const [workflows, setWorkflows] = useState([]);
-  const { fetchTasks, editTask } = useTasks();
+  const [team, setTeam] = useState([]);
+  const [filters, setFilters] = useState({ status: '', assignee: '' });
+  const { fetchTasks, editTask, tasks } = useTasks();
+
+  useEffect(() => {
+    const pid = searchParams.get('projectId');
+    if (pid) setProjectId(pid);
+  }, [searchParams]);
 
   useEffect(() => {
     if (projectId) {
-      fetchTasks(projectId);
+      fetchTasks(projectId, filters);
+      fetchProjectTeam(projectId).then(setTeam).catch((err) => {
+        console.error('Failed to load team', err);
+      });
       listWorkflows(projectId).then(setWorkflows).catch((err) => {
         console.error('Failed to load workflows', err);
       });
     }
-  }, [projectId, fetchTasks]);
+  }, [projectId, filters, fetchTasks]);
 
   const handleEdit = (task) => setEditingTask(task);
 
@@ -47,8 +62,11 @@ function TaskWorkflowPage() {
         setProjectId={setProjectId}
         editingTask={editingTask}
         onUpdate={handleUpdate}
+        team={team}
       />
+      <TaskFilters filters={filters} onChange={setFilters} team={team} />
       <TaskList onEdit={handleEdit} />
+      <WorkloadSummary tasks={tasks} team={team} />
       <Divider my={6} />
       <Heading size="md" mb={2}>Workflows</Heading>
       <WorkflowForm projectId={projectId} onCreated={reloadWorkflows} />

--- a/frontend/src/styles/TaskFilters.css
+++ b/frontend/src/styles/TaskFilters.css
@@ -1,0 +1,3 @@
+.task-filters {
+  margin-bottom: 1rem;
+}

--- a/frontend/src/styles/WorkloadSummary.css
+++ b/frontend/src/styles/WorkloadSummary.css
@@ -1,0 +1,5 @@
+.workload-summary {
+  background-color: #f7fafc;
+  padding: 1rem;
+  border-radius: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- build task & workflow management page with project-based filtering
- enable task assignment, status updates, and workload overview
- link workspace projects directly to task workflows

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68935974b198832085b922829a8ff091