### PR TITLE
Handle missing env vars gracefully for backend

### DIFF
--- a/backend/api/pusher.js
+++ b/backend/api/pusher.js
@@ -1,12 +1,22 @@
-const Pusher = require('pusher');
+let pusher = {
+  trigger: () => Promise.resolve(),
+};
 
-const pusher = new Pusher({
-  appId: process.env.PUSHER_APP_ID,
-  key: process.env.PUSHER_KEY,
-  secret: process.env.PUSHER_SECRET,
-  cluster: process.env.PUSHER_CLUSTER,
-  useTLS: true,
-});
+if (
+  process.env.PUSHER_APP_ID &&
+  process.env.PUSHER_KEY &&
+  process.env.PUSHER_SECRET &&
+  process.env.PUSHER_CLUSTER
+) {
+  const Pusher = require('pusher');
+  pusher = new Pusher({
+    appId: process.env.PUSHER_APP_ID,
+    key: process.env.PUSHER_KEY,
+    secret: process.env.PUSHER_SECRET,
+    cluster: process.env.PUSHER_CLUSTER,
+    useTLS: true,
+  });
+}
 
 /**
  * Trigger an event on a Pusher channel.

--- a/backend/api/s3.js
+++ b/backend/api/s3.js
@@ -1,22 +1,18 @@
-const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
+let s3 = null;
+let uploadObject = async () => Promise.resolve();
 
-const s3 = new S3Client({ region: process.env.AWS_REGION });
-
-/**
- * Upload a file to S3.
- * @param {string} bucket
- * @param {string} key
- * @param {Buffer|Uint8Array|string} body
- * @param {Object} [options]
- */
-async function uploadObject(bucket, key, body, options = {}) {
-  const command = new PutObjectCommand({
-    Bucket: bucket,
-    Key: key,
-    Body: body,
-    ...options,
-  });
-  return s3.send(command);
+if (process.env.AWS_REGION) {
+  const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
+  s3 = new S3Client({ region: process.env.AWS_REGION });
+  uploadObject = async (bucket, key, body, options = {}) => {
+    const command = new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: body,
+      ...options,
+    });
+    return s3.send(command);
+  };
 }
 
 module.exports = {

--- a/backend/api/smtp.js
+++ b/backend/api/smtp.js
@@ -1,15 +1,17 @@
-const nodemailer = require('nodemailer');
-
 function createTransport() {
-  return nodemailer.createTransport({
-    host: process.env.SMTP_HOST,
-    port: parseInt(process.env.SMTP_PORT || '587', 10),
-    secure: false,
-    auth: {
-      user: process.env.SMTP_USER,
-      pass: process.env.SMTP_PASS,
-    },
-  });
+  if (process.env.SMTP_HOST && process.env.SMTP_USER && process.env.SMTP_PASS) {
+    const nodemailer = require('nodemailer');
+    return nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: parseInt(process.env.SMTP_PORT || '587', 10),
+      secure: false,
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+  }
+  return { sendMail: async () => Promise.resolve() };
 }
 
 async function sendMail(options) {

--- a/backend/api/stripe.js
+++ b/backend/api/stripe.js
@@ -1,12 +1,14 @@
-const Stripe = require('stripe');
+let stripe;
 
-/**
- * Stripe SDK instance configured via STRIPE_SECRET_KEY.
- * The default API version is pinned to avoid breaking changes.
- */
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2023-08-16',
-});
+if (process.env.STRIPE_SECRET_KEY) {
+  const Stripe = require('stripe');
+  stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+    apiVersion: '2023-08-16',
+  });
+} else {
+  const noop = async () => ({ });
+  stripe = new Proxy({}, { get: () => noop });
+}
 
 module.exports = stripe;
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,3 +1,4 @@
+require('./config/env');
 const express = require('express');
 const cors = require('cors');
 const products = require('./data/products.json');

--- a/backend/config/env.js
+++ b/backend/config/env.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+const rootDir = path.resolve(__dirname, '..');
+const envFiles = ['.env', '.env.example'].map(file => path.join(rootDir, file));
+
+for (const file of envFiles) {
+  if (fs.existsSync(file)) {
+    dotenv.config({ path: file });
+    break;
+  }
+}


### PR DESCRIPTION
## Summary
- Autoload `.env` or fallback `.env.example` for the backend
- Provide no-op stubs for Pusher, Stripe, SMTP and S3 when keys are absent

## Testing
- `npm test` (backend)
- `npm start` (backend)
- `npm test` (frontend)
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6893a20049cc8320a739787793d12ffd