### PR TITLE
feat: add admin support dispute management page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -206,7 +206,7 @@ export default function App() {
     { path: '/disputes/new', element: <DisputeFormPage />, protected: true },
     { path: '/disputes/:disputeId/respond', element: <DisputeFormPage />, protected: true },
     { path: '/disputes/:disputeId?', element: <DisputeManagementPage />, protected: true },
-    { path: '/support', element: <SupportDisputePage />, protected: true },
+    { path: '/admin/support', element: <SupportDisputePage />, admin: true },
     { path: '/admin', element: <AdminDashboard />, admin: true },
     { path: '/admin/analytics', element: <AnalyticsAuditPage />, admin: true },
     { path: '/admin/system-settings', element: <SystemSettingsEmployeeManagement />, admin: true },

--- a/frontend/src/api/disputes.js
+++ b/frontend/src/api/disputes.js
@@ -1,26 +1,25 @@
 import apiClient from '../utils/apiClient.js';
 
-export async function getDispute(disputeId) {
-  const { data } = await apiClient.get(`/disputes/${disputeId}`);
-  return data;
-}
-
-export async function postDisputeMessage(disputeId, message) {
-  const { data } = await apiClient.post(`/disputes/${disputeId}/messages`, { message });
-  return data;
-export async function createDispute(data) {
-  const { data: dispute } = await apiClient.post('/disputes/create', data);
-  return dispute;
-}
-
-export async function respondToDispute(disputeId, data) {
-  const { data: dispute } = await apiClient.post(`/disputes/${disputeId}/respond`, data);
-  return dispute;
-}
-
-export async function getDispute(disputeId) {
-  const { data: dispute } = await apiClient.get(`/disputes/${disputeId}`);
-  return dispute;
 export function listDisputes(params = {}) {
-  return apiClient.get('/disputes', { params }).then(res => res.data);
+  return apiClient.get('/admin/disputes', { params }).then(res => res.data);
+}
+
+export function getDispute(disputeId) {
+  return apiClient.get(`/disputes/${disputeId}`).then(res => res.data);
+}
+
+export function createDispute(data) {
+  return apiClient.post('/disputes/create', data).then(res => res.data);
+}
+
+export function respondToDispute(disputeId, data) {
+  return apiClient.post(`/disputes/${disputeId}/respond`, data).then(res => res.data);
+}
+
+export function resolveDispute(disputeId, data = {}) {
+  return apiClient.put(`/disputes/${disputeId}/resolve`, data).then(res => res.data);
+}
+
+export function postDisputeMessage(disputeId, message) {
+  return apiClient.post(`/disputes/${disputeId}/messages`, { message }).then(res => res.data);
 }

--- a/frontend/src/api/support.js
+++ b/frontend/src/api/support.js
@@ -1,23 +1,17 @@
-import axios from 'axios';
+import apiClient from '../utils/apiClient.js';
 
-const API_BASE = import.meta.env.VITE_API_URL || '';
-
-export async function fetchTickets() {
-  const res = await axios.get(`${API_BASE}/support/tickets`, { withCredentials: true });
-  return res.data;
+export function fetchTickets(params = {}) {
+  return apiClient.get('/admin/support/tickets', { params }).then(res => res.data);
 }
 
-export async function createTicket(data) {
-  const res = await axios.post(`${API_BASE}/support/tickets`, data, { withCredentials: true });
-  return res.data;
+export function createTicket(data) {
+  return apiClient.post('/support/tickets', data).then(res => res.data);
 }
 
-export async function resolveTicket(id) {
-  const res = await axios.put(`${API_BASE}/support/tickets/${id}/resolve`, {}, { withCredentials: true });
-  return res.data;
+export function resolveTicket(ticketId, solution) {
+  return apiClient.post('/admin/support/resolve', { ticketId, solution }).then(res => res.data);
 }
 
-export async function fetchDisputes() {
-  const res = await axios.get(`${API_BASE}/support/disputes`, { withCredentials: true });
-  return res.data;
+export function fetchDisputes(params = {}) {
+  return apiClient.get('/admin/disputes', { params }).then(res => res.data);
 }

--- a/frontend/src/nav/menu.js
+++ b/frontend/src/nav/menu.js
@@ -8,7 +8,6 @@ export const menu = [
       { label: 'Profile', path: '/profile' },
       { label: 'Customize Profile', path: '/profile/customize' },
       { label: 'Connections', path: '/connections' },
-      { label: 'Support', path: '/support' },
       { label: 'Notifications', path: '/notifications' },
       { label: 'Settings', path: '/settings' }
     ]
@@ -86,6 +85,7 @@ export const menu = [
       { label: 'Admin Dashboard', path: '/admin' },
       { label: 'Admin Analytics', path: '/admin/analytics' },
       { label: 'Admin Settings', path: '/admin/system-settings' },
+            { label: 'Support & Disputes', path: '/admin/support' },
       { label: 'Affiliates', path: '/affiliates' },
       { label: 'Sim Dashboard', path: '/sim-dashboard' },
       { label: 'Install Wizard', path: '/install' }

--- a/frontend/src/pages/SupportDisputePage.jsx
+++ b/frontend/src/pages/SupportDisputePage.jsx
@@ -26,100 +26,190 @@ import {
   FormLabel,
   Input,
   Textarea,
+  Spinner,
+  useToast
 } from '@chakra-ui/react';
 import '../styles/SupportDisputePage.css';
-import { fetchTickets, createTicket, resolveTicket, fetchDisputes } from '../api/support';
+import { fetchTickets, createTicket, resolveTicket, fetchDisputes } from '../api/support.js';
+import { resolveDispute } from '../api/disputes.js';
 
 export default function SupportDisputePage() {
   const [tickets, setTickets] = useState([]);
   const [disputes, setDisputes] = useState([]);
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const [form, setForm] = useState({ subject: '', message: '' });
+  const [loading, setLoading] = useState(true);
+  const toast = useToast();
+
+  const ticketModal = useDisclosure();
+  const resolveTicketModal = useDisclosure();
+  const resolveDisputeModal = useDisclosure();
+  const [ticketForm, setTicketForm] = useState({ subject: '', message: '' });
+  const [resolution, setResolution] = useState('');
+  const [activeTicket, setActiveTicket] = useState(null);
+  const [activeDispute, setActiveDispute] = useState(null);
+  const [ticketQuery, setTicketQuery] = useState('');
+  const [disputeQuery, setDisputeQuery] = useState('');
 
   async function loadData() {
-    const [t, d] = await Promise.all([fetchTickets(), fetchDisputes()]);
-    setTickets(t);
-    setDisputes(d);
+    try {
+      setLoading(true);
+      const [t, d] = await Promise.all([fetchTickets(), fetchDisputes()]);
+      setTickets(t);
+      setDisputes(d);
+    } catch {
+      toast({ status: 'error', description: 'Failed to load data' });
+    } finally {
+      setLoading(false);
+    }
   }
 
   useEffect(() => {
     loadData();
   }, []);
 
-  async function handleSubmit() {
-    await createTicket(form);
-    setForm({ subject: '', message: '' });
-    onClose();
-    loadData();
+  async function handleCreateTicket() {
+    try {
+      await createTicket(ticketForm);
+      toast({ status: 'success', description: 'Ticket created' });
+      setTicketForm({ subject: '', message: '' });
+      ticketModal.onClose();
+      loadData();
+    } catch {
+      toast({ status: 'error', description: 'Failed to create ticket' });
+    }
   }
 
-  async function handleResolve(id) {
-    await resolveTicket(id);
-    loadData();
+  function openResolveTicket(ticket) {
+    setActiveTicket(ticket);
+    setResolution('');
+    resolveTicketModal.onOpen();
   }
+
+  async function handleResolveTicket() {
+    if (!activeTicket) return;
+    try {
+      await resolveTicket(activeTicket.id, resolution);
+      toast({ status: 'success', description: 'Ticket resolved' });
+      resolveTicketModal.onClose();
+      loadData();
+    } catch {
+      toast({ status: 'error', description: 'Failed to resolve ticket' });
+    }
+  }
+
+  function openResolveDispute(dispute) {
+    setActiveDispute(dispute);
+    setResolution('');
+    resolveDisputeModal.onOpen();
+  }
+
+  async function handleResolveDispute() {
+    if (!activeDispute) return;
+    try {
+      await resolveDispute(activeDispute.id, { resolution });
+      toast({ status: 'success', description: 'Dispute resolved' });
+      resolveDisputeModal.onClose();
+      loadData();
+    } catch {
+      toast({ status: 'error', description: 'Failed to resolve dispute' });
+    }
+  }
+
+  const filteredTickets = tickets.filter(t =>
+    t.subject?.toLowerCase().includes(ticketQuery.toLowerCase())
+  );
+  const filteredDisputes = disputes.filter(d =>
+    d.category?.toLowerCase().includes(disputeQuery.toLowerCase()) ||
+    String(d.userId).includes(disputeQuery)
+  );
 
   return (
     <Box className="support-page">
-      <Heading mb={4}>Support & Disputes</Heading>
-      <Tabs>
-        <TabList>
-          <Tab>Support Tickets</Tab>
-          <Tab>Disputes</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>
-            <Button colorScheme="teal" mb={4} onClick={onOpen}>
-              New Ticket
-            </Button>
-            <Table variant="simple">
-              <Thead>
-                <Tr>
-                  <Th>Subject</Th>
-                  <Th>Status</Th>
-                  <Th>Actions</Th>
-                </Tr>
-              </Thead>
-              <Tbody>
-                {tickets.map(t => (
-                  <Tr key={t.id}>
-                    <Td>{t.subject}</Td>
-                    <Td>{t.status}</Td>
-                    <Td>
-                      {t.status !== 'resolved' && (
-                        <Button size="sm" onClick={() => handleResolve(t.id)}>
-                          Resolve
-                        </Button>
-                      )}
-                    </Td>
+      <Heading mb={4}>Support &amp; Disputes</Heading>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <Tabs>
+          <TabList>
+            <Tab>Support Tickets</Tab>
+            <Tab>Disputes</Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>
+              <Button colorScheme="teal" mb={4} onClick={ticketModal.onOpen}>
+                New Ticket
+              </Button>
+              <Input
+                placeholder="Search tickets"
+                mb={2}
+                value={ticketQuery}
+                onChange={e => setTicketQuery(e.target.value)}
+              />
+              <Table variant="simple">
+                <Thead>
+                  <Tr>
+                    <Th>Subject</Th>
+                    <Th>User</Th>
+                    <Th>Status</Th>
+                    <Th>Actions</Th>
                   </Tr>
-                ))}
-              </Tbody>
-            </Table>
-          </TabPanel>
-          <TabPanel>
-            <Table variant="simple">
-              <Thead>
-                <Tr>
-                  <Th>User</Th>
-                  <Th>Category</Th>
-                  <Th>Status</Th>
-                </Tr>
-              </Thead>
-              <Tbody>
-                {disputes.map(d => (
-                  <Tr key={d.id}>
-                    <Td>{d.userId}</Td>
-                    <Td>{d.category}</Td>
-                    <Td>{d.status}</Td>
+                </Thead>
+                <Tbody>
+                  {filteredTickets.map(t => (
+                    <Tr key={t.id}>
+                      <Td>{t.subject}</Td>
+                      <Td>{t.user?.name || t.userId}</Td>
+                      <Td>{t.status}</Td>
+                      <Td>
+                        {t.status !== 'resolved' && (
+                          <Button size="sm" onClick={() => openResolveTicket(t)}>
+                            Resolve
+                          </Button>
+                        )}
+                      </Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+            </TabPanel>
+            <TabPanel>
+              <Input
+                placeholder="Search disputes"
+                mb={2}
+                value={disputeQuery}
+                onChange={e => setDisputeQuery(e.target.value)}
+              />
+              <Table variant="simple">
+                <Thead>
+                  <Tr>
+                    <Th>User</Th>
+                    <Th>Category</Th>
+                    <Th>Status</Th>
+                    <Th>Actions</Th>
                   </Tr>
-                ))}
-              </Tbody>
-            </Table>
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
+                </Thead>
+                <Tbody>
+                  {filteredDisputes.map(d => (
+                    <Tr key={d.id}>
+                      <Td>{d.user?.name || d.userId}</Td>
+                      <Td>{d.category}</Td>
+                      <Td>{d.status}</Td>
+                      <Td>
+                        {d.status !== 'resolved' && (
+                          <Button size="sm" onClick={() => openResolveDispute(d)}>
+                            Resolve
+                          </Button>
+                        )}
+                      </Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      )}
 
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal isOpen={ticketModal.isOpen} onClose={ticketModal.onClose}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>New Support Ticket</ModalHeader>
@@ -128,24 +218,68 @@ export default function SupportDisputePage() {
             <FormControl mb={3}>
               <FormLabel>Subject</FormLabel>
               <Input
-                value={form.subject}
-                onChange={e => setForm({ ...form, subject: e.target.value })}
+                value={ticketForm.subject}
+                onChange={e => setTicketForm({ ...ticketForm, subject: e.target.value })}
               />
             </FormControl>
             <FormControl>
               <FormLabel>Message</FormLabel>
               <Textarea
-                value={form.message}
-                onChange={e => setForm({ ...form, message: e.target.value })}
+                value={ticketForm.message}
+                onChange={e => setTicketForm({ ...ticketForm, message: e.target.value })}
               />
             </FormControl>
           </ModalBody>
           <ModalFooter>
-            <Button mr={3} onClick={onClose}>
+            <Button mr={3} onClick={ticketModal.onClose}>
               Cancel
             </Button>
-            <Button colorScheme="teal" onClick={handleSubmit}>
+            <Button colorScheme="teal" onClick={handleCreateTicket}>
               Submit
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      <Modal isOpen={resolveTicketModal.isOpen} onClose={resolveTicketModal.onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Resolve Ticket</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <FormControl>
+              <FormLabel>Resolution</FormLabel>
+              <Textarea value={resolution} onChange={e => setResolution(e.target.value)} />
+            </FormControl>
+          </ModalBody>
+          <ModalFooter>
+            <Button mr={3} onClick={resolveTicketModal.onClose}>
+              Cancel
+            </Button>
+            <Button colorScheme="teal" onClick={handleResolveTicket}>
+              Resolve
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+
+      <Modal isOpen={resolveDisputeModal.isOpen} onClose={resolveDisputeModal.onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Resolve Dispute</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <FormControl>
+              <FormLabel>Resolution</FormLabel>
+              <Textarea value={resolution} onChange={e => setResolution(e.target.value)} />
+            </FormControl>
+          </ModalBody>
+          <ModalFooter>
+            <Button mr={3} onClick={resolveDisputeModal.onClose}>
+              Cancel
+            </Button>
+            <Button colorScheme="teal" onClick={handleResolveDispute}>
+              Resolve
             </Button>
           </ModalFooter>
         </ModalContent>


### PR DESCRIPTION
## Summary
- add unified admin support & disputes interface
- secure API modules for support tickets and disputes
- wire up admin navigation and routing

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689359e0ad1883208d99e903ef6b4c6e