### PR TITLE
chore: remove redundant scripts for stage 10

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -141,12 +141,6 @@
 <script type="text/babel" data-presets="env,react" src="utils/api.js"></script>
 <script type="text/babel" data-presets="env,react" src="views/financial_media_setup.js"></script>
     <script type="text/babel" data-presets="env,react" src="utils/date.js"></script>
-    <script type="text/babel" data-presets="env,react" src="api/profile.js"></script>
-    <script type="text/babel" data-presets="env,react" src="api/resume.js"></script>
-    <script type="text/babel" data-presets="env,react" src="api/employment.js"></script>
-    <script type="text/babel" data-presets="env,react" src="views/profile_customization.js"></script>
-    <script type="text/babel" data-presets="env,react" src="utils/api.js"></script>
-    <script type="text/babel" data-presets="env,react" src="views/financial_media_setup.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/communications.js"></script>
     <script type="text/babel" data-presets="env,react" src="components/widgets/chat_widget.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/chat_inbox.js"></script>

--- a/list_of_errors.md
+++ b/list_of_errors.md
@@ -96,12 +96,7 @@ vite v5.4.19 building for production...
 
 ## Stage 10: Frontend script references (8)
 
-- `<script src="api/profile.js"> in "/index.html" can't be bundled without type="module" attribute`
-- `<script src="api/resume.js"> in "/index.html" can't be bundled without type="module" attribute`
-- `<script src="api/employment.js"> in "/index.html" can't be bundled without type="module" attribute`
-- `<script src="views/profile_customization.js"> in "/index.html" can't be bundled without type="module" attribute`
-- `<script src="utils/api.js"> in "/index.html" can't be bundled without type="module" attribute`
-- `<script src="views/financial_media_setup.js"> in "/index.html" can't be bundled without type="module" attribute`
+Resolved by removing redundant script tags from `frontend/index.html`.
 
 ## Stage 11: Frontend script references (9)
 


### PR DESCRIPTION
## Summary
- remove stage-10 script references from frontend index file
- note resolution of Stage 10 in error log

## Testing
- `npm test` (backend)
- `npm test` (frontend)
- `npm run build` (frontend) *(fails: Unexpected "}" in LoginPage.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_6893978ae5b48320a3402079abacb456