### PR TITLE
Add analytics and blog pages

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -52,6 +52,8 @@ import OnboardingDocumentsPage from './pages/OnboardingDocumentsPage.jsx';
 import ChatInboxPage from './pages/ChatInboxPage.jsx';
 import JobListingsPage from './pages/JobListingsPage.jsx';
 import FreelanceDashboardPage from './pages/FreelanceDashboardPage.jsx';
+import StatsAnalyticsPage from './pages/StatsAnalyticsPage.jsx';
+import BlogHomePage from './pages/BlogHomePage.jsx';
 
 import DashboardPage from './pages/DashboardPage.jsx';
 import LiveFeedPage from './pages/LiveFeedPage.jsx';
@@ -196,8 +198,8 @@ export default function App() {
     // Settings, Billing & Analytics
     { path: '/notifications', element: <NotificationSettingsPage />, protected: true },
     { path: '/settings', element: <SettingsPage />, protected: true },
-    { path: '/stats', element: <PlaceholderPage title="Stats & Analytics" />, protected: true },
-    { path: '/blog', element: <PlaceholderPage title="Blog Homepage" />, protected: true },
+    { path: '/stats', element: <StatsAnalyticsPage />, protected: true },
+    { path: '/blog', element: <BlogHomePage />, protected: true },
     { path: '/articles', element: <ArticlePage /> },
     { path: '/articles/:articleId', element: <ArticlePage /> },
 

--- a/frontend/src/api/blog.js
+++ b/frontend/src/api/blog.js
@@ -1,0 +1,12 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function fetchCategories() {
+  const { data } = await apiClient.get('/blog/categories');
+  return data;
+}
+
+export async function fetchPosts(category) {
+  const config = category ? { params: { category } } : undefined;
+  const { data } = await apiClient.get('/blog/posts', config);
+  return data;
+}

--- a/frontend/src/api/stats.js
+++ b/frontend/src/api/stats.js
@@ -1,0 +1,6 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function fetchStatsOverview() {
+  const { data } = await apiClient.get('/stats/overview');
+  return data;
+}

--- a/frontend/src/pages/BlogHomePage.jsx
+++ b/frontend/src/pages/BlogHomePage.jsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  Text,
+  Image,
+  Spinner,
+  Stack,
+  Tabs,
+  TabList,
+  Tab,
+  TabPanels,
+  TabPanel,
+  useToast
+} from '@chakra-ui/react';
+import { fetchCategories, fetchPosts } from '../api/blog.js';
+import '../styles/BlogHomePage.css';
+
+export default function BlogHomePage() {
+  const [categories, setCategories] = useState([]);
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [tabIndex, setTabIndex] = useState(0);
+  const toast = useToast();
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const cats = await fetchCategories();
+        setCategories(cats);
+        const initialPosts = await fetchPosts();
+        setPosts(initialPosts);
+      } catch (err) {
+        toast({ title: 'Failed to load blog', status: 'error' });
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [toast]);
+
+  async function handleTabChange(index) {
+    setTabIndex(index);
+    setLoading(true);
+    try {
+      const category = index === 0 ? undefined : categories[index - 1].name;
+      const data = await fetchPosts(category);
+      setPosts(data);
+    } catch {
+      toast({ title: 'Failed to load posts', status: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const postsList = (
+    <Stack spacing={4} mt={4}>
+      {posts.map((post) => (
+        <Box key={post.id} p={4} borderWidth="1px" borderRadius="md" className="post-card">
+          {post.image && <Image src={post.image} alt={post.title} className="post-image" mb={2} />}
+          <Heading size="md" mb={1}>{post.title}</Heading>
+          <Text fontSize="sm" color="gray.600" mb={2}>{new Date(post.createdAt).toLocaleDateString()}</Text>
+          <Text>{post.excerpt}</Text>
+        </Box>
+      ))}
+      {posts.length === 0 && !loading && <Text>No posts found.</Text>}
+    </Stack>
+  );
+
+  return (
+    <Box className="blog-home-page" p={4}>
+      <Heading mb={4}>Blog</Heading>
+      {categories.length > 0 && (
+        <Tabs
+          variant="enclosed"
+          index={tabIndex}
+          onChange={handleTabChange}
+        >
+          <TabList overflowX="auto">
+            <Tab>All</Tab>
+            {categories.map((c) => (
+              <Tab key={c.name}>{c.name} ({c.count})</Tab>
+            ))}
+          </TabList>
+          <TabPanels>
+            {[null, ...categories].map((c, idx) => (
+              <TabPanel key={idx} p={0}>
+                {loading && tabIndex === idx ? <Spinner /> : postsList}
+              </TabPanel>
+            ))}
+          </TabPanels>
+        </Tabs>
+      )}
+      {categories.length === 0 && (loading ? <Spinner /> : postsList)}
+    </Box>
+  );
+}

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -49,6 +49,12 @@ export default function DashboardPage() {
       <Button mb={4} colorScheme="teal" onClick={() => navigate('/service-orders')}>
         Manage Service Orders
       </Button>
+      <Button mb={4} colorScheme="blue" onClick={() => navigate('/stats')}>
+        View Analytics
+      </Button>
+      <Button mb={4} colorScheme="orange" onClick={() => navigate('/blog')}>
+        Visit Blog
+      </Button>
       <SimpleGrid columns={[1, 3]} spacing={4}>
         {'totalSpend' in data && (
           <Stat>

--- a/frontend/src/pages/StatsAnalyticsPage.jsx
+++ b/frontend/src/pages/StatsAnalyticsPage.jsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Heading, SimpleGrid, Spinner, useToast } from '@chakra-ui/react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import StatCard from '../components/StatCard.jsx';
+import { fetchStatsOverview } from '../api/stats.js';
+import '../styles/StatsAnalyticsPage.css';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+export default function StatsAnalyticsPage() {
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const toast = useToast();
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await fetchStatsOverview();
+        setStats(data);
+      } catch (err) {
+        toast({ title: 'Failed to load statistics', status: 'error' });
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [toast]);
+
+  if (loading) return <Spinner />;
+  if (!stats) return <Box p={4}>No statistics available.</Box>;
+
+  const chartData = {
+    labels: ['Total Users', 'Active Users', 'New Signups', 'Revenue'],
+    datasets: [
+      {
+        label: 'Overview',
+        data: [stats.totalUsers, stats.activeUsers, stats.newSignups, stats.revenue],
+        borderColor: '#3182CE',
+        backgroundColor: 'rgba(49,130,206,0.2)'
+      }
+    ]
+  };
+
+  return (
+    <Box className="stats-analytics-page" p={4}>
+      <Heading mb={4}>Stats &amp; Analytics</Heading>
+      <SimpleGrid columns={[1, 2, 4]} spacing={4} mb={8}>
+        <StatCard label="Total Users" value={stats.totalUsers} />
+        <StatCard label="Active Users" value={stats.activeUsers} />
+        <StatCard label="New Signups" value={stats.newSignups} />
+        <StatCard label="Revenue" value={`$${stats.revenue}`} />
+      </SimpleGrid>
+      <Box className="chart-container">
+        <Line data={chartData} />
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/styles/BlogHomePage.css
+++ b/frontend/src/styles/BlogHomePage.css
@@ -1,0 +1,9 @@
+.blog-home-page .post-card {
+  background: #fff;
+}
+
+.blog-home-page .post-image {
+  max-height: 200px;
+  width: 100%;
+  object-fit: cover;
+}

--- a/frontend/src/styles/StatsAnalyticsPage.css
+++ b/frontend/src/styles/StatsAnalyticsPage.css
@@ -1,0 +1,4 @@
+.stats-analytics-page .chart-container {
+  max-width: 600px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- add Stats & Analytics page with chart and stat cards
- implement Blog home with category tabs and posts
- expose new API modules and hook up routes and dashboard links

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689359a7efc883208010fef34649edac