### PR TITLE
feat: add KL Edition workspace page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,10 @@ DB_PASSWORD=workhouse
 DB_NAME=workhouse
 DB_PORT=3306
 
+EC2_HOST=
+EC2_USER=
+SSH_KEY_PATH=
+
 VITE_API_BASE_URL=http://localhost:5000
 VITE_AVATAR_API=https://api.dicebear.com/6.x/initials/svg
 VITE_JITSI_DOMAIN=https://meet.jit.si
@@ -54,3 +58,5 @@ VITE_RECAPTCHA_SITE_KEY=
 VITE_EDU_SCHEDULE_ENDPOINT=/education/schedule
 VITE_COURSES_ENDPOINT=/courses
 VITE_CALENDAR_ENDPOINT=/service-providers/calendar
+VITE_IDE_URL=http://localhost:8080
+VITE_N8N_URL=http://localhost:5678

--- a/backend/app.js
+++ b/backend/app.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const products = require('./data/products.json');
 const authRoutes = require('./routes/auth');
 const landingRoutes = require('./routes/landing');
+const environmentRoutes = require('./routes/environment');
 const api = require("./api");
 const { initDb } = require('./utils/db');
 const logger = require('./utils/logger');
@@ -18,6 +19,7 @@ app.get('/operations/retail/products', (req, res) => {
 
 app.use('/auth', authRoutes);
 app.use('/landing', landingRoutes);
+app.use('/environment', environmentRoutes);
 
 // 404 handler
 app.use((req, res, next) => {

--- a/backend/controllers/environment.js
+++ b/backend/controllers/environment.js
@@ -1,0 +1,15 @@
+const { setupEnvironment } = require('../services/environment');
+const logger = require('../utils/logger');
+
+async function setup(req, res) {
+  const { type } = req.body;
+  try {
+    await setupEnvironment(type);
+    res.json({ message: 'Environment setup initiated' });
+  } catch (err) {
+    logger.error('Environment setup failed', { error: err.message });
+    res.status(500).json({ error: err.message });
+  }
+}
+
+module.exports = { setup };

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "test": "jest",
     "setup": "node scripts/setupWizard.js",
     "db:migrate": "node scripts/dbSetup.js",
-    "db:seed": "node scripts/seedData.js"
+    "db:seed": "node scripts/seedData.js",
+    "env:setup": "node scripts/containerSetup.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/backend/routes/environment.js
+++ b/backend/routes/environment.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { setup } = require('../controllers/environment');
+
+const router = express.Router();
+
+router.post('/setup', setup);
+
+module.exports = router;

--- a/backend/scripts/containerSetup.js
+++ b/backend/scripts/containerSetup.js
@@ -1,0 +1,37 @@
+const { execSync } = require('child_process');
+
+const type = process.argv[2];
+if (!type) {
+  console.error('Usage: node containerSetup.js <n8n|ide>');
+  process.exit(1);
+}
+
+const host = process.env.EC2_HOST;
+const user = process.env.EC2_USER;
+const key = process.env.SSH_KEY_PATH;
+
+if (!host || !user || !key) {
+  console.error('Missing EC2_HOST, EC2_USER, or SSH_KEY_PATH environment variables');
+  process.exit(1);
+}
+
+const commands = {
+  n8n: 'docker run -d --name n8n -p 5678:5678 n8nio/n8n',
+  ide: 'docker run -d --name code-server -p 8080:8080 codercom/code-server:latest'
+};
+
+const remoteCmd = commands[type];
+if (!remoteCmd) {
+  console.error(`Unknown environment type: ${type}`);
+  process.exit(1);
+}
+
+const sshCommand = `ssh -i ${key} ${user}@${host} "${remoteCmd}"`;
+
+try {
+  const output = execSync(sshCommand, { stdio: 'pipe' }).toString();
+  console.log(output);
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}

--- a/backend/services/environment.js
+++ b/backend/services/environment.js
@@ -1,0 +1,16 @@
+const path = require('path');
+const { exec } = require('child_process');
+
+function setupEnvironment(type) {
+  return new Promise((resolve, reject) => {
+    const script = path.join(__dirname, '..', 'scripts', 'containerSetup.js');
+    exec(`node ${script} ${type}`, (err, stdout, stderr) => {
+      if (err) {
+        return reject(new Error(stderr || err.message));
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+module.exports = { setupEnvironment };

--- a/frontend/env.js
+++ b/frontend/env.js
@@ -16,4 +16,6 @@ window.env = {
   FILE_IO_API: apiBase + (import.meta.env.VITE_FILE_IO_API || '/files'),
   ANALYTICS_ENDPOINT: import.meta.env.VITE_ANALYTICS_ENDPOINT,
   AUDIT_RESULTS_ENDPOINT: import.meta.env.VITE_AUDIT_RESULTS_ENDPOINT,
+  IDE_URL: import.meta.env.VITE_IDE_URL,
+  N8N_URL: import.meta.env.VITE_N8N_URL,
 };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import { ChakraProvider, Box } from '@chakra-ui/react';
 import LoginPage from './pages/LoginPage.jsx';
 import SignupPage from './pages/SignupPage.jsx';
 import DashboardPage from './pages/DashboardPage.jsx';
+import KlEditionPage from './pages/KlEditionPage.jsx';
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 
 function Protected({ children }) {
@@ -26,6 +27,14 @@ export default function App() {
                 element={
                   <Protected>
                     <DashboardPage />
+                  </Protected>
+                }
+              />
+              <Route
+                path="/kl"
+                element={
+                  <Protected>
+                    <KlEditionPage />
                   </Protected>
                 }
               />

--- a/frontend/src/pages/KlEditionPage.jsx
+++ b/frontend/src/pages/KlEditionPage.jsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Flex,
+  Heading,
+  Tabs,
+  TabList,
+  TabPanels,
+  Tab,
+  TabPanel,
+  Textarea,
+  Button,
+} from '@chakra-ui/react';
+import '../styles/KlEditionPage.css';
+
+export default function KlEditionPage() {
+  const [chat, setChat] = useState('');
+  const [messages, setMessages] = useState([]);
+  const ideUrl = window.env?.IDE_URL || import.meta.env.VITE_IDE_URL;
+  const n8nUrl = window.env?.N8N_URL || import.meta.env.VITE_N8N_URL;
+
+  const handleSend = () => {
+    if (chat.trim()) {
+      setMessages([...messages, { role: 'user', content: chat }]);
+      setChat('');
+    }
+  };
+
+  return (
+    <Box className="kl-edition-page" p={4}>
+      <Heading size="lg" mb={4}>
+        KL Edition
+      </Heading>
+      <Tabs isFitted variant="enclosed">
+        <TabList mb="1em">
+          <Tab>IDE</Tab>
+          <Tab>AutoFlows</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <Flex height="70vh" borderWidth="1px" borderRadius="md" overflow="hidden">
+              <Box
+                width="30%"
+                borderRightWidth="1px"
+                p={2}
+                display="flex"
+                flexDirection="column"
+              >
+                <Box flex="1" overflowY="auto">
+                  {messages.map((m, i) => (
+                    <Box key={i} mb={2} className="chat-message">
+                      {m.content}
+                    </Box>
+                  ))}
+                </Box>
+                <Textarea
+                  value={chat}
+                  onChange={(e) => setChat(e.target.value)}
+                  placeholder="Chat with the operator..."
+                  mb={2}
+                />
+                <Button onClick={handleSend} colorScheme="teal">
+                  Send
+                </Button>
+              </Box>
+              <Box flex="1" position="relative">
+                {ideUrl ? (
+                  <iframe src={ideUrl} title="KL IDE" className="ide-iframe" />
+                ) : (
+                  <Flex
+                    className="ide-placeholder"
+                    align="center"
+                    justify="center"
+                    height="100%"
+                  >
+                    IDE URL not configured
+                  </Flex>
+                )}
+              </Box>
+            </Flex>
+          </TabPanel>
+          <TabPanel>
+            <Box height="70vh" borderWidth="1px" borderRadius="md" overflow="hidden">
+              {n8nUrl ? (
+                <iframe src={n8nUrl} title="n8n workflow" className="workflow-iframe" />
+              ) : (
+                <Flex align="center" justify="center" height="100%">
+                  n8n URL not configured
+                </Flex>
+              )}
+            </Box>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Box>
+  );
+}

--- a/frontend/src/styles/KlEditionPage.css
+++ b/frontend/src/styles/KlEditionPage.css
@@ -1,0 +1,21 @@
+.kl-edition-page {
+  background: #f9f9f9;
+}
+
+.kl-edition-page .chat-message {
+  background-color: #edf2f7;
+  border-radius: 4px;
+  padding: 4px 8px;
+}
+
+.kl-edition-page .ide-placeholder {
+  background-color: #1a202c;
+  color: #fff;
+}
+
+.kl-edition-page .ide-iframe,
+.kl-edition-page .workflow-iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add KL Edition page with IDE and AutoFlows placeholders
- style KL Edition page
- register KL Edition route
- add backend container setup endpoint and script for remote IDE/n8n environments

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d2480b288320897d6795def86085