### PR TITLE
feat: add task marketplace with bidding

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -5,6 +5,7 @@ const products = require('./data/products.json');
 const authRoutes = require('./routes/auth');
 const landingRoutes = require('./routes/landing');
 const n8nRoutes = require('./routes/n8n');
+const tasksRoutes = require('./routes/tasks');
 const api = require("./api");
 const { initDb } = require('./utils/db');
 const logger = require('./utils/logger');
@@ -20,6 +21,7 @@ app.get('/operations/retail/products', (req, res) => {
 app.use('/auth', authRoutes);
 app.use('/landing', landingRoutes);
 app.use('/n8n', n8nRoutes);
+app.use('/tasks', tasksRoutes);
 
 // 404 handler
 app.use((req, res, next) => {

--- a/backend/controllers/taskMarketplace.js
+++ b/backend/controllers/taskMarketplace.js
@@ -1,0 +1,58 @@
+const marketplace = require('../models/taskMarketplace');
+
+async function createTask(req, res) {
+  try {
+    const task = marketplace.createTask(req.body);
+    res.status(201).json(task);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+async function listTasks(req, res) {
+  const tasks = marketplace.listTasks();
+  res.json(tasks);
+}
+
+async function createProposal(req, res) {
+  const { taskId } = req.params;
+  const proposal = marketplace.createProposal({ taskId, ...req.body });
+  if (!proposal) return res.status(404).json({ error: 'Task not found' });
+  res.status(201).json(proposal);
+}
+
+async function listProposals(req, res) {
+  const { taskId } = req.params;
+  const list = marketplace.listProposals(taskId);
+  res.json(list);
+}
+
+async function acceptProposal(req, res) {
+  const { taskId, proposalId } = req.params;
+  const result = marketplace.acceptProposal(taskId, proposalId);
+  if (!result) return res.status(404).json({ error: 'Not found' });
+  res.json(result);
+}
+
+async function closeTask(req, res) {
+  const { taskId } = req.params;
+  const task = marketplace.closeTask(taskId);
+  if (!task) return res.status(404).json({ error: 'Task not found' });
+  res.json(task);
+}
+
+async function findNearby(req, res) {
+  const { lat, lng, radiusKm } = req.query;
+  const tasks = marketplace.findTasksNearby({ lat: Number(lat), lng: Number(lng), radiusKm: Number(radiusKm) });
+  res.json(tasks);
+}
+
+module.exports = {
+  createTask,
+  listTasks,
+  createProposal,
+  listProposals,
+  acceptProposal,
+  closeTask,
+  findNearby,
+};

--- a/backend/models/taskMarketplace.js
+++ b/backend/models/taskMarketplace.js
@@ -1,0 +1,94 @@
+const { randomUUID } = require('crypto');
+const { addPost } = require('./liveFeed');
+
+const tasks = new Map();
+const proposals = new Map();
+
+function createTask({ title, description = '', price = 0, creatorId, maxTaskers = 1, postcode = null, location = null }) {
+  const id = randomUUID();
+  const task = {
+    id,
+    title,
+    description,
+    price,
+    creatorId,
+    maxTaskers,
+    postcode,
+    location,
+    status: 'open',
+    assignees: [],
+    createdAt: new Date(),
+  };
+  tasks.set(id, task);
+  addPost({ author: creatorId, content: `Task posted: ${title}`, category: 'tasks' });
+  return task;
+}
+
+function listTasks() {
+  return Array.from(tasks.values());
+}
+
+function createProposal({ taskId, bidderId, amount, message }) {
+  if (!tasks.has(taskId)) return null;
+  const id = randomUUID();
+  const proposal = { id, taskId, bidderId, amount, message: message || '', status: 'pending', createdAt: new Date() };
+  proposals.set(id, proposal);
+  return proposal;
+}
+
+function listProposals(taskId) {
+  return Array.from(proposals.values()).filter((p) => p.taskId === taskId);
+}
+
+function acceptProposal(taskId, proposalId) {
+  const task = tasks.get(taskId);
+  const proposal = proposals.get(proposalId);
+  if (!task || !proposal || proposal.taskId !== taskId) return null;
+  proposal.status = 'accepted';
+  task.assignees.push(proposal.bidderId);
+  if (task.assignees.length >= task.maxTaskers) {
+    task.status = 'assigned';
+  }
+  tasks.set(taskId, task);
+  proposals.set(proposalId, proposal);
+  return { task, proposal };
+}
+
+function closeTask(taskId) {
+  const task = tasks.get(taskId);
+  if (!task) return null;
+  task.status = 'closed';
+  tasks.set(taskId, task);
+  return task;
+}
+
+function haversineDistance(a, b) {
+  const toRad = (deg) => (deg * Math.PI) / 180;
+  const R = 6371;
+  const dLat = toRad((b.lat || 0) - (a.lat || 0));
+  const dLon = toRad((b.lng || 0) - (a.lng || 0));
+  const lat1 = toRad(a.lat || 0);
+  const lat2 = toRad(b.lat || 0);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.sin(dLon / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+  const c = 2 * Math.atan2(Math.sqrt(h), Math.sqrt(1 - h));
+  return R * c;
+}
+
+function findTasksNearby({ lat, lng, radiusKm }) {
+  const origin = { lat, lng };
+  return Array.from(tasks.values()).filter(
+    (t) => t.location && haversineDistance(origin, t.location) <= radiusKm
+  );
+}
+
+module.exports = {
+  createTask,
+  listTasks,
+  createProposal,
+  listProposals,
+  acceptProposal,
+  closeTask,
+  findTasksNearby,
+};

--- a/backend/routes/tasks.js
+++ b/backend/routes/tasks.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const ctrl = require('../controllers/taskMarketplace');
+
+const router = express.Router();
+
+router.post('/', ctrl.createTask);
+router.get('/', ctrl.listTasks);
+router.post('/:taskId/proposals', ctrl.createProposal);
+router.get('/:taskId/proposals', ctrl.listProposals);
+router.post('/:taskId/proposals/:proposalId/accept', ctrl.acceptProposal);
+router.post('/:taskId/close', ctrl.closeTask);
+router.get('/nearby/search', ctrl.findNearby);
+
+module.exports = router;

--- a/backend/tests/taskMarketplace.test.js
+++ b/backend/tests/taskMarketplace.test.js
@@ -1,0 +1,18 @@
+const marketplace = require('../models/taskMarketplace');
+
+describe('task marketplace model', () => {
+  test('supports task creation, bidding and distance matching', () => {
+    const task = marketplace.createTask({
+      title: 'Fix sink',
+      creatorId: 'u1',
+      price: 100,
+      postcode: '2000',
+      location: { lat: -33.86, lng: 151.21 },
+    });
+    const proposal = marketplace.createProposal({ taskId: task.id, bidderId: 'u2', amount: 90 });
+    const result = marketplace.acceptProposal(task.id, proposal.id);
+    expect(result.task.assignees).toContain('u2');
+    const nearby = marketplace.findTasksNearby({ lat: -33.86, lng: 151.2, radiusKm: 5 });
+    expect(nearby.find((t) => t.id === task.id)).toBeTruthy();
+  });
+});

--- a/backend/tests/tasks.test.js
+++ b/backend/tests/tasks.test.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('tasks routes', () => {
+  test('should define an Express router', () => {
+    const filePath = path.join(__dirname, '../routes/tasks.js');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect(content).toMatch(/express\.Router\(/);
+    expect(content).toMatch(/module\.exports\s*=\s*router/);
+  });
+});


### PR DESCRIPTION
## Summary
- add task marketplace model supporting bidding, multi-taskers, and distance matching
- expose task marketplace APIs and register new routes

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893dc548b2883208c7f33161100a731