### PR TITLE
refactor: streamline api base and db setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-API_BASE_URL=http://localhost:5000
+API_BASE_URL=/api
 
 DEEPSEEK_API_KEY=
 GEMINI_API_KEY=
@@ -26,10 +26,12 @@ JITSI_ROOM_PREFIX=workhouse-interview
 APP_ID=workhouse
 APP_URL=http://localhost:5173
 DB_HOST=localhost
+DB_PORT=5432
 DB_USER=workhouse
 DB_PASSWORD=workhouse
 DB_NAME=workhouse
-VITE_API_BASE_URL=http://localhost:5000
+DB_TYPE=postgres
+VITE_API_BASE_URL=/api
 VITE_AVATAR_API=https://api.dicebear.com/6.x/initials/svg
 VITE_JITSI_DOMAIN=https://meet.jit.si
 VITE_JITSI_ROOM_PREFIX=workhouse-interview

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-API_BASE_URL=http://localhost:5000
+API_BASE_URL=/api
 
 DEEPSEEK_API_KEY=
 GEMINI_API_KEY=
@@ -28,12 +28,13 @@ JITSI_ROOM_PREFIX=workhouse-interview
 APP_ID=workhouse
 APP_URL=http://localhost:5173
 DB_HOST=localhost
+DB_PORT=5432
 DB_USER=workhouse
 DB_PASSWORD=workhouse
 DB_NAME=workhouse
-DB_PORT=3306
+DB_TYPE=postgres
 
-VITE_API_BASE_URL=http://localhost:5000
+VITE_API_BASE_URL=/api
 VITE_AVATAR_API=https://api.dicebear.com/6.x/initials/svg
 VITE_JITSI_DOMAIN=https://meet.jit.si
 VITE_JITSI_ROOM_PREFIX=workhouse-interview

--- a/app.js
+++ b/app.js
@@ -18,7 +18,10 @@ app.use(apiBase, backend);
 // Expose runtime configuration to the frontend
 app.get('/config.js', (req, res) => {
   res.type('application/javascript');
-  res.send(`window.API_BASE_URL = '${apiBase}';`);
+  res.send(
+    `window.API_BASE_URL='${apiBase}';` +
+    `window.env=Object.assign(window.env||{}, {API_BASE_URL:'${apiBase}'});`
+  );
 });
 
 // Fallback to index.html for any other request (SPA behavior)

--- a/db_setup
+++ b/db_setup
@@ -5,4 +5,5 @@ set -euo pipefail
 dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Run the database setup using dotenv and existing backend script
-node -r "$dir/backend/node_modules/dotenv/config" "$dir/backend/scripts/dbSetup.js" "$@"
+# Rely on Node's module resolution for dotenv rather than hardcoding paths
+node -r dotenv/config "$dir/backend/scripts/dbSetup.js" "$@"

--- a/frontend/api.js
+++ b/frontend/api.js
@@ -1,11 +1,13 @@
+const base = window.env?.API_BASE_URL || window.API_BASE_URL || '/api';
+
 window.api = {
   async fetchProducts() {
-    const res = await fetch(`${window.API_BASE_URL}/operations/retail/products`);
+    const res = await fetch(`${base}/operations/retail/products`);
     if (!res.ok) throw new Error('Failed to load products');
     return res.json();
   },
   async fetchProduct(id) {
-    const res = await fetch(`${window.API_BASE_URL}/operations/retail/product/${id}`);
+    const res = await fetch(`${base}/operations/retail/product/${id}`);
     if (!res.ok) throw new Error('Failed to load product');
     return res.json();
   }

--- a/frontend/api/applications.js
+++ b/frontend/api/applications.js
@@ -1,28 +1,12 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  if (res.status === 204) return {};
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function applyToOpportunity(opportunityId, message = '') {
-  return request('/applications', {
+  return apiFetch('/applications', {
     method: 'POST',
     body: JSON.stringify({ opportunityId, message }),
   });
 }
 
 export function getUserApplications() {
-  return request('/applications/user');
+  return apiFetch('/applications/user');
 }

--- a/frontend/api/billing.js
+++ b/frontend/api/billing.js
@@ -1,48 +1,33 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch, { API_BASE_URL } from '../utils/api.js';
 
 export function fetchSubscription() {
-  return request('/billing/subscription');
+  return apiFetch('/billing/subscription');
 }
 
 export function updateSubscription(data) {
-  return request('/billing/subscription', {
+  return apiFetch('/billing/subscription', {
     method: 'PUT',
     body: JSON.stringify(data),
   });
 }
 
 export function fetchPaymentMethods() {
-  return request('/billing/payment-methods');
+  return apiFetch('/billing/payment-methods');
 }
 
 export function addPaymentMethod(data) {
-  return request('/billing/payment-methods', {
+  return apiFetch('/billing/payment-methods', {
     method: 'POST',
     body: JSON.stringify(data),
   });
 }
 
 export function removePaymentMethod(id) {
-  return request(`/billing/payment-methods/${id}`, { method: 'DELETE' });
+  return apiFetch(`/billing/payment-methods/${id}`, { method: 'DELETE' });
 }
 
 export function fetchTransactions() {
-  return request('/billing/transactions');
+  return apiFetch('/billing/transactions');
 }
 
 export async function downloadInvoice(id) {

--- a/frontend/api/content.js
+++ b/frontend/api/content.js
@@ -1,47 +1,26 @@
 (function (global) {
-  const baseUrl = (global.env && global.env.API_BASE_URL) || '';
+  const request = global.apiFetch;
 
-  function headers() {
-    const token = localStorage.getItem('token');
-    return {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    };
+  function listContent() {
+    return request('/content');
   }
 
-  async function listContent() {
-    const res = await fetch(`${baseUrl}/content`, { headers: headers() });
-    if (!res.ok) throw new Error('Failed to fetch content');
-    return res.json();
-  }
-
-  async function createContent(data) {
-    const res = await fetch(`${baseUrl}/content/create`, {
+  function createContent(data) {
+    return request('/content/create', {
       method: 'POST',
-      headers: headers(),
       body: JSON.stringify(data),
     });
-    if (!res.ok) throw new Error('Failed to create content');
-    return res.json();
   }
 
-  async function updateContent(id, data) {
-    const res = await fetch(`${baseUrl}/content/${id}`, {
+  function updateContent(id, data) {
+    return request(`/content/${id}`, {
       method: 'PUT',
-      headers: headers(),
       body: JSON.stringify(data),
     });
-    if (!res.ok) throw new Error('Failed to update content');
-    return res.json();
   }
 
-  async function deleteContent(id) {
-    const res = await fetch(`${baseUrl}/content/${id}`, {
-      method: 'DELETE',
-      headers: headers(),
-    });
-    if (!res.ok) throw new Error('Failed to delete content');
-    return true;
+  function deleteContent(id) {
+    return request(`/content/${id}`, { method: 'DELETE' });
   }
 
   global.contentAPI = { listContent, createContent, updateContent, deleteContent };

--- a/frontend/api/contentLibrary.js
+++ b/frontend/api/contentLibrary.js
@@ -1,24 +1,9 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function fetchContentLibrary() {
-  return request('/content-library');
+  return apiFetch('/content-library');
 }
 
 export function fetchContentDetails(type, id) {
-  return request(`/content-library/${type}/${id}`);
+  return apiFetch(`/content-library/${type}/${id}`);
 }

--- a/frontend/api/contracts.js
+++ b/frontend/api/contracts.js
@@ -1,30 +1,15 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}/contracts${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 function fetchProposals(contractId) {
-  return request(`/${contractId}/proposals`);
+  return apiFetch(`/contracts/${contractId}/proposals`);
 }
 
 function fetchInvoices(contractId) {
-  return request(`/${contractId}/invoices`);
+  return apiFetch(`/contracts/${contractId}/invoices`);
 }
 
 function submitInvoice(contractId, data) {
-  return request(`/${contractId}/invoices`, {
+  return apiFetch(`/contracts/${contractId}/invoices`, {
     method: 'POST',
     body: JSON.stringify(data),
   });

--- a/frontend/api/courses.js
+++ b/frontend/api/courses.js
@@ -1,20 +1,5 @@
 (function(global){
-  const baseUrl = (global.env && global.env.API_BASE_URL) || '/api';
-
-  async function request(path, options = {}) {
-    const token = localStorage.getItem('token');
-    const headers = {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...options.headers,
-    };
-    const res = await fetch(`${baseUrl}${path}`, { ...options, headers });
-    if (!res.ok) {
-      const msg = await res.text();
-      throw new Error(msg || 'Request failed');
-    }
-    return res.json();
-  }
+  const request = global.apiFetch;
 
   function listCourses(){
     return request('/courses');

--- a/frontend/api/disputes.js
+++ b/frontend/api/disputes.js
@@ -1,48 +1,27 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}/disputes${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function createDispute(data) {
-  return request('/create', { method: 'POST', body: JSON.stringify(data) });
+  return apiFetch('/disputes/create', { method: 'POST', body: JSON.stringify(data) });
 }
 
 export function respondToDispute(disputeId, data) {
-  return request(`/${disputeId}/respond`, { method: 'POST', body: JSON.stringify(data) });
+  return apiFetch(`/disputes/${disputeId}/respond`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
 }
 
 export function getDispute(disputeId) {
-  return request(`/${disputeId}`);
+  return apiFetch(`/disputes/${disputeId}`);
 }
 
-export function listDisputes({ role, userId } = {}) {
-  const params = new URLSearchParams();
-  if (userId) {
-    if (role === 'disputee') params.set('disputeeId', userId);
-    else params.set('userId', userId);
-  }
-  const query = params.toString();
-  return request(query ? `?${query}` : '');
-}
-function listDisputes(params = {}) {
+export function listDisputes(params = {}) {
   const query = new URLSearchParams(params).toString();
-  return request(query ? `?${query}` : '');
+  return apiFetch(`/disputes${query ? `?${query}` : ''}`);
 }
 
-function postDisputeMessage(disputeId, message) {
-  return request(`/${disputeId}/messages`, {
+export function postDisputeMessage(disputeId, message) {
+  return apiFetch(`/disputes/${disputeId}/messages`, {
     method: 'POST',
     body: JSON.stringify({ message }),
   });

--- a/frontend/api/education.js
+++ b/frontend/api/education.js
@@ -1,26 +1,11 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function fetchEducationOverview() {
-  return request('/education-analytics/courses/overview');
+  return apiFetch('/education-analytics/courses/overview');
 }
 
 export function fetchUserEngagement(userId) {
-  return request(`/education-analytics/user-engagement/${userId}`);
+  return apiFetch(`/education-analytics/user-engagement/${userId}`);
 }
 (function(global){
   async function listCourses(){

--- a/frontend/api/freelancers.js
+++ b/frontend/api/freelancers.js
@@ -1,13 +1,7 @@
 (function(global){
-  const baseUrl = (global.env && global.env.API_BASE_URL) || '';
-
   async function searchFreelancers(params={}){
     const query = new URLSearchParams(params).toString();
-    const res = await fetch(`${baseUrl}/freelancers/search?${query}`, {
-      headers: { 'Content-Type': 'application/json', ...(localStorage.getItem('token') ? { 'Authorization': `Bearer ${localStorage.getItem('token')}` } : {}) }
-    });
-    if(!res.ok) throw new Error('Failed to fetch freelancers');
-    return res.json();
+    return global.apiFetch(`/freelancers/search?${query}`);
   }
 
   global.freelancersAPI = { searchFreelancers };

--- a/frontend/api/headhunter.js
+++ b/frontend/api/headhunter.js
@@ -1,56 +1,41 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function searchJobSeekers(params = {}) {
   const qs = new URLSearchParams();
   Object.entries(params).forEach(([key, value]) => {
     if (value !== undefined && value !== '') qs.append(key, value);
   });
-  return request(`/headhunter/search-job-seekers?${qs.toString()}`);
+  return apiFetch(`/headhunter/search-job-seekers?${qs.toString()}`);
 }
 
 export function getRecommendations() {
-  return request('/headhunter/recommendations');
+  return apiFetch('/headhunter/recommendations');
 }
 
 export function fetchTasks() {
-  return request('/headhunter/tasks');
+  return apiFetch('/headhunter/tasks');
 }
 
 export function updateTaskStatus(id, status) {
-  return request(`/headhunter/tasks/${id}`, {
+  return apiFetch(`/headhunter/tasks/${id}`, {
     method: 'PATCH',
     body: JSON.stringify({ status }),
   });
 }
 
 export function fetchJobAllocations() {
-  return request('/headhunter/job-allocations');
+  return apiFetch('/headhunter/job-allocations');
 }
 
 export function allocateJob(jobId, headhunterId) {
-  return request('/headhunter/job-allocations', {
+  return apiFetch('/headhunter/job-allocations', {
     method: 'POST',
     body: JSON.stringify({ jobId, headhunterId }),
   });
 }
 
 export function fetchHeadhunters() {
-  return request('/headhunter/list');
+  return apiFetch('/headhunter/list');
 }
 
 export default {

--- a/frontend/api/interviews.js
+++ b/frontend/api/interviews.js
@@ -1,48 +1,33 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function scheduleInterview(data) {
-  return request('/interviews', {
+  return apiFetch('/interviews', {
     method: 'POST',
     body: JSON.stringify(data),
   });
 }
 
 export function getUserInterviews() {
-  return request('/interviews/user');
+  return apiFetch('/interviews/user');
 }
 
 export function getEmployerInterviews() {
-  return request('/interviews/employer');
+  return apiFetch('/interviews/employer');
 }
 
 export function updateInterviewStatus(id, status) {
-  return request(`/interviews/${id}/status`, {
+  return apiFetch(`/interviews/${id}/status`, {
     method: 'PUT',
     body: JSON.stringify({ status }),
   });
 }
 
 export function getInterview(id) {
-  return request(`/interviews/${id}`);
+  return apiFetch(`/interviews/${id}`);
 }
 
 export function addNote(id, text) {
-  return request(`/interviews/${id}/notes`, {
+  return apiFetch(`/interviews/${id}/notes`, {
     method: 'POST',
     body: JSON.stringify({ text }),
   });

--- a/frontend/api/jobs.js
+++ b/frontend/api/jobs.js
@@ -1,56 +1,36 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function fetchJobs(agencyId) {
-  return request(`/agency/${agencyId}/jobs`);
+  return apiFetch(`/agency/${agencyId}/jobs`);
 }
 
 export function createJob(agencyId, data) {
-  return request(`/agency/${agencyId}/jobs/create`, {
+  return apiFetch(`/agency/${agencyId}/jobs/create`, {
     method: 'POST',
     body: JSON.stringify(data),
   });
 }
 
 export function updateJob(agencyId, jobId, data) {
-  return request(`/agency/${agencyId}/jobs/update/${jobId}`, {
+  return apiFetch(`/agency/${agencyId}/jobs/update/${jobId}`, {
     method: 'PUT',
     body: JSON.stringify(data),
   });
 }
 
 export function deleteJob(agencyId, jobId) {
-  return request(`/agency/${agencyId}/jobs/delete/${jobId}`, {
+  return apiFetch(`/agency/${agencyId}/jobs/delete/${jobId}`, {
     method: 'DELETE',
   });
 }
-(function(global){
-  const baseUrl = (global.env && global.env.API_BASE_URL) || '';
 
+(function(global){
   async function listJobs(){
-    const res = await fetch(`${baseUrl}/agency/jobs`);
-    if(!res.ok) throw new Error('Failed to fetch jobs');
-    return res.json();
+    return apiFetch('/agency/jobs');
   }
 
   async function getJob(jobId){
-    const res = await fetch(`${baseUrl}/agency/jobs/${jobId}`);
-    if(!res.ok) throw new Error('Failed to fetch job');
-    return res.json();
+    return apiFetch(`/agency/jobs/${jobId}`);
   }
 
   global.jobsAPI = { listJobs, getJob };

--- a/frontend/api/networking.js
+++ b/frontend/api/networking.js
@@ -1,72 +1,52 @@
-const API_BASE_URL =
-  (typeof window !== 'undefined' && window.API_BASE_URL) ||
-  import.meta.env.VITE_API_BASE_URL ||
-  '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  if (res.status === 204) return {};
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function fetchNetworkingEvents() {
-  return request('/events/networking');
+  return apiFetch('/events/networking');
 }
 
 export function fetchHostedNetworkingEvents() {
-  return request('/events/networking/host');
+  return apiFetch('/events/networking/host');
 }
 
 export function attendNetworkingEvent(eventId) {
-  return request(`/events/networking/attend/${eventId}`, { method: 'POST' });
+  return apiFetch(`/events/networking/attend/${eventId}`, { method: 'POST' });
 }
 
 export function startVideo(sessionId, data = {}) {
-  return request(`/communicationTools/video/start/${sessionId}`, {
+  return apiFetch(`/communicationTools/video/start/${sessionId}`, {
     method: 'POST',
     body: JSON.stringify(data),
   });
 }
 
 export function endVideo(sessionId) {
-  return request(`/communicationTools/video/end/${sessionId}`, { method: 'POST' });
+  return apiFetch(`/communicationTools/video/end/${sessionId}`, { method: 'POST' });
 }
 
 export function exchangeContact(sessionId, data) {
-  return request(`/communicationTools/contact/exchange/${sessionId}`, {
+  return apiFetch(`/communicationTools/contact/exchange/${sessionId}`, {
     method: 'POST',
     body: JSON.stringify(data),
   });
 }
 
 export function rateMatch(matchId, data) {
-  return request(`/matchingSystem/feedback/${matchId}`, {
+  return apiFetch(`/matchingSystem/feedback/${matchId}`, {
     method: 'POST',
     body: JSON.stringify(data),
   });
 }
 
 export function getNextOneMinuteMatch(eventId) {
-  return request(`/matchingSystem/one-minute/${eventId}`);
+  return apiFetch(`/matchingSystem/one-minute/${eventId}`);
 }
 
 export function getSessionMetrics(sessionId) {
-  return request(`/communicationTools/analytics/${sessionId}`);
+  return apiFetch(`/communicationTools/analytics/${sessionId}`);
 }
 
 export function getNetworkingDashboard() {
-  return request('/events/networking');
+  return apiFetch('/events/networking');
 }
 
 export default {

--- a/frontend/api/opportunities.js
+++ b/frontend/api/opportunities.js
@@ -1,58 +1,39 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  const res = await fetch(`${API_BASE_URL}/opportunities${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  if (res.status === 204) return {};
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function listOpportunities(params = {}) {
   const query = new URLSearchParams(params).toString();
-  return request(query ? `?${query}` : '');
+  return apiFetch(`/opportunities${query ? `?${query}` : ''}`);
 }
 
 export function getOpportunity(id) {
-  return request(`/opportunities/${id}`);
+  return apiFetch(`/opportunities/${id}`);
 }
 
 export function fetchOpportunities(query = '') {
   const q = query ? `?${query}` : '';
-  return request(`/opportunities${q}`);
-  return request(`/${id}`);
+  return apiFetch(`/opportunities${q}`);
 }
 
 export function createOpportunity(data) {
-  return request('/opportunities', {
+  return apiFetch('/opportunities', {
     method: 'POST',
     body: JSON.stringify(data),
   });
 }
 
 export function updateOpportunity(id, data) {
-  return request(`/opportunities/${id}`, {
+  return apiFetch(`/opportunities/${id}`, {
     method: 'PUT',
     body: JSON.stringify(data),
   });
 }
 
 export function deleteOpportunity(id) {
-  return request(`/opportunities/${id}`, { method: 'DELETE' });
+  return apiFetch(`/opportunities/${id}`, { method: 'DELETE' });
 }
 
 export function fetchOpportunityDashboard() {
-  return request('/opportunities/dashboard');
+  return apiFetch('/opportunities/dashboard');
 }
 
 export default {

--- a/frontend/api/payments.js
+++ b/frontend/api/payments.js
@@ -1,20 +1,5 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function fetchPayments(agencyId) {
-  return request(`/agency/${agencyId}/payments`);
+  return apiFetch(`/agency/${agencyId}/payments`);
 }

--- a/frontend/api/projectManagement.js
+++ b/frontend/api/projectManagement.js
@@ -1,19 +1,4 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function apiFetch(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    ...(options.body instanceof FormData ? {} : { 'Content-Type': 'application/json' }),
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function fetchProjects() {
   return apiFetch('/workspace/projects');
@@ -40,7 +25,6 @@ export function deleteProject(projectId) {
 }
 
 export function listFiles(projectId) {
-  return request(`/project-management/files/project/${projectId}`);
   return apiFetch(`/workspace/files/project/${projectId}`);
 }
 
@@ -54,12 +38,6 @@ export async function uploadFile(projectId, file) {
   });
   const uploadData = await uploadRes.json();
   if (!uploadRes.ok || !uploadData.success) {
-    throw new Error('File upload failed');
-  }
-  const body = { projectId, filename: file.name, url: uploadData.link };
-  return request('/project-management/files/upload', {
-    method: 'POST',
-    body: JSON.stringify(body),
     throw new Error(uploadData.error || 'File upload failed');
   }
 

--- a/frontend/api/sessions.js
+++ b/frontend/api/sessions.js
@@ -1,20 +1,5 @@
 (function(global) {
-  const API_BASE_URL = global.API_BASE_URL || '/api';
-
-  async function request(path, options = {}) {
-    const token = localStorage.getItem('token');
-    const headers = {
-      'Content-Type': 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      ...(options.headers || {}),
-    };
-    const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-    if (!res.ok) {
-      const message = await res.text();
-      throw new Error(message || 'Request failed');
-    }
-    return res.json();
-  }
+  const request = global.apiFetch;
 
   async function getUpcomingSessions(userId) {
     return request(`/sessions/upcoming/${userId}`);

--- a/frontend/api/settings.js
+++ b/frontend/api/settings.js
@@ -1,26 +1,11 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function fetchSettings() {
-  return request('/settings');
+  return apiFetch('/settings');
 }
 
 export function updateSettings(data) {
-  return request('/settings', {
+  return apiFetch('/settings', {
     method: 'PUT',
     body: JSON.stringify(data),
   });

--- a/frontend/api/timesheets.js
+++ b/frontend/api/timesheets.js
@@ -1,26 +1,11 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function fetchTimesheets(agencyId) {
-  return request(`/agency/${agencyId}/timesheets`);
+  return apiFetch(`/agency/${agencyId}/timesheets`);
 }
 
 export function logTimesheet(agencyId, data) {
-  return request(`/agency/${agencyId}/timesheets`, {
+  return apiFetch(`/agency/${agencyId}/timesheets`, {
     method: 'POST',
     body: JSON.stringify(data),
   });

--- a/frontend/api/workspace.js
+++ b/frontend/api/workspace.js
@@ -1,36 +1,21 @@
-const API_BASE_URL = window.API_BASE_URL || '/api';
-
-async function request(path, options = {}) {
-  const token = localStorage.getItem('token');
-  const headers = {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    ...options.headers,
-  };
-  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const message = await res.text();
-    throw new Error(message || 'Request failed');
-  }
-  return res.json();
-}
+import apiFetch from '../utils/api.js';
 
 export function fetchWorkspaceOverview() {
-  return request('/analytics/workspace/overview');
+  return apiFetch('/analytics/workspace/overview');
 }
 
 export function fetchProjects() {
-  return request('/workspace/projects');
+  return apiFetch('/workspace/projects');
 }
 
 export function fetchProjectTasks(projectId) {
-  return request(`/workspace/projects/${projectId}/tasks`);
+  return apiFetch(`/workspace/projects/${projectId}/tasks`);
 }
 
 export function fetchProjectBudget(projectId) {
-  return request(`/workspace/projects/${projectId}/budget`);
+  return apiFetch(`/workspace/projects/${projectId}/budget`);
 }
 
 export function fetchProjectTeam(projectId) {
-  return request(`/workspace/employment/list?projectId=${projectId}`);
+  return apiFetch(`/workspace/employment/list?projectId=${projectId}`);
 }

--- a/frontend/env.js
+++ b/frontend/env.js
@@ -1,4 +1,10 @@
-const apiBase = import.meta.env.VITE_API_BASE_URL || '';
+const apiBase =
+  window.API_BASE_URL ||
+  import.meta.env.VITE_API_BASE_URL ||
+  '/api';
+
+// expose the resolved base URL globally for legacy scripts
+window.API_BASE_URL = apiBase;
 
 window.env = {
   API_BASE_URL: apiBase,

--- a/frontend/utils/api.js
+++ b/frontend/utils/api.js
@@ -1,4 +1,5 @@
-const API_BASE_URL = window.env?.API_BASE_URL || window.API_BASE_URL || '/api';
+export const API_BASE_URL =
+  window.env?.API_BASE_URL || window.API_BASE_URL || '/api';
 
 export async function apiFetch(path, options = {}) {
   const token = localStorage.getItem('token');


### PR DESCRIPTION
## Summary
- make db_setup use built-in dotenv resolution
- expose API base via config.js and unify front-end env handling
- refactor front-end API modules to share apiFetch and use dynamic base URL
- default .env to Postgres settings with relative API path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893df6268dc8320b67c18e28caf6868