### PR TITLE
fix: create database during setup

### DIFF
--- a/backend/scripts/dbSetup.js
+++ b/backend/scripts/dbSetup.js
@@ -3,14 +3,18 @@ const path = require('path');
 const mysql = require('mysql2/promise');
 
 async function runMigrations() {
+  const dbName = process.env.DB_NAME || 'workhouse';
   const connection = await mysql.createConnection({
     host: process.env.DB_HOST || 'localhost',
     user: process.env.DB_USER || 'root',
     password: process.env.DB_PASSWORD || '',
-    database: process.env.DB_NAME || 'workhouse',
     port: process.env.DB_PORT || 3306,
     multipleStatements: true
   });
+
+  // Ensure the database exists before running migrations
+  await connection.query(`CREATE DATABASE IF NOT EXISTS \`${dbName}\``);
+  await connection.changeUser({ database: dbName });
 
   const dir = path.join(__dirname, '..', 'database');
   const files = fs.readdirSync(dir).filter(f => f.endsWith('.sql')).sort();


### PR DESCRIPTION
## Summary
- ensure database setup script creates the target database before running migrations

## Testing
- `npm test`
- `DB_HOST=127.0.0.1 DB_USER=workhouse DB_PASSWORD=workhouse DB_NAME=workhouse npm run db:migrate` *(fails: Unknown data type: 'JSONB')*

------
https://chatgpt.com/codex/tasks/task_e_6893cbb16dd883208856d368cf058171