### PR TITLE
feat: enhance affiliate dashboard integration

### DIFF
--- a/frontend/src/api/affiliate.js
+++ b/frontend/src/api/affiliate.js
@@ -5,6 +5,11 @@ export async function fetchAffiliate(id) {
   return res.data;
 }
 
+export async function fetchAffiliateDashboard(id) {
+  const res = await apiClient.get(`/affiliates/dashboard/${id}`);
+  return res.data;
+}
+
 export async function fetchCommissionHistory(id) {
   const res = await apiClient.get(`/commissions/${id}/history`);
   return res.data;

--- a/frontend/src/context/AffiliateContext.jsx
+++ b/frontend/src/context/AffiliateContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
 import {
-  fetchAffiliate,
+  fetchAffiliateDashboard,
   fetchCommissionHistory,
   fetchCommissionRates,
   fetchPayoutHistory,
@@ -24,8 +24,8 @@ export function AffiliateProvider({ children }) {
 
   const loadDashboard = useCallback(async () => {
     if (!user) return;
-    const [affiliate, commissions, ratesData, payoutHist, refs, comps, notes] = await Promise.all([
-      fetchAffiliate(user.id),
+    const [dashboard, commissions, ratesData, payoutHist, refs, comps, notes] = await Promise.all([
+      fetchAffiliateDashboard(user.id),
       fetchCommissionHistory(user.id),
       fetchCommissionRates(),
       fetchPayoutHistory(user.id),
@@ -33,8 +33,13 @@ export function AffiliateProvider({ children }) {
       fetchCompetitions(user.id),
       fetchNotifications(user.id),
     ]);
-    const earnings = commissions.reduce((sum, c) => sum + c.amount, 0);
-    setStats({ affiliate, commissions, earnings, referrals: refs.length });
+    const earnings = dashboard.earnings ?? commissions.reduce((sum, c) => sum + c.amount, 0);
+    setStats({
+      performance: dashboard.performance,
+      earnings,
+      referrals: dashboard.referrals ?? refs.length,
+      commissions,
+    });
     setPayouts(payoutHist);
     setRates(ratesData);
     setCompetitions(comps);

--- a/frontend/src/pages/AffiliateManagementPage.jsx
+++ b/frontend/src/pages/AffiliateManagementPage.jsx
@@ -24,7 +24,14 @@ function AffiliateManagementPage() {
   return (
     <div className="affiliate-management-page">
       <Heading mb={4}>Affiliate Dashboard</Heading>
-      <AffiliateStats stats={{ referrals: stats.referrals, earnings: stats.earnings }} />
+      <AffiliateStats
+        stats={{
+          clicks: stats.performance?.clicks,
+          referrals: stats.referrals,
+          conversions: stats.performance?.conversions,
+          earnings: stats.earnings,
+        }}
+      />
       <EarningsTracker amount={stats.earnings} />
       <PayRateSection rates={rates} />
       <PayoutSection affiliateId={user.id} payouts={payouts} onRefresh={loadDashboard} />

--- a/frontend/views/home_dashboard.js
+++ b/frontend/views/home_dashboard.js
@@ -7,11 +7,12 @@ function HomeDashboard() {
   const [affiliate, setAffiliate] = useState(null);
 
   useEffect(() => {
+    if (!user) return;
     dashboardAPI
-      .getAffiliateDashboard(1)
+      .getAffiliateDashboard(user.id)
       .then(setAffiliate)
       .catch(err => console.error('Failed to load affiliate dashboard', err));
-  }, []);
+  }, [user]);
 
   if (!user) return <p>Loading...</p>;
 


### PR DESCRIPTION
## Summary
- add API call for affiliate dashboard metrics
- populate affiliate context with performance and earnings data
- show full stats on affiliate page and dynamic home dashboard widget

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68935a0d6c448320830f77f87c459da2