### PR TITLE
feat: expand service provider roles with business support

### DIFF
--- a/backend/controllers/businesses.js
+++ b/backend/controllers/businesses.js
@@ -1,0 +1,26 @@
+const Business = require('../models/business');
+
+exports.createBusiness = (req, res) => {
+  const { ownerId, name, zone = [] } = req.body;
+  if (!ownerId || !name) {
+    return res.status(400).json({ error: 'ownerId and name are required' });
+  }
+  const business = Business.createBusiness({ ownerId, name, zone });
+  res.status(201).json(business);
+};
+
+exports.addProvider = (req, res) => {
+  const { id } = req.params;
+  const { userId } = req.body;
+  const business = Business.addProvider(id, userId);
+  if (!business) return res.status(404).json({ error: 'Business not found' });
+  res.json(business);
+};
+
+exports.setZone = (req, res) => {
+  const { id } = req.params;
+  const { zone } = req.body;
+  const business = Business.setZone(id, zone);
+  if (!business) return res.status(404).json({ error: 'Business not found' });
+  res.json(business);
+};

--- a/backend/controllers/serviceProviders.js
+++ b/backend/controllers/serviceProviders.js
@@ -1,7 +1,19 @@
 const Service = require('../models/service');
 
 exports.createService = (req, res) => {
-  const { sellerId, title, description, price, status, category, tags } = req.body;
+  const {
+    sellerId,
+    title,
+    description,
+    price,
+    status,
+    category,
+    tags,
+    businessId,
+    providerIds = [],
+    commissionSplit,
+    serviceArea = [],
+  } = req.body;
   if (!sellerId || !title) {
     return res.status(400).json({ error: 'sellerId and title are required' });
   }
@@ -13,6 +25,10 @@ exports.createService = (req, res) => {
     status,
     category,
     tags,
+    businessId,
+    providerIds,
+    commissionSplit,
+    serviceArea,
   });
   res.status(201).json(service);
 };

--- a/backend/models/business.js
+++ b/backend/models/business.js
@@ -1,0 +1,39 @@
+const { randomUUID } = require('crypto');
+
+// In-memory business store. A business extends a user account and can manage
+// multiple providers and services within a specific service zone.
+const businesses = new Map();
+
+function createBusiness({ ownerId, name, zone = [] }) {
+  const id = randomUUID();
+  const business = { id, ownerId, name, providers: [], services: [], zone };
+  businesses.set(id, business);
+  return business;
+}
+
+function addProvider(businessId, userId) {
+  const business = businesses.get(businessId);
+  if (!business) return null;
+  if (!business.providers.includes(userId)) {
+    business.providers.push(userId);
+  }
+  return business;
+}
+
+function assignService(businessId, serviceId) {
+  const business = businesses.get(businessId);
+  if (!business) return null;
+  if (!business.services.includes(serviceId)) {
+    business.services.push(serviceId);
+  }
+  return business;
+}
+
+function setZone(businessId, zone) {
+  const business = businesses.get(businessId);
+  if (!business) return null;
+  business.zone = zone;
+  return business;
+}
+
+module.exports = { businesses, createBusiness, addProvider, assignService, setZone };

--- a/backend/models/service.js
+++ b/backend/models/service.js
@@ -1,4 +1,5 @@
 const { randomUUID } = require('crypto');
+const Business = require('./business');
 
 // In-memory service store. In a production system this would be a database
 // table with proper indexing and persistence. For demonstration purposes we
@@ -42,11 +43,19 @@ function createService({
   status = 'active',
   category = '',
   tags = [],
+  businessId = null,
+  providerIds = [],
+  commissionSplit = null,
+  serviceArea = [],
 }) {
   const now = new Date();
   const service = {
     id: randomUUID(),
     sellerId,
+    businessId,
+    providerIds,
+    commissionSplit,
+    serviceArea,
     name: title,
     description,
     price,
@@ -59,6 +68,9 @@ function createService({
     updatedAt: now,
   };
   services.push(service);
+  if (businessId) {
+    Business.assignService(businessId, service.id);
+  }
   return service;
 }
 
@@ -99,6 +111,9 @@ function updateService(id, updates) {
     delete data.title;
   }
   Object.assign(service, data, { updatedAt: now });
+  if (data.businessId) {
+    Business.assignService(data.businessId, service.id);
+  }
   return service;
 }
 

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -6,6 +6,16 @@ const { randomUUID } = require('crypto');
 // profile information.
 const users = new Map();
 
+// Define the supported roles within the system. Providers can register
+// as individual professionals offering services or as businesses that
+// manage multiple providers.
+const ROLES = {
+  USER: 'user',
+  PROFESSIONAL: 'professional',
+  BUSINESS: 'business',
+  ADMIN: 'admin',
+};
+
 /**
  * Find a user by username.
  * @param {string} username
@@ -30,13 +40,14 @@ function findUser(username) {
  * }} param0
  * @returns {object} The created user record
  */
-function addUser({ username, password, role = 'user', fullName = '', email = '', phone = '', location = '', bio = '', expertise = '' }) {
+function addUser({ username, password, role = ROLES.USER, fullName = '', email = '', phone = '', location = '', bio = '', expertise = '' }) {
+  const normalizedRole = Object.values(ROLES).includes(role) ? role : ROLES.USER;
   const user = {
     id: randomUUID(),
     username,
     email: email || username,
     password,
-    role,
+    role: normalizedRole,
     fullName,
     phone,
     location,
@@ -60,4 +71,4 @@ function updatePassword(username, password) {
   return true;
 }
 
-module.exports = { users, findUser, addUser, updatePassword };
+module.exports = { users, ROLES, findUser, addUser, updatePassword };

--- a/backend/routes/businesses.js
+++ b/backend/routes/businesses.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../controllers/businesses');
+
+router.post('/businesses', controller.createBusiness);
+router.post('/businesses/:id/providers', controller.addProvider);
+router.put('/businesses/:id/zone', controller.setZone);
+
+module.exports = router;

--- a/backend/tests/businesses.test.js
+++ b/backend/tests/businesses.test.js
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('businesses routes', () => {
+  test('should define an Express router', () => {
+    const filePath = path.join(__dirname, '../routes/businesses.js');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect(content).toMatch(/express\.Router\(/);
+    expect(content).toMatch(/module\.exports\s*=\s*router/);
+  });
+});

--- a/backend/tests/serviceProviders.test.js
+++ b/backend/tests/serviceProviders.test.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 const path = require('path');
+const Service = require('../models/service');
+const Business = require('../models/business');
 
 describe('serviceProviders routes', () => {
   test('should define an Express router', () => {
@@ -7,5 +9,21 @@ describe('serviceProviders routes', () => {
     const content = fs.readFileSync(filePath, 'utf8');
     expect(content).toMatch(/express\.Router\(/);
     expect(content).toMatch(/module\.exports\s*=\s*router/);
+  });
+
+  test('should create a service with business and providers', () => {
+    const business = Business.createBusiness({ ownerId: 'owner-1', name: 'Test Biz' });
+    const service = Service.createService({
+      sellerId: 'seller-1',
+      title: 'Test Service',
+      businessId: business.id,
+      providerIds: ['prov-1'],
+      commissionSplit: { provider: 70, business: 30 },
+      serviceArea: [{ lat: 0, lng: 0 }],
+    });
+    expect(service.businessId).toBe(business.id);
+    expect(service.providerIds).toContain('prov-1');
+    expect(service.commissionSplit.provider).toBe(70);
+    expect(Business.businesses.get(business.id).services).toContain(service.id);
   });
 });


### PR DESCRIPTION
## Summary
- allow user roles to include professional and business accounts
- add business model/routes to manage providers and service zones
- extend service creation to assign providers, business, commission split and service area

## Testing
- `npm test --workspace backend`


------
https://chatgpt.com/codex/tasks/task_e_6893e313e6b883209c06ed16e79279bc