### PR TITLE
fix: remove legacy chat scripts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,33 +137,21 @@
 <script type="text/babel" data-presets="env,react" src="components/ProfessionalDetails.js"></script>
 <script type="text/babel" data-presets="env,react" src="components/ActivityFeed.js"></script>
 <script type="text/babel" data-presets="env,react" src="views/profile_page.js"></script>
-<script type="text/babel" data-presets="env,react" src="views/profile_customization.js"></script>
 <script type="text/babel" data-presets="env,react" src="utils/api.js"></script>
 <script type="text/babel" data-presets="env,react" src="views/financial_media_setup.js"></script>
     <script type="text/babel" data-presets="env,react" src="utils/date.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/profile.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/resume.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/employment.js"></script>
-    <script type="text/babel" data-presets="env,react" src="views/profile_customization.js"></script>
     <script type="text/babel" data-presets="env,react" src="utils/api.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/financial_media_setup.js"></script>
-    <script type="text/babel" data-presets="env,react" src="api/communications.js"></script>
-    <script type="text/babel" data-presets="env,react" src="components/widgets/chat_widget.js"></script>
-    <script type="text/babel" data-presets="env,react" src="views/chat_inbox.js"></script>
-    <script type="text/babel" data-presets="env,react" src="views/employment_dashboard.js"></script>
-    <script type="text/babel" data-presets="env,react" src="api/interviews.js"></script>
-    <script type="text/babel" data-presets="env,react" src="views/profile_customization.js"></script>
     <script type="text/babel" data-presets="env,react" src="utils/api.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/financial_media_setup.js"></script>
-    <script type="text/babel" data-presets="env,react" src="api/communications.js"></script>
-    <script type="text/babel" data-presets="env,react" src="components/widgets/chat_widget.js"></script>
-    <script type="text/babel" data-presets="env,react" src="views/chat_inbox.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/application_interview_management.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/virtual_interview.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/gigs.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/education.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/calendar.js"></script>
-    <script type="text/babel" data-presets="env,react" src="views/profile_customization.js"></script>
     <script type="text/babel" data-presets="env,react" src="utils/api.js"></script>
     <script type="text/babel" data-presets="env,react" src="views/financial_media_setup.js"></script>
     <script type="text/babel" data-presets="env,react" src="api/gigs.js"></script>


### PR DESCRIPTION
## Summary
- cleanup legacy chat and interview scripts from index.html

## Testing
- `cd frontend && npm test`
- `cd frontend && npm run build` *(fails: script tag bundling and LoginPage.jsx syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_6893979369cc83208f59086f4340b475