### PR TITLE
feat: enhance message notification settings

### DIFF
--- a/backend/controllers/userNotifications.js
+++ b/backend/controllers/userNotifications.js
@@ -1,4 +1,8 @@
-const { getNotificationsByUser } = require('../models/userNotifications');
+const {
+  getNotificationsByUser,
+  updateNotification,
+  deleteNotification,
+} = require('../models/userNotifications');
 const { getSettings, updateSettings } = require('../models/notificationSettings');
 const logger = require('../utils/logger');
 
@@ -32,8 +36,46 @@ async function updateSettingsHandler(req, res) {
   }
 }
 
+async function updateNotificationHandler(req, res) {
+  try {
+    const notification = updateNotification(
+      req.user.id,
+      req.params.id,
+      req.body
+    );
+    if (!notification) {
+      return res.status(404).json({ error: 'Notification not found' });
+    }
+    res.json(notification);
+  } catch (err) {
+    logger.error('Updating notification failed', {
+      error: err.message,
+      userId: req.user.id,
+    });
+    res.status(500).json({ error: 'Failed to update notification' });
+  }
+}
+
+async function deleteNotificationHandler(req, res) {
+  try {
+    const deleted = deleteNotification(req.user.id, req.params.id);
+    if (!deleted) {
+      return res.status(404).json({ error: 'Notification not found' });
+    }
+    res.json({ success: true });
+  } catch (err) {
+    logger.error('Deleting notification failed', {
+      error: err.message,
+      userId: req.user.id,
+    });
+    res.status(500).json({ error: 'Failed to delete notification' });
+  }
+}
+
 module.exports = {
   listNotifications,
   getSettingsHandler,
   updateSettingsHandler,
+   updateNotificationHandler,
+   deleteNotificationHandler,
 };

--- a/backend/models/notificationSettings.js
+++ b/backend/models/notificationSettings.js
@@ -3,7 +3,13 @@ const settingsStore = new Map();
 
 function getSettings(userId) {
   if (!settingsStore.has(userId)) {
-    settingsStore.set(userId, { email: true, sms: false, push: true });
+    settingsStore.set(userId, {
+      email: true,
+      sms: false,
+      push: true,
+      deliveryReceipts: true,
+      readReceipts: true,
+    });
   }
   return settingsStore.get(userId);
 }

--- a/backend/models/userNotifications.js
+++ b/backend/models/userNotifications.js
@@ -3,12 +3,16 @@ const { randomUUID } = require('crypto');
 // Simple in-memory store for user notifications
 const notifications = [];
 
-function addNotification({ userId, message }) {
+function addNotification({ userId, message, conversationId = null }) {
   const notification = {
     id: randomUUID(),
     userId,
+    conversationId,
     message,
     read: false,
+    archived: false,
+    muted: false,
+    starred: false,
     createdAt: new Date(),
   };
   notifications.push(notification);
@@ -29,9 +33,31 @@ function markNotificationRead(notificationId, userId) {
   return notification;
 }
 
+function updateNotification(userId, notificationId, updates) {
+  const notification = notifications.find(
+    (n) => n.id === notificationId && n.userId === userId
+  );
+  if (notification) {
+    Object.assign(notification, updates);
+  }
+  return notification;
+}
+
+function deleteNotification(userId, notificationId) {
+  const index = notifications.findIndex(
+    (n) => n.id === notificationId && n.userId === userId
+  );
+  if (index !== -1) {
+    return notifications.splice(index, 1)[0];
+  }
+  return null;
+}
+
 module.exports = {
   addNotification,
   getNotificationsByUser,
   markNotificationRead,
+  updateNotification,
+  deleteNotification,
   notifications,
 };

--- a/backend/routes/userNotifications.js
+++ b/backend/routes/userNotifications.js
@@ -4,6 +4,8 @@ const {
   listNotifications,
   getSettingsHandler,
   updateSettingsHandler,
+  updateNotificationHandler,
+  deleteNotificationHandler,
 } = require('../controllers/userNotifications');
 
 const router = express.Router();
@@ -11,5 +13,7 @@ const router = express.Router();
 router.get('/', auth, listNotifications);
 router.get('/settings', auth, getSettingsHandler);
 router.put('/settings', auth, updateSettingsHandler);
+router.patch('/:id', auth, updateNotificationHandler);
+router.delete('/:id', auth, deleteNotificationHandler);
 
 module.exports = router;

--- a/frontend/src/api/notifications.js
+++ b/frontend/src/api/notifications.js
@@ -11,3 +11,11 @@ export function fetchNotificationSettings() {
 export function updateNotificationSettings(settings) {
   return apiClient.put('/notifications/settings', settings).then(res => res.data);
 }
+
+export function updateNotification(id, updates) {
+  return apiClient.patch(`/notifications/${id}`, updates).then(res => res.data);
+}
+
+export function deleteNotification(id) {
+  return apiClient.delete(`/notifications/${id}`).then(res => res.data);
+}

--- a/frontend/src/components/MessageNotificationItem.jsx
+++ b/frontend/src/components/MessageNotificationItem.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { Flex, Text, IconButton, Tooltip } from '@chakra-ui/react';
+import {
+  StarIcon,
+  SmallCloseIcon,
+  RepeatIcon,
+  BellOffIcon,
+  DeleteIcon,
+} from '@chakra-ui/icons';
+import '../styles/MessageNotificationItem.css';
+
+export default function MessageNotificationItem({ notification, onUpdate, onDelete }) {
+  return (
+    <Flex className="message-notification-item" align="center">
+      <Text flex="1" className={notification.read ? '' : 'unread'}>
+        {notification.message}
+      </Text>
+      <div className="message-notification-actions">
+        <Tooltip label={notification.starred ? 'Unstar' : 'Star'}>
+          <IconButton
+            aria-label="star"
+            icon={<StarIcon />}
+            variant={notification.starred ? 'solid' : 'ghost'}
+            size="sm"
+            onClick={() => onUpdate({ starred: !notification.starred })}
+          />
+        </Tooltip>
+        <Tooltip label={notification.muted ? 'Unmute' : 'Mute'}>
+          <IconButton
+            aria-label="mute"
+            icon={<BellOffIcon />}
+            variant={notification.muted ? 'solid' : 'ghost'}
+            size="sm"
+            onClick={() => onUpdate({ muted: !notification.muted })}
+          />
+        </Tooltip>
+        <Tooltip label={notification.archived ? 'Unarchive' : 'Archive'}>
+          <IconButton
+            aria-label="archive"
+            icon={<SmallCloseIcon />}
+            variant={notification.archived ? 'solid' : 'ghost'}
+            size="sm"
+            onClick={() => onUpdate({ archived: !notification.archived })}
+          />
+        </Tooltip>
+        <Tooltip label={notification.read ? 'Mark as Unread' : 'Mark as Read'}>
+          <IconButton
+            aria-label="mark-read"
+            icon={<RepeatIcon />}
+            variant="ghost"
+            size="sm"
+            onClick={() => onUpdate({ read: !notification.read })}
+          />
+        </Tooltip>
+        <Tooltip label="Delete">
+          <IconButton
+            aria-label="delete"
+            icon={<DeleteIcon />}
+            variant="ghost"
+            size="sm"
+            onClick={onDelete}
+          />
+        </Tooltip>
+      </div>
+    </Flex>
+  );
+}

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -46,6 +46,9 @@ export default function DashboardPage() {
       <Button mb={4} colorScheme="teal" onClick={() => navigate('/feed')}>
         View Live Feed
       </Button>
+      <Button mb={4} colorScheme="teal" onClick={() => navigate('/notifications')}>
+        Message Notifications
+      </Button>
       <Button mb={4} colorScheme="teal" onClick={() => navigate('/service-orders')}>
         Manage Service Orders
       </Button>

--- a/frontend/src/styles/MessageNotificationItem.css
+++ b/frontend/src/styles/MessageNotificationItem.css
@@ -1,0 +1,13 @@
+.message-notification-item {
+  padding: 8px 0;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.message-notification-item .unread {
+  font-weight: 600;
+}
+
+.message-notification-actions {
+  display: flex;
+  gap: 4px;
+}

--- a/frontend/src/styles/NotificationSettingsPage.css
+++ b/frontend/src/styles/NotificationSettingsPage.css
@@ -2,8 +2,3 @@
   max-width: 600px;
   margin: 0 auto;
 }
-
-.notification-item {
-  padding: 8px 0;
-  border-bottom: 1px solid #e2e8f0;
-}


### PR DESCRIPTION
## Summary
- expand notification model for mute, archive, star, and receipt controls
- add API endpoints and UI for managing message notifications and preferences
- link notifications from dashboard and supply Chakra-based components with styles

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6893598da7008320a3a903c04a022399