### PR TITLE
feat: add setup wizard url support

### DIFF
--- a/.env
+++ b/.env
@@ -32,6 +32,7 @@ DB_PASSWORD=workhouse
 DB_NAME=workhouse
 DB_TYPE=postgres
 VITE_API_BASE_URL=/api
+VITE_APP_URL=http://localhost:5173
 VITE_AVATAR_API=https://api.dicebear.com/6.x/initials/svg
 VITE_JITSI_DOMAIN=https://meet.jit.si
 VITE_JITSI_ROOM_PREFIX=workhouse-interview

--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,7 @@ DB_NAME=workhouse
 DB_TYPE=postgres
 
 VITE_API_BASE_URL=/api
+VITE_APP_URL=http://localhost:5173
 VITE_AVATAR_API=https://api.dicebear.com/6.x/initials/svg
 VITE_JITSI_DOMAIN=https://meet.jit.si
 VITE_JITSI_ROOM_PREFIX=workhouse-interview

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Workhouse/
    ```bash
    npm install
    ```
+3. **Run the interactive setup wizard** to configure database and URLs:
+   ```bash
+   npm run setup
+   ```
 
 ## Running the App
 ### Development
@@ -60,7 +64,8 @@ Or you can still run the scripts from within each directory:
 cd backend && npm start
 cd frontend && npm run dev
 ```
-Configure `VITE_API_URL` in `.env` to point the frontend to the backend server.
+Configure `VITE_API_URL` and `VITE_APP_URL` in `.env` to point the frontend to
+the backend server and public site address.
 
 ### Production
 Build the frontend and launch the combined server:

--- a/SETUP.md
+++ b/SETUP.md
@@ -10,15 +10,17 @@ creates an `.env` file, runs database migrations and seeds sample data.
 
 ## Backend setup
 
+From the repository root you can launch the interactive setup wizard:
+
 ```bash
-cd backend
-npm install
 npm run setup
 ```
 
 The wizard will ask for database credentials and then run the migrations and
 seeders. All environment variables are written to `backend/.env` with safe
-placeholders so the server starts even if optional keys are missing.
+placeholders so the server starts even if optional keys are missing. The wizard
+also exposes the frontend under `VITE_APP_URL` so the browser UI can resolve
+the correct site address.
 
 After setup you can start the API with:
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,4 @@
 VITE_API_BASE_URL=http://localhost:3000
 VITE_AVATAR_API=https://api.dicebear.com/6.x/identicon/svg
 VITE_RECAPTCHA_SITE_KEY=your_recaptcha_site_key
+VITE_APP_URL=http://localhost:5173

--- a/frontend/env.js
+++ b/frontend/env.js
@@ -2,12 +2,14 @@ const apiBase =
   window.API_BASE_URL ||
   import.meta.env.VITE_API_BASE_URL ||
   '/api';
+const appUrl = import.meta.env.VITE_APP_URL || window.location.origin;
 
 // expose the resolved base URL globally for legacy scripts
 window.API_BASE_URL = apiBase;
 
 window.env = {
   API_BASE_URL: apiBase,
+  APP_URL: appUrl,
   AVATAR_API: import.meta.env.VITE_AVATAR_API,
   JITSI_DOMAIN: import.meta.env.VITE_JITSI_DOMAIN,
   JITSI_ROOM_PREFIX: import.meta.env.VITE_JITSI_ROOM_PREFIX,

--- a/frontend/src/pages/InstallationWizardPage.jsx
+++ b/frontend/src/pages/InstallationWizardPage.jsx
@@ -28,7 +28,10 @@ export default function InstallationWizardPage() {
   const [step, setStep] = useState(0);
   const [dbConfig, setDbConfig] = useState({ host: '', user: '', password: '', name: '' });
   const [admin, setAdmin] = useState({ username: '', email: '', password: '' });
-  const [app, setApp] = useState({ appId: '', appUrl: '' });
+  const defaultUrl = typeof window !== 'undefined' && window.env?.APP_URL
+    ? window.env.APP_URL
+    : window.location.origin;
+  const [app, setApp] = useState({ appId: '', appUrl: defaultUrl });
   const [error, setError] = useState('');
   const [complete, setComplete] = useState(false);
   const [dbCheck, setDbCheck] = useState(null);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "npm test --workspaces",
     "start:frontend": "npm run dev --workspace frontend",
-    "start:backend": "npm start --workspace backend"
+    "start:backend": "npm start --workspace backend",
+    "setup": "npm run setup --workspace backend"
   }
 }


### PR DESCRIPTION
## Summary
- allow running setup wizard from monorepo root
- expose site URL via VITE_APP_URL for frontend configuration
- document interactive setup flow and url variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893e24137588320bc70df8d2fb4d411