### PR TITLE
Enhance Experience Launchpad matching with field and compensation filters

### DIFF
--- a/backend/models/opportunity.js
+++ b/backend/models/opportunity.js
@@ -18,6 +18,10 @@ function create({
   compensation = 0,
   experienceLevel = '',
   status = 'open',
+  field = '',
+  offering = '',
+  isPaid = false,
+  employmentType = 'freelance',
 }) {
   const id = randomUUID();
   const now = new Date();
@@ -38,6 +42,10 @@ function create({
     compensation,
     experienceLevel,
     status,
+    field,
+    offering,
+    isPaid,
+    employmentType,
     views: 0,
     applications: 0,
     matches: 0,

--- a/backend/services/experienceDashboard.js
+++ b/backend/services/experienceDashboard.js
@@ -11,6 +11,7 @@ function getDashboardData(user = {}) {
   const role = user.role || 'participant';
   const opportunities = Opportunity.list();
   let quickStats = {};
+  let notifications = [];
 
   if (role === 'provider') {
     const myOpps = opportunities.filter(o => o.organizationId === user.id);
@@ -26,7 +27,36 @@ function getDashboardData(user = {}) {
       skillsAcquired: participant?.profile?.skills?.length || 0,
       newOpportunities: opportunities.length,
     };
+
+    const prefs = participant?.preferences || {};
+    const looking = prefs.looking !== false; // default to true
+    const filtered = opportunities.filter(o => {
+      if (prefs.field && o.field !== prefs.field) return false;
+      if (typeof prefs.isPaid !== 'undefined' && o.isPaid !== prefs.isPaid) return false;
+      if (prefs.employmentType && o.employmentType !== prefs.employmentType) return false;
+      if (prefs.offering && o.offering !== prefs.offering) return false;
+      return true;
+    });
+    const recommendations = looking ? filtered.slice(0, 3).map(o => ({
+      id: o.id,
+      title: o.title,
+      description: o.description,
+    })) : [];
+
+    if (prefs.autoNotify && looking) {
+      notifications = recommendations.map(r => ({ message: `New match: ${r.title}` }));
+    }
+
+    logger.info('Experience dashboard data compiled', { userId: user.id, role });
+
+    return {
+      quickStats,
+      notifications,
+      recommendations,
+    };
   }
+
+  logger.info('Experience dashboard data compiled', { userId: user.id, role });
 
   const recommendations = opportunities.slice(0, 3).map(o => ({
     id: o.id,
@@ -34,11 +64,9 @@ function getDashboardData(user = {}) {
     description: o.description,
   }));
 
-  logger.info('Experience dashboard data compiled', { userId: user.id, role });
-
   return {
     quickStats,
-    notifications: [],
+    notifications,
     recommendations,
   };
 }

--- a/backend/services/opportunity.js
+++ b/backend/services/opportunity.js
@@ -20,6 +20,14 @@ async function listOpportunities(filters = {}, { page = 1, limit = 10 } = {}) {
   if (filters.duration) results = results.filter(o => o.duration === filters.duration);
   if (filters.experienceLevel) results = results.filter(o => o.experienceLevel === filters.experienceLevel);
   if (filters.status) results = results.filter(o => o.status === filters.status);
+  if (filters.field) results = results.filter(o => o.field === filters.field);
+  if (filters.offering) results = results.filter(o => o.offering === filters.offering);
+  if (typeof filters.isPaid !== 'undefined') {
+    const paid = filters.isPaid === 'true' || filters.isPaid === true;
+    results = results.filter(o => o.isPaid === paid);
+  }
+  if (filters.employmentType)
+    results = results.filter(o => o.employmentType === filters.employmentType);
   if (filters.keyword) {
     const kw = String(filters.keyword).toLowerCase();
     results = results.filter(o =>
@@ -31,7 +39,6 @@ async function listOpportunities(filters = {}, { page = 1, limit = 10 } = {}) {
     results = results.filter(o => o.compensation >= Number(filters.compensationMin));
   if (filters.compensationMax)
     results = results.filter(o => o.compensation <= Number(filters.compensationMax));
-  if (filters.status) results = results.filter(o => o.status === filters.status);
   const total = results.length;
   const start = (page - 1) * limit;
   const opportunities = results.slice(start, start + limit);

--- a/backend/validation/opportunity.js
+++ b/backend/validation/opportunity.js
@@ -12,11 +12,14 @@ const opportunityQuerySchema = Joi.object({
   category: Joi.string().optional(),
   duration: Joi.string().optional(),
   experienceLevel: Joi.string().optional(),
-  status: Joi.string().valid('open', 'closed').optional(),
+  status: Joi.string().valid('open', 'in_progress', 'closed').optional(),
   keyword: Joi.string().optional(),
   compensationMin: Joi.number().optional(),
   compensationMax: Joi.number().optional(),
-  status: Joi.string().valid('open', 'in_progress', 'closed').optional(),
+  field: Joi.string().optional(),
+  offering: Joi.string().optional(),
+  isPaid: Joi.boolean().optional(),
+  employmentType: Joi.string().valid('freelance', 'employment').optional(),
   page: Joi.number().integer().min(1).default(1),
   limit: Joi.number().integer().min(1).max(100).default(10),
 });
@@ -35,7 +38,11 @@ const createOpportunitySchema = Joi.object({
   duration: Joi.string().allow('').optional(),
   compensation: Joi.number().optional(),
   experienceLevel: Joi.string().allow('').optional(),
-  status: Joi.string().valid('open', 'closed').optional(),
+  status: Joi.string().valid('open', 'in_progress', 'closed').optional(),
+  field: Joi.string().allow('').optional(),
+  offering: Joi.string().allow('').optional(),
+  isPaid: Joi.boolean().optional(),
+  employmentType: Joi.string().valid('freelance', 'employment').optional(),
 });
 
 const updateOpportunitySchema = createOpportunitySchema.fork(
@@ -54,13 +61,12 @@ const updateOpportunitySchema = createOpportunitySchema.fork(
     'compensation',
     'experienceLevel',
     'status',
+    'field',
+    'offering',
+    'isPaid',
+    'employmentType',
   ],
-  status: Joi.string().valid('open', 'in_progress', 'closed').optional(),
-});
-
-const updateOpportunitySchema = createOpportunitySchema.fork(
-  ['title', 'description', 'location', 'remote', 'commitmentTime', 'urgency', 'requirements', 'multimedia', 'isFeatured', 'status'],
-  (schema) => schema.optional()
+  schema => schema.optional()
 );
 
 module.exports = {
@@ -69,3 +75,4 @@ module.exports = {
   createOpportunitySchema,
   updateOpportunitySchema,
 };
+

--- a/backend/validation/participant.js
+++ b/backend/validation/participant.js
@@ -9,6 +9,12 @@ const registerSchema = Joi.object({
 const preferencesSchema = Joi.object({
   topics: Joi.array().items(Joi.string()).default([]),
   goals: Joi.string().max(500).allow('', null),
+  field: Joi.string().allow('', null),
+  isPaid: Joi.boolean().optional(),
+  employmentType: Joi.string().valid('freelance', 'employment').optional(),
+  offering: Joi.string().allow('', null),
+  looking: Joi.boolean().optional(),
+  autoNotify: Joi.boolean().optional(),
 });
 
 const paymentSchema = Joi.object({


### PR DESCRIPTION
## Summary
- extend Opportunity model with field, offering, paid flag, and employment type
- filter opportunities and recommend matches based on participant preferences
- validate new opportunity and participant fields

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893de9ef7c88320947908f77d614067