### PR TITLE
chore(frontend): strip deprecated npm proxy config

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "test": "vitest run"
+    "build": "node scripts/build.js",
+    "test": "node scripts/test.js"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.0",

--- a/frontend/scripts/build.js
+++ b/frontend/scripts/build.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// Removes deprecated npm_config_http_proxy env var to avoid warnings.
+delete process.env.npm_config_http_proxy;
+const { spawn } = require('child_process');
+const child = spawn('vite', ['build'], { stdio: 'inherit', shell: true });
+child.on('exit', code => process.exit(code));

--- a/frontend/scripts/test.js
+++ b/frontend/scripts/test.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// Removes deprecated npm_config_http_proxy env var before running tests.
+delete process.env.npm_config_http_proxy;
+const { spawn } = require('child_process');
+const child = spawn('vitest', ['run'], { stdio: 'inherit', shell: true });
+child.on('exit', code => process.exit(code));


### PR DESCRIPTION
## Summary
- avoid deprecated `npm_config_http_proxy` warning by stripping it before running build and tests
- run build/tests via small node scripts

## Testing
- `grep -n "Unknown env config" /tmp/build.log || echo 'no warning'`
- `npm_config_http_proxy= npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893973da8408320aaafbe086bc723f1