### PR TITLE
Add root database setup script

### DIFF
--- a/backend/scripts/dbSetup.js
+++ b/backend/scripts/dbSetup.js
@@ -19,7 +19,9 @@ async function runMigrations() {
   const dir = path.join(__dirname, '..', 'database');
   const files = fs
     .readdirSync(dir)
-    .filter(f => f.endsWith('.sql'))
+    // `database.sql` is an aggregate file that references the others; we execute
+    // each file individually so skip it to avoid duplicate/erroneous execution.
+    .filter(f => f.endsWith('.sql') && f !== 'database.sql')
     .sort();
 
   if (type === 'mysql') {

--- a/db_setup
+++ b/db_setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine directory of this script
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Run the database setup using dotenv and existing backend script
+node -r "$dir/backend/node_modules/dotenv/config" "$dir/backend/scripts/dbSetup.js" "$@"


### PR DESCRIPTION
## Summary
- add root-level `db_setup` script for database migrations
- skip aggregate `database.sql` during migrations to prevent duplicate or malformed execution

## Testing
- `service postgresql start`
- `./db_setup`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893dbab4f908320abdbae13e526b0a7