### PR TITLE
feat: extend classroom features

### DIFF
--- a/backend/controllers/classroomMaterials.js
+++ b/backend/controllers/classroomMaterials.js
@@ -1,0 +1,24 @@
+const { createMaterial, listMaterials } = require('../services/classroomMaterials');
+
+async function addMaterialHandler(req, res, next) {
+  try {
+    const { classroomId } = req.params;
+    const { type, title, url } = req.body;
+    const material = await createMaterial(classroomId, type, title, url);
+    res.status(201).json(material);
+  } catch (err) {
+    next(err);
+  }
+}
+
+async function listMaterialsHandler(req, res, next) {
+  try {
+    const { classroomId } = req.params;
+    const materials = await listMaterials(classroomId);
+    res.json(materials);
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { addMaterialHandler, listMaterialsHandler };

--- a/backend/models/classroomMaterials.js
+++ b/backend/models/classroomMaterials.js
@@ -1,0 +1,25 @@
+const { randomUUID } = require('crypto');
+
+// In-memory store mapping classroomId to array of materials
+const materialStore = new Map();
+
+function addMaterial(classroomId, type, title, url) {
+  const material = {
+    id: randomUUID(),
+    classroomId,
+    type,
+    title,
+    url,
+  };
+  if (!materialStore.has(classroomId)) {
+    materialStore.set(classroomId, []);
+  }
+  materialStore.get(classroomId).push(material);
+  return material;
+}
+
+function getMaterials(classroomId) {
+  return materialStore.get(classroomId) || [];
+}
+
+module.exports = { addMaterial, getMaterials };

--- a/backend/routes/classroomMaterials.js
+++ b/backend/routes/classroomMaterials.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+const { validate } = require('../middleware/validate');
+const { addMaterialHandler, listMaterialsHandler } = require('../controllers/classroomMaterials');
+const { classroomIdParamSchema, materialSchema } = require('../validation/classroomMaterials');
+
+router.post(
+  '/:classroomId/material',
+  validate(classroomIdParamSchema, 'params'),
+  validate(materialSchema, 'body'),
+  addMaterialHandler
+);
+
+router.get(
+  '/:classroomId/materials',
+  validate(classroomIdParamSchema, 'params'),
+  listMaterialsHandler
+);
+
+module.exports = router;

--- a/backend/services/classroomMaterials.js
+++ b/backend/services/classroomMaterials.js
@@ -1,0 +1,16 @@
+const model = require('../models/classroomMaterials');
+const logger = require('../utils/logger');
+
+async function createMaterial(classroomId, type, title, url) {
+  const material = model.addMaterial(classroomId, type, title, url);
+  logger.info('Classroom material created', { classroomId, type });
+  return material;
+}
+
+async function listMaterials(classroomId) {
+  const materials = model.getMaterials(classroomId);
+  logger.info('Classroom materials retrieved', { classroomId, count: materials.length });
+  return materials;
+}
+
+module.exports = { createMaterial, listMaterials };

--- a/backend/tests/classroomMaterials.test.js
+++ b/backend/tests/classroomMaterials.test.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('classroomMaterials routes', () => {
+  test('should define an Express router', () => {
+    const filePath = path.join(__dirname, '../routes/classroomMaterials.js');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect(content).toMatch(/express\.Router\(/);
+    expect(content).toMatch(/module\.exports\s*=\s*router/);
+  });
+});

--- a/backend/validation/classroomMaterials.js
+++ b/backend/validation/classroomMaterials.js
@@ -1,0 +1,13 @@
+const Joi = require('joi');
+
+const classroomIdParamSchema = Joi.object({
+  classroomId: Joi.string().guid({ version: 'uuidv4' }).required(),
+});
+
+const materialSchema = Joi.object({
+  type: Joi.string().valid('ppt', 'video', 'storage').required(),
+  title: Joi.string().required(),
+  url: Joi.string().uri().required(),
+});
+
+module.exports = { classroomIdParamSchema, materialSchema };

--- a/frontend/src/components/AssessmentCenter.jsx
+++ b/frontend/src/components/AssessmentCenter.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+
+export default function AssessmentCenter() {
+  return (
+    <Box className="assessment-center">
+      <Heading size="md" mb={2}>Assessments & Grading</Heading>
+      <Box mb={2}>Create quizzes and tests, manage assessments,</Box>
+      <Box mb={2}>and track grades with certification badges.</Box>
+      <Box>Collect reviews and testimonials from participants.</Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/ClassroomSections.jsx
+++ b/frontend/src/components/ClassroomSections.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+
+export default function ClassroomSections() {
+  return (
+    <Box className="classroom-sections">
+      <Heading size="md" mb={2}>Group Classes</Heading>
+      <Box mb={4}>Manage and join group class sessions.</Box>
+      <Heading size="md" mb={2}>Tutor Classes</Heading>
+      <Box mb={4}>One-on-one or small group tutor sessions.</Box>
+      <Heading size="md" mb={2}>Recorded Classes</Heading>
+      <Box mb={4}>Access your library of recorded lessons.</Box>
+      <Heading size="md" mb={2}>Calendar & Alerts</Heading>
+      <Box mb={4}>Configure schedules and receive alerts.</Box>
+      <Heading size="md" mb={2}>Teacher Releases</Heading>
+      <Box>View upcoming teacher drops and release schedules.</Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/CourseMaterials.jsx
+++ b/frontend/src/components/CourseMaterials.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+
+export default function CourseMaterials() {
+  return (
+    <Box className="course-materials">
+      <Heading size="md" mb={2}>Course Materials</Heading>
+      <Box mb={2}>Upload PowerPoint presentations, share recorded videos,</Box>
+      <Box>and link to self storage or platform storage locations.</Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/TeacherProfileBanner.jsx
+++ b/frontend/src/components/TeacherProfileBanner.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+
+export default function TeacherProfileBanner() {
+  return (
+    <Box className="teacher-profile-banner">
+      <Heading size="md" mb={2}>Teacher Profile Banner</Heading>
+      <Box mb={2}>Teachers can customize their banner profiles</Box>
+      <Box>and showcase videos advertising their services.</Box>
+    </Box>
+  );
+}

--- a/frontend/src/pages/ClassroomPage.jsx
+++ b/frontend/src/pages/ClassroomPage.jsx
@@ -2,6 +2,10 @@ import React, { useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { Box, Heading, VStack } from '@chakra-ui/react';
 import ClassroomChat from '../components/ClassroomChat.jsx';
+import ClassroomSections from '../components/ClassroomSections.jsx';
+import CourseMaterials from '../components/CourseMaterials.jsx';
+import AssessmentCenter from '../components/AssessmentCenter.jsx';
+import TeacherProfileBanner from '../components/TeacherProfileBanner.jsx';
 import '../styles/ClassroomPage.css';
 
 export default function ClassroomPage() {
@@ -25,6 +29,10 @@ export default function ClassroomPage() {
       <VStack spacing={4} align="stretch">
         <Box id="jitsi-container" className="video-container" />
         <ClassroomChat classroomId={id} />
+        <ClassroomSections />
+        <CourseMaterials />
+        <AssessmentCenter />
+        <TeacherProfileBanner />
       </VStack>
     </Box>
   );


### PR DESCRIPTION
## Summary
- add API routes to attach materials (ppt, video, storage links) to classrooms
- expand classroom page with sections for group/tutor classes, recorded sessions, schedules, materials, assessments and teacher promos

## Testing
- `npm test` (backend)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6893d9e1e740832090c050614f080ea6