### PR TITLE
feat: initialize mysql with error handling

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -5,6 +5,8 @@ const products = require('./data/products.json');
 const authRoutes = require('./routes/auth');
 const landingRoutes = require('./routes/landing');
 const api = require("./api");
+const { initDb } = require('./utils/db');
+const logger = require('./utils/logger');
 
 const app = express();
 app.use(cors());
@@ -17,9 +19,39 @@ app.get('/operations/retail/products', (req, res) => {
 app.use('/auth', authRoutes);
 app.use('/landing', landingRoutes);
 
+// 404 handler
+app.use((req, res, next) => {
+  res.status(404).json({ error: 'Not Found' });
+});
+
+// Error handler
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
+  logger.error('Unhandled error', { error: err.message });
+  res.status(500).json({ error: 'Internal server error' });
+});
+
 const port = process.env.PORT || 5000;
+async function start() {
+  try {
+    await initDb();
+    app.listen(port, () => logger.info(`Server running on port ${port}`));
+  } catch (err) {
+    logger.error('Failed to start server', { error: err.message });
+    process.exit(1);
+  }
+}
+
+process.on('unhandledRejection', err => {
+  logger.error('Unhandled promise rejection', { error: err.message });
+});
+
+process.on('uncaughtException', err => {
+  logger.error('Uncaught exception', { error: err.message });
+});
+
 if (require.main === module) {
-  app.listen(port, () => console.log(`Server running on port ${port}`));
+  start();
 }
 
 module.exports = app;

--- a/backend/utils/db.js
+++ b/backend/utils/db.js
@@ -1,0 +1,65 @@
+const mysql = require('mysql2/promise');
+const fs = require('fs');
+const path = require('path');
+const logger = require('./logger');
+
+let pool;
+
+async function runMigrations(connection) {
+  const dir = path.join(__dirname, '..', 'database');
+  if (!fs.existsSync(dir)) return;
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.sql')).sort();
+  for (const file of files) {
+    const sql = fs.readFileSync(path.join(dir, file), 'utf8');
+    try {
+      await connection.query(sql);
+      logger.info(`Executed ${file}`);
+    } catch (err) {
+      logger.error(`Error executing ${file}`, { error: err.message });
+    }
+  }
+}
+
+async function initDb(retries = 5, delay = 2000) {
+  if (pool) return pool;
+  while (retries) {
+    try {
+      pool = mysql.createPool({
+      host: process.env.DB_HOST || 'localhost',
+      user: process.env.DB_USER || 'root',
+      password: process.env.DB_PASSWORD || '',
+      database: process.env.DB_NAME || 'workhouse',
+      port: process.env.DB_PORT || 3306,
+      waitForConnections: true,
+      connectionLimit: 10,
+      queueLimit: 0,
+      multipleStatements: true
+      });
+      await pool.query('SELECT 1');
+      await runMigrations(pool);
+      logger.info('Database connection established');
+      return pool;
+    } catch (err) {
+      logger.error('Database connection failed', { error: err.message });
+      retries -= 1;
+      if (!retries) {
+        throw err;
+      }
+      await new Promise(res => setTimeout(res, delay));
+    }
+  }
+}
+
+function getPool() {
+  if (!pool) {
+    throw new Error('Database not initialized');
+  }
+  return pool;
+}
+
+async function query(sql, params) {
+  const [rows] = await getPool().query(sql, params);
+  return rows;
+}
+
+module.exports = { initDb, getPool, query };


### PR DESCRIPTION
## Summary
- initialize MySQL pool with automatic migrations and retry logic
- start server only after DB connects and add process-level error logging
- add 404 and error-handling middleware to keep app running

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893c9dbbc0883208c2989f80a0ec889