### PR TITLE
Add root database setup script

### DIFF
--- a/db_setup
+++ b/db_setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine directory of this script
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Run the database setup using dotenv and existing backend script
+node -r "$dir/backend/node_modules/dotenv/config" "$dir/backend/scripts/dbSetup.js" "$@"


### PR DESCRIPTION
## Summary
- add root-level `db_setup` script for database migrations

## Testing
- `./db_setup` *(fails: connect ECONNREFUSED 127.0.0.1:5432)*
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893dbab4f908320abdbae13e526b0a7