### PR TITLE
feat: add n8n setup with dashboard and chat

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const products = require('./data/products.json');
 const authRoutes = require('./routes/auth');
 const landingRoutes = require('./routes/landing');
+const n8nRoutes = require('./routes/n8n');
 const api = require("./api");
 const { initDb } = require('./utils/db');
 const logger = require('./utils/logger');
@@ -18,6 +19,7 @@ app.get('/operations/retail/products', (req, res) => {
 
 app.use('/auth', authRoutes);
 app.use('/landing', landingRoutes);
+app.use('/n8n', n8nRoutes);
 
 // 404 handler
 app.use((req, res, next) => {

--- a/backend/controllers/n8n.js
+++ b/backend/controllers/n8n.js
@@ -1,0 +1,13 @@
+const { setupN8n } = require('../services/n8nSetup');
+
+async function setupN8nHandler(req, res) {
+  const { host, username, key, port, n8nPort } = req.body;
+  try {
+    await setupN8n({ host, username, key, port, n8nPort });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+module.exports = { setupN8nHandler };

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "test": "jest",
     "setup": "node scripts/setupWizard.js",
     "db:migrate": "node scripts/dbSetup.js",
-    "db:seed": "node scripts/seedData.js"
+    "db:seed": "node scripts/seedData.js",
+    "n8n:setup": "node scripts/setupN8n.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/backend/routes/n8n.js
+++ b/backend/routes/n8n.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { setupN8nHandler } = require('../controllers/n8n');
+
+const router = express.Router();
+
+router.post('/setup', setupN8nHandler);
+
+module.exports = router;

--- a/backend/scripts/setupN8n.js
+++ b/backend/scripts/setupN8n.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const readline = require('readline');
+const { setupN8n } = require('../services/n8nSetup');
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+const questions = [
+  { key: 'host', q: 'Server host:' },
+  { key: 'username', q: 'SSH username:' },
+  { key: 'keyPath', q: 'Path to private SSH key:' },
+];
+
+const answers = {};
+
+function ask(i = 0) {
+  if (i === questions.length) {
+    try {
+      const key = fs.readFileSync(answers.keyPath, 'utf8');
+      setupN8n({ host: answers.host, username: answers.username, key })
+        .then(() => {
+          console.log('n8n setup complete');
+          rl.close();
+        })
+        .catch(err => {
+          console.error('Setup failed:', err.message);
+          rl.close();
+        });
+    } catch (err) {
+      console.error('Failed to read key file', err.message);
+      rl.close();
+    }
+    return;
+  }
+  rl.question(`${questions[i].q} `, answer => {
+    answers[questions[i].key] = answer.trim();
+    ask(i + 1);
+  });
+}
+
+ask();

--- a/backend/services/n8nSetup.js
+++ b/backend/services/n8nSetup.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { exec } = require('child_process');
+
+function runRemoteInstall({ host, username, key, port = 22, n8nPort = 5678 }) {
+  return new Promise((resolve, reject) => {
+    const keyPath = path.join(os.tmpdir(), `n8n_key_${Date.now()}`);
+    fs.writeFileSync(keyPath, key, { mode: 0o600 });
+    const installCmd = `docker run -d --restart always --name n8n -p ${n8nPort}:5678 n8nio/n8n`;
+    const sshCmd = `ssh -i ${keyPath} -p ${port} -o StrictHostKeyChecking=no ${username}@${host} '${installCmd}'`;
+    exec(sshCmd, (error, stdout, stderr) => {
+      fs.unlinkSync(keyPath);
+      if (error) {
+        return reject(new Error(stderr.trim() || error.message));
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+async function setupN8n({ host, username, key, port, n8nPort }) {
+  if (!host || !username || !key) {
+    throw new Error('Missing required parameters');
+  }
+  await runRemoteInstall({ host, username, key, port, n8nPort });
+}
+
+module.exports = { setupN8n };

--- a/backend/tests/n8n.test.js
+++ b/backend/tests/n8n.test.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('n8n route', () => {
+  test('defines setup endpoint', () => {
+    const filePath = path.join(__dirname, '../routes/n8n.js');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect(content).toMatch(/router\.post\('\/setup'/);
+    expect(content).toMatch(/module\.exports\s*=\s*router/);
+  });
+});

--- a/frontend/src/pages/KlEditionPage.jsx
+++ b/frontend/src/pages/KlEditionPage.jsx
@@ -4,6 +4,7 @@ import {
   Button,
   Flex,
   Heading,
+  Input,
   Tabs,
   TabList,
   TabPanels,
@@ -16,6 +17,12 @@ import '../styles/KlEditionPage.css';
 export default function KlEditionPage() {
   const [chat, setChat] = useState('');
   const [messages, setMessages] = useState([]);
+  const [flowChat, setFlowChat] = useState('');
+  const [flowMessages, setFlowMessages] = useState([]);
+  const [setup, setSetup] = useState({ host: '', username: '', key: '' });
+  const [installing, setInstalling] = useState(false);
+  const [connected, setConnected] = useState(false);
+
   const ideUrl = window.env?.IDE_URL || import.meta.env.VITE_IDE_URL;
   const n8nUrl = window.env?.N8N_URL || import.meta.env.VITE_N8N_URL;
 
@@ -26,15 +33,32 @@ export default function KlEditionPage() {
     }
   };
 
+  const handleFlowSend = () => {
+    if (flowChat.trim()) {
+      setFlowMessages([...flowMessages, { role: 'user', content: flowChat }]);
+      setFlowChat('');
+    }
+  };
 
   const launchEc3 = () => {
     // Placeholder for launching an EC3 IDE instance via AWS API
     console.log('Launch EC3 instance');
   };
 
-  const launchN8n = () => {
-    // Placeholder for launching n8n workflow instance
-    console.log('Launch n8n instance');
+  const handleN8nSetup = async () => {
+    setInstalling(true);
+    try {
+      await fetch('/n8n/setup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(setup),
+      });
+      setConnected(true);
+    } catch (err) {
+      console.error('Failed to setup n8n', err);
+    } finally {
+      setInstalling(false);
+    }
   };
 
   return (
@@ -106,19 +130,77 @@ export default function KlEditionPage() {
             </Flex>
           </TabPanel>
           <TabPanel>
-            <Box height="70vh" borderWidth="1px" borderRadius="md" overflow="hidden">
-              {n8nUrl ? (
-                <iframe src={n8nUrl} title="n8n workflow" className="workflow-iframe" />
-              ) : (
-                <Flex align="center" justify="center" height="100%">
-                  n8n URL not configured
-                </Flex>
-              )}
-            <Box textAlign="center" p={10} borderWidth="1px" borderRadius="md">
-              <Button colorScheme="blue" onClick={launchN8n}>
-                Launch n8n Workflow
-              </Button>
-            </Box>
+            <Flex height="70vh" borderWidth="1px" borderRadius="md" overflow="hidden">
+              <Box
+                width="30%"
+                borderRightWidth="1px"
+                p={2}
+                display="flex"
+                flexDirection="column"
+              >
+                <Box flex="1" overflowY="auto">
+                  {flowMessages.map((m, i) => (
+                    <Box key={i} mb={2} className="chat-message">
+                      {m.content}
+                    </Box>
+                  ))}
+                </Box>
+                <Textarea
+                  value={flowChat}
+                  onChange={(e) => setFlowChat(e.target.value)}
+                  placeholder="Chat with your team..."
+                  mb={2}
+                />
+                <Button onClick={handleFlowSend} colorScheme="teal">
+                  Send
+                </Button>
+              </Box>
+              <Box flex="1" position="relative">
+                {n8nUrl && connected ? (
+                  <iframe src={n8nUrl} title="n8n workflow" className="workflow-iframe" />
+                ) : (
+                  <Flex
+                    className="ide-placeholder"
+                    align="center"
+                    justify="center"
+                    height="100%"
+                  >
+                    n8n URL not configured
+                  </Flex>
+                )}
+                {!connected && (
+                  <Box className="setup-overlay">
+                    <Box className="setup-form">
+                      <Input
+                        placeholder="Server host"
+                        value={setup.host}
+                        onChange={(e) => setSetup({ ...setup, host: e.target.value })}
+                        mb={2}
+                      />
+                      <Input
+                        placeholder="SSH username"
+                        value={setup.username}
+                        onChange={(e) => setSetup({ ...setup, username: e.target.value })}
+                        mb={2}
+                      />
+                      <Textarea
+                        placeholder="Private SSH key"
+                        value={setup.key}
+                        onChange={(e) => setSetup({ ...setup, key: e.target.value })}
+                        mb={2}
+                      />
+                      <Button
+                        colorScheme="blue"
+                        onClick={handleN8nSetup}
+                        isLoading={installing}
+                      >
+                        Connect & Install
+                      </Button>
+                    </Box>
+                  </Box>
+                )}
+              </Box>
+            </Flex>
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/frontend/src/styles/KlEditionPage.css
+++ b/frontend/src/styles/KlEditionPage.css
@@ -20,3 +20,22 @@
   border: 0;
 }
 
+.kl-edition-page .setup-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.kl-edition-page .setup-form {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  width: 300px;
+}
+


### PR DESCRIPTION
## Summary
- embed n8n AutoFlows panel with team chat and remote setup overlay
- add backend endpoint and script to install n8n on provided server via SSH

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6893d9439cdc8320b4585f069433a5c0