### PR TITLE
feat: add KL Edition workspace page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,3 +54,5 @@ VITE_RECAPTCHA_SITE_KEY=
 VITE_EDU_SCHEDULE_ENDPOINT=/education/schedule
 VITE_COURSES_ENDPOINT=/courses
 VITE_CALENDAR_ENDPOINT=/service-providers/calendar
+VITE_IDE_URL=http://localhost:8080
+VITE_N8N_URL=http://localhost:5678

--- a/frontend/env.js
+++ b/frontend/env.js
@@ -16,4 +16,6 @@ window.env = {
   FILE_IO_API: apiBase + (import.meta.env.VITE_FILE_IO_API || '/files'),
   ANALYTICS_ENDPOINT: import.meta.env.VITE_ANALYTICS_ENDPOINT,
   AUDIT_RESULTS_ENDPOINT: import.meta.env.VITE_AUDIT_RESULTS_ENDPOINT,
+  IDE_URL: import.meta.env.VITE_IDE_URL,
+  N8N_URL: import.meta.env.VITE_N8N_URL,
 };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { ChakraProvider, Box } from '@chakra-ui/react';
 import LoginPage from './pages/LoginPage.jsx';
 import SignupPage from './pages/SignupPage.jsx';
 import DashboardPage from './pages/DashboardPage.jsx';
+import KlEditionPage from './pages/KlEditionPage.jsx';
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 
 function Protected({ children }) {
@@ -26,6 +27,14 @@ export default function App() {
                 element={
                   <Protected>
                     <DashboardPage />
+                  </Protected>
+                }
+              />
+              <Route
+                path="/kl"
+                element={
+                  <Protected>
+                    <KlEditionPage />
                   </Protected>
                 }
               />

--- a/frontend/src/pages/KlEditionPage.jsx
+++ b/frontend/src/pages/KlEditionPage.jsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Flex,
+  Heading,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  Textarea,
+  Button,
+} from '@chakra-ui/react';
+import '../styles/KlEditionPage.css';
+
+export default function KlEditionPage() {
+  const [chat, setChat] = useState('');
+  const [messages, setMessages] = useState([]);
+  const ideUrl = window.env?.IDE_URL || import.meta.env.VITE_IDE_URL;
+  const n8nUrl = window.env?.N8N_URL || import.meta.env.VITE_N8N_URL;
+
+  const handleSend = () => {
+    if (chat.trim()) {
+      setMessages([...messages, { role: 'user', content: chat }]);
+      setChat('');
+    }
+  };
+
+  return (
+    <Box className="kl-edition-page" p={4}>
+      <Heading size="lg" mb={4}>
+        KL Edition
+      </Heading>
+      <Tabs isFitted variant="enclosed">
+        <TabList mb="1em">
+          <Tab>IDE</Tab>
+          <Tab>AutoFlows</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <Flex height="70vh" borderWidth="1px" borderRadius="md" overflow="hidden">
+              <Box
+                width="30%"
+                borderRightWidth="1px"
+                p={2}
+                display="flex"
+                flexDirection="column"
+              >
+                <Box flex="1" overflowY="auto">
+                  {messages.map((m, i) => (
+                    <Box key={i} mb={2} className="chat-message">
+                      {m.content}
+                    </Box>
+                  ))}
+                </Box>
+                <Textarea
+                  value={chat}
+                  onChange={(e) => setChat(e.target.value)}
+                  placeholder="Chat with the operator..."
+                  mb={2}
+                />
+                <Button onClick={handleSend} colorScheme="teal">
+                  Send
+                </Button>
+              </Box>
+              <Box flex="1" position="relative">
+                {ideUrl ? (
+                  <iframe src={ideUrl} title="KL IDE" className="ide-iframe" />
+                ) : (
+                  <Flex
+                    className="ide-placeholder"
+                    align="center"
+                    justify="center"
+                    height="100%"
+                  >
+                    IDE URL not configured
+                  </Flex>
+                )}
+              </Box>
+            </Flex>
+          </TabPanel>
+          <TabPanel>
+            <Box height="70vh" borderWidth="1px" borderRadius="md" overflow="hidden">
+              {n8nUrl ? (
+                <iframe src={n8nUrl} title="n8n workflow" className="workflow-iframe" />
+              ) : (
+                <Flex align="center" justify="center" height="100%">
+                  n8n URL not configured
+                </Flex>
+              )}
+            </Box>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Box>
+  );
+}

--- a/frontend/src/styles/KlEditionPage.css
+++ b/frontend/src/styles/KlEditionPage.css
@@ -1,0 +1,21 @@
+.kl-edition-page {
+  background: #f9f9f9;
+}
+
+.kl-edition-page .chat-message {
+  background-color: #edf2f7;
+  border-radius: 4px;
+  padding: 4px 8px;
+}
+
+.kl-edition-page .ide-placeholder {
+  background-color: #1a202c;
+  color: #fff;
+}
+
+.kl-edition-page .ide-iframe,
+.kl-edition-page .workflow-iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add KL Edition page with IDE and AutoFlows placeholders
- style KL Edition page
- register KL Edition route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893d2480b288320897d6795def86085