### PR TITLE
Switch database setup to PostgreSQL and fix schema conflicts

### DIFF
--- a/backend/database/opportunities.sql
+++ b/backend/database/opportunities.sql
@@ -13,7 +13,6 @@ CREATE TABLE IF NOT EXISTS opportunities (
   duration VARCHAR(100),
   compensation NUMERIC,
   experience_level VARCHAR(100),
-  status VARCHAR(20) DEFAULT 'open',
   status VARCHAR(50) DEFAULT 'open',
   views INTEGER DEFAULT 0,
   applications INTEGER DEFAULT 0,

--- a/backend/database/service_provider_analytics.sql
+++ b/backend/database/service_provider_analytics.sql
@@ -34,16 +34,9 @@ CREATE TABLE service_bookings (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE portfolio_items (
-  id UUID PRIMARY KEY,
-  provider_id UUID REFERENCES service_providers(id),
-  title VARCHAR(255) NOT NULL,
-  description TEXT NOT NULL,
-  media_url TEXT,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
+-- Portfolio items are defined in portfolio.sql
 
-CREATE TABLE testimonials (
+CREATE TABLE provider_testimonials (
   id UUID PRIMARY KEY,
   provider_id UUID REFERENCES service_providers(id),
   client_id UUID NOT NULL,

--- a/backend/scripts/seedData.js
+++ b/backend/scripts/seedData.js
@@ -1,32 +1,26 @@
 const fs = require('fs');
 const path = require('path');
-const mysql = require('mysql2/promise');
+const { execSync } = require('child_process');
 
-async function seedProducts(connection) {
+function escape(str) {
+  return str.replace(/'/g, "''");
+}
+
+async function seedProducts() {
   const dataPath = path.join(__dirname, '..', 'data', 'products.json');
   if (!fs.existsSync(dataPath)) return;
   const products = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  const dbName = process.env.DB_NAME || 'workhouse';
+
   for (const p of products) {
-    await connection.query(
-      'INSERT INTO products (id, name, description, price, image) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE name=VALUES(name), description=VALUES(description), price=VALUES(price), image=VALUES(image)',
-      [p.id, p.name, p.description, p.price, p.image]
-    );
+    const query = `INSERT INTO products (id, name, description, price, image) VALUES ('${escape(p.id)}', '${escape(p.name)}', '${escape(p.description)}', ${p.price}, '${escape(p.image)}') ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, description = EXCLUDED.description, price = EXCLUDED.price, image = EXCLUDED.image;`;
+    execSync(`echo "${query}" | sudo -u postgres psql -d ${dbName}`, { stdio: 'inherit' });
   }
   console.log('Seeded products');
 }
 
 async function run() {
-  const connection = await mysql.createConnection({
-    host: process.env.DB_HOST || 'localhost',
-    user: process.env.DB_USER || 'root',
-    password: process.env.DB_PASSWORD || '',
-    database: process.env.DB_NAME || 'workhouse',
-    port: process.env.DB_PORT || 3306,
-    multipleStatements: true
-  });
-
-  await seedProducts(connection);
-  await connection.end();
+  await seedProducts();
 }
 
 run().catch(err => {


### PR DESCRIPTION
## Summary
- use PostgreSQL's `psql` for migrations and seeding
- remove duplicate `status` column in opportunities
- avoid table name collisions in service provider analytics

## Testing
- `npm run db:migrate`
- `npm run db:seed`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ceffda188320ac8d2cfc182fed25