### PR TITLE
feat: enhance installation wizard

### DIFF
--- a/backend/controllers/install.js
+++ b/backend/controllers/install.js
@@ -1,4 +1,4 @@
-const { checkInstallation, runInstallation } = require('../services/install');
+const { checkInstallation, runInstallation, checkDatabase } = require('../services/install');
 const logger = require('../utils/logger');
 
 async function getStatus(req, res) {
@@ -21,4 +21,14 @@ async function install(req, res) {
   }
 }
 
-module.exports = { getStatus, install };
+async function checkDb(req, res) {
+  try {
+    const result = await checkDatabase(req.body.dbConfig || {});
+    res.json(result);
+  } catch (err) {
+    logger.error('Database check failed', { error: err.message });
+    res.status(400).json({ error: err.message });
+  }
+}
+
+module.exports = { getStatus, install, checkDb };

--- a/backend/routes/install.js
+++ b/backend/routes/install.js
@@ -1,9 +1,10 @@
 const express = require('express');
-const { getStatus, install } = require('../controllers/install');
+const { getStatus, install, checkDb } = require('../controllers/install');
 
 const router = express.Router();
 
 router.get('/status', getStatus);
 router.post('/', install);
+router.post('/check-db', checkDb);
 
 module.exports = router;

--- a/frontend/src/api/install.js
+++ b/frontend/src/api/install.js
@@ -9,3 +9,8 @@ export async function runInstallation(payload) {
   const { data } = await apiClient.post('/install', payload);
   return data;
 }
+
+export async function checkDatabaseConnection(dbConfig) {
+  const { data } = await apiClient.post('/install/check-db', { dbConfig });
+  return data;
+}

--- a/frontend/src/pages/InstallationWizardPage.jsx
+++ b/frontend/src/pages/InstallationWizardPage.jsx
@@ -8,9 +8,19 @@ import {
   Input,
   Button,
   Alert,
-  AlertIcon
+  AlertIcon,
+  Stepper,
+  Step,
+  StepIndicator,
+  StepStatus,
+  StepNumber,
+  StepIcon,
+  StepTitle,
+  StepSeparator,
+  Flex,
+  Text,
 } from '@chakra-ui/react';
-import { getInstallStatus, runInstallation } from '../api/install.js';
+import { getInstallStatus, runInstallation, checkDatabaseConnection } from '../api/install.js';
 import '../styles/InstallationWizardPage.css';
 
 export default function InstallationWizardPage() {
@@ -21,6 +31,12 @@ export default function InstallationWizardPage() {
   const [app, setApp] = useState({ appId: '', appUrl: '' });
   const [error, setError] = useState('');
   const [complete, setComplete] = useState(false);
+  const [dbCheck, setDbCheck] = useState(null);
+
+  const errorSuggestions = {
+    'Admin user already exists': 'Try a different username.',
+    'Admin username and password are required': 'Fill in all admin fields.',
+  };
 
   useEffect(() => {
     getInstallStatus()
@@ -38,8 +54,25 @@ export default function InstallationWizardPage() {
     );
   }
 
+  const validateStep = () => {
+    switch (step) {
+      case 0:
+        return dbConfig.host && dbConfig.user && dbConfig.name;
+      case 1:
+        return admin.username && admin.email && admin.password;
+      case 2:
+        return app.appId && app.appUrl;
+      default:
+        return true;
+    }
+  };
+
   const handleNext = async () => {
     setError('');
+    if (!validateStep()) {
+      setError('Please fill out all required fields.');
+      return;
+    }
     if (step < 2) {
       setStep(step + 1);
     } else {
@@ -47,8 +80,27 @@ export default function InstallationWizardPage() {
         await runInstallation({ dbConfig, admin, app });
         setComplete(true);
       } catch (e) {
-        setError(e.response?.data?.error || e.message);
+        const msg = e.response?.data?.error || e.message;
+        setError(msg);
       }
+    }
+  };
+
+  const handleBack = () => {
+    setError('');
+    if (step > 0) setStep(step - 1);
+  };
+
+  const handleCheckDb = async () => {
+    setDbCheck(null);
+    setError('');
+    try {
+      await checkDatabaseConnection(dbConfig);
+      setDbCheck('Connection successful!');
+    } catch (e) {
+      const msg = e.response?.data?.error || e.message;
+      setDbCheck(null);
+      setError(msg);
     }
   };
 
@@ -62,16 +114,18 @@ export default function InstallationWizardPage() {
     );
   }
 
+  const steps = [{ title: 'Database' }, { title: 'Admin' }, { title: 'Application' }];
+
   const renderStep = () => {
     switch (step) {
       case 0:
         return (
           <>
-            <FormControl>
+            <FormControl isRequired>
               <FormLabel>Database Host</FormLabel>
               <Input value={dbConfig.host} onChange={e => setDbConfig({ ...dbConfig, host: e.target.value })} />
             </FormControl>
-            <FormControl>
+            <FormControl isRequired>
               <FormLabel>Database User</FormLabel>
               <Input value={dbConfig.user} onChange={e => setDbConfig({ ...dbConfig, user: e.target.value })} />
             </FormControl>
@@ -79,24 +133,33 @@ export default function InstallationWizardPage() {
               <FormLabel>Database Password</FormLabel>
               <Input type="password" value={dbConfig.password} onChange={e => setDbConfig({ ...dbConfig, password: e.target.value })} />
             </FormControl>
-            <FormControl>
+            <FormControl isRequired>
               <FormLabel>Database Name</FormLabel>
               <Input value={dbConfig.name} onChange={e => setDbConfig({ ...dbConfig, name: e.target.value })} />
             </FormControl>
+            <Button mt={4} colorScheme="blue" onClick={handleCheckDb}>
+              Check Connection
+            </Button>
+            {dbCheck && (
+              <Alert status="success" mt={4}>
+                <AlertIcon />
+                {dbCheck}
+              </Alert>
+            )}
           </>
         );
       case 1:
         return (
           <>
-            <FormControl>
+            <FormControl isRequired>
               <FormLabel>Admin Username</FormLabel>
               <Input value={admin.username} onChange={e => setAdmin({ ...admin, username: e.target.value })} />
             </FormControl>
-            <FormControl>
+            <FormControl isRequired>
               <FormLabel>Admin Email</FormLabel>
               <Input value={admin.email} onChange={e => setAdmin({ ...admin, email: e.target.value })} />
             </FormControl>
-            <FormControl>
+            <FormControl isRequired>
               <FormLabel>Admin Password</FormLabel>
               <Input type="password" value={admin.password} onChange={e => setAdmin({ ...admin, password: e.target.value })} />
             </FormControl>
@@ -105,11 +168,11 @@ export default function InstallationWizardPage() {
       case 2:
         return (
           <>
-            <FormControl>
+            <FormControl isRequired>
               <FormLabel>App ID</FormLabel>
               <Input value={app.appId} onChange={e => setApp({ ...app, appId: e.target.value })} />
             </FormControl>
-            <FormControl>
+            <FormControl isRequired>
               <FormLabel>App URL</FormLabel>
               <Input value={app.appUrl} onChange={e => setApp({ ...app, appUrl: e.target.value })} />
             </FormControl>
@@ -120,21 +183,46 @@ export default function InstallationWizardPage() {
     }
   };
 
+  const suggestion = errorSuggestions[error] || '';
+
   return (
-    <Box className="installation-wizard" p={6}>
-      <Heading mb={4}>Installation Wizard</Heading>
+    <Box className="installation-wizard" p={6} bgGradient="linear(to-r, blue.50, blue.100)" borderWidth="1px" borderColor="blue.200" borderRadius="md" shadow="md">
+      <Heading mb={6} color="blue.700">
+        Workhouse Setup Wizard
+      </Heading>
+      <Stepper index={step} colorScheme="blue" mb={6}>
+        {steps.map((s, idx) => (
+          <Step key={idx}>
+            <StepIndicator>
+              <StepStatus complete={<StepIcon />} incomplete={<StepNumber />} active={<StepNumber />} />
+            </StepIndicator>
+            <Box flexShrink="0">
+              <StepTitle>{s.title}</StepTitle>
+            </Box>
+            <StepSeparator />
+          </Step>
+        ))}
+      </Stepper>
       {error && (
         <Alert status="error" mb={4}>
           <AlertIcon />
-          {error}
+          <Box>
+            <Text>{error}</Text>
+            {suggestion && <Text mt={1} fontSize="sm">{suggestion}</Text>}
+          </Box>
         </Alert>
       )}
       <VStack spacing={4} align="stretch">
         {renderStep()}
       </VStack>
-      <Button mt={6} colorScheme="teal" onClick={handleNext}>
-        {step < 2 ? 'Next' : 'Install'}
-      </Button>
+      <Flex mt={6} justify="space-between">
+        <Button onClick={handleBack} isDisabled={step === 0} colorScheme="blue" variant="outline">
+          Back
+        </Button>
+        <Button colorScheme="blue" onClick={handleNext}>
+          {step < 2 ? 'Next' : 'Install'}
+        </Button>
+      </Flex>
     </Box>
   );
 }

--- a/frontend/src/styles/InstallationWizardPage.css
+++ b/frontend/src/styles/InstallationWizardPage.css
@@ -1,4 +1,4 @@
 .installation-wizard {
   max-width: 600px;
-  margin: 0 auto;
+  margin: 40px auto;
 }


### PR DESCRIPTION
## Summary
- add backend database connectivity checks using mysql and expose new `/install/check-db` endpoint
- revamp installation wizard with chakra stepper, blue theme, field validation, and connection test feedback
- refine wizard layout styles and add API helper for DB checks

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c77efdc483208e240b5bbf87e289