### PR TITLE
feat: enhance live feed with stories and news

### DIFF
--- a/frontend/api/liveFeed.js
+++ b/frontend/api/liveFeed.js
@@ -22,11 +22,23 @@
     return res.json();
   }
 
+  async function getStories(){
+    const res = await apiFetch('/api/live-feed/stories');
+    if(!res.ok) throw new Error('Failed to load stories');
+    return res.json();
+  }
+
+  async function getNews(){
+    const res = await apiFetch('/api/live-feed/news');
+    if(!res.ok) throw new Error('Failed to load news');
+    return res.json();
+  }
+
   async function likePost(postId){
     const res = await apiFetch(`/api/live-feed/posts/${postId}/like`, { method: 'POST' });
     if(!res.ok) throw new Error('Failed to like post');
     return res.json();
   }
 
-  global.liveFeedAPI = { getPosts, createPost, getEvents, likePost };
+  global.liveFeedAPI = { getPosts, createPost, getEvents, likePost, getStories, getNews };
 })(window);

--- a/frontend/views/live_feed.css
+++ b/frontend/views/live_feed.css
@@ -5,3 +5,15 @@
 .live-event {
   background-color: #ffffff;
 }
+
+.story-bubbles,
+.event-bubbles {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  padding-bottom: 1rem;
+}
+
+.news-item {
+  background-color: #ffffff;
+}

--- a/frontend/views/live_feed.jsx
+++ b/frontend/views/live_feed.jsx
@@ -1,9 +1,47 @@
 const { useEffect, useState } = React;
-const { Box, Flex, Button, Textarea, Select, Heading, VStack } = ChakraUI;
+const {
+  Box,
+  Flex,
+  Button,
+  Textarea,
+  Select,
+  Heading,
+  VStack,
+  HStack,
+  Avatar,
+  Text,
+} = ChakraUI;
+
+function StoryBubble({ story }) {
+  return (
+    <VStack spacing={1} className="story-bubble">
+      <Avatar size="lg" name={story.author} src={story.image} />
+      <Text fontSize="sm" noOfLines={1} maxW="16">
+        {story.author}
+      </Text>
+    </VStack>
+  );
+}
+
+function EventBubble({ event }) {
+  return (
+    <VStack spacing={1} className="event-bubble">
+      <Avatar size="md" name={event.title} src={event.image} />
+      <Text fontSize="xs" noOfLines={1} textAlign="center" maxW="20">
+        {event.title}
+      </Text>
+      <Button size="xs" colorScheme="blue">
+        Join
+      </Button>
+    </VStack>
+  );
+}
 
 function LiveFeed() {
   const [posts, setPosts] = useState([]);
   const [events, setEvents] = useState([]);
+  const [stories, setStories] = useState([]);
+  const [news, setNews] = useState([]);
   const [content, setContent] = useState('');
   const [category, setCategory] = useState('');
 
@@ -25,10 +63,55 @@ function LiveFeed() {
     }
   }
 
+  async function fetchStories() {
+    try {
+      const data = await liveFeedAPI.getStories();
+      setStories(data);
+    } catch (err) {
+      console.error('Failed to load stories', err);
+    }
+  }
+
+  async function fetchNews() {
+    try {
+      const data = await liveFeedAPI.getNews();
+      setNews(data);
+    } catch (err) {
+      console.error('Failed to load news', err);
+    }
+  }
+
   useEffect(() => {
     fetchPosts();
     fetchEvents();
+    fetchStories();
+    fetchNews();
   }, []);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (!document.hidden) {
+        fetchPosts(category);
+        fetchEvents();
+        fetchStories();
+        fetchNews();
+      }
+    }, 60000);
+    return () => clearInterval(interval);
+  }, [category]);
+
+  useEffect(() => {
+    function handleVisibility() {
+      if (!document.hidden) {
+        fetchPosts(category);
+        fetchEvents();
+        fetchStories();
+        fetchNews();
+      }
+    }
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [category]);
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -42,8 +125,18 @@ function LiveFeed() {
   }
 
   return (
-    <Flex className="live-feed" p={4} align="flex-start">
-      <Box flex="3">
+    <Flex
+      className="live-feed"
+      p={4}
+      align="flex-start"
+      flexDir={{ base: 'column', md: 'row' }}
+    >
+      <Box flex={{ base: 1, md: 3 }}>
+        <HStack spacing={4} overflowX="auto" pb={4} className="story-bubbles">
+          {stories.map(story => (
+            <StoryBubble key={story.id} story={story} />
+          ))}
+        </HStack>
         <Box as="form" onSubmit={handleSubmit} mb={4}>
           <Textarea
             placeholder="Share an update..."
@@ -70,19 +163,36 @@ function LiveFeed() {
             <Button type="submit" colorScheme="blue">Post</Button>
           </Flex>
         </Box>
-          {posts.map(post => (
-            <FeedPost key={post.id} post={post} />
-          ))}
+        {posts.map(post => (
+          <FeedPost key={post.id} post={post} />
+        ))}
       </Box>
-      <Box flex="1" ml={4}>
-        <Heading size="md" mb={2}>Live Events</Heading>
-        <VStack spacing={2} align="stretch">
-          {events.map(ev => (
-            <Box key={ev.id} className="live-event" borderWidth="1px" borderRadius="md" p={2} bg="white">
-              {ev.title}
+      <Box flex={{ base: 1, md: 1 }} ml={{ md: 4 }} mt={{ base: 4, md: 0 }}>
+        <Heading size="sm" mb={2}>
+          News
+        </Heading>
+        <VStack spacing={2} align="stretch" mb={4}>
+          {news.map(item => (
+            <Box
+              key={item.id}
+              className="news-item"
+              borderWidth="1px"
+              borderRadius="md"
+              p={2}
+              bg="white"
+            >
+              {item.title}
             </Box>
           ))}
         </VStack>
+        <Heading size="md" mb={2}>
+          Live Now
+        </Heading>
+        <HStack spacing={4} overflowX="auto" className="event-bubbles">
+          {events.map(ev => (
+            <EventBubble key={ev.id} event={ev} />
+          ))}
+        </HStack>
       </Box>
     </Flex>
   );


### PR DESCRIPTION
## Summary
- add responsive story bubbles and live webinar bubbles to live feed
- include news stream and periodic refresh for posts and events
- extend API for stories and news support

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893ddde6ca48320a2b45bf9fdcb1d08