### PR TITLE
feat: add role-based admin dashboard shell

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -6,6 +6,8 @@ const authRoutes = require('./routes/auth');
 const landingRoutes = require('./routes/landing');
 const n8nRoutes = require('./routes/n8n');
 const tasksRoutes = require('./routes/tasks');
+const adminAuthRoutes = require('./routes/adminAuth');
+const adminDashboardRoutes = require('./routes/adminDashboard');
 const api = require("./api");
 const { initDb } = require('./utils/db');
 const logger = require('./utils/logger');
@@ -22,6 +24,8 @@ app.use('/auth', authRoutes);
 app.use('/landing', landingRoutes);
 app.use('/n8n', n8nRoutes);
 app.use('/tasks', tasksRoutes);
+app.use('/admin', adminAuthRoutes);
+app.use('/admin', adminDashboardRoutes);
 
 // 404 handler
 app.use((req, res, next) => {

--- a/backend/controllers/adminAuth.js
+++ b/backend/controllers/adminAuth.js
@@ -4,15 +4,17 @@ const { findUser } = require('../models/user');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
 
+const ADMIN_ROLES = ['superadmin', 'admin', 'finance', 'support', 'management', 'marketing', 'hr'];
+
 /**
- * Handle admin login. Only users with role 'admin' are allowed.
+ * Handle admin login for privileged roles.
  * Expects validatedBody with username and password provided by validation middleware.
  */
 async function adminLoginHandler(req, res) {
   const { username, password } = req.validatedBody;
   try {
     const user = findUser(username);
-    if (!user || user.role !== 'admin') {
+    if (!user || !ADMIN_ROLES.includes(user.role)) {
       throw new Error('Invalid credentials');
     }
     const match = await bcrypt.compare(password, user.password);
@@ -24,7 +26,7 @@ async function adminLoginHandler(req, res) {
       JWT_SECRET,
       { expiresIn: '1h' }
     );
-    res.json({ token });
+    res.json({ token, role: user.role });
   } catch (err) {
     res.status(401).json({ error: err.message });
   }

--- a/backend/routes/adminDashboard.js
+++ b/backend/routes/adminDashboard.js
@@ -6,6 +6,11 @@ const authorize = require('../middleware/authorize');
 const router = express.Router();
 
 // GET /admin/dashboard
-router.get('/dashboard', auth, authorize('admin', 'moderator', 'support'), adminDashboardHandler);
+router.get(
+  '/dashboard',
+  auth,
+  authorize('superadmin', 'admin', 'finance', 'support', 'management', 'marketing', 'hr'),
+  adminDashboardHandler
+);
 
 module.exports = router;

--- a/frontend/pages/AdminDashboard.jsx
+++ b/frontend/pages/AdminDashboard.jsx
@@ -1,100 +1,27 @@
-import { Box, Heading, SimpleGrid, Stat, StatLabel, StatNumber, Tabs, TabList, TabPanels, Tab, TabPanel, Spinner } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
-import NavMenu from '../components/NavMenu';
-import { useAuth } from '../context/AuthContext.jsx';
-import FlaggedContentTable from '../components/admin/FlaggedContentTable.jsx';
-import TicketTable from '../components/admin/TicketTable.jsx';
-import DisputeTable from '../components/admin/DisputeTable.jsx';
-import '../api/adminDashboard';
-import EmployeeTable from '../components/admin/EmployeeTable';
-import SystemSettings from '../components/admin/SystemSettings';
-import { listEmployees } from '../api/admin.js';
-import '../styles/AdminDashboard.css';
+import { useAuth } from '../context/AuthContext.js';
+import FinanceDashboard from './FinanceDashboard.jsx';
+import SupportDashboard from './SupportDashboard.jsx';
+import ManagementDashboard from './ManagementDashboard.jsx';
+import MarketingDashboard from './MarketingDashboard.jsx';
+import HRDashboard from './HRDashboard.jsx';
+import SuperAdminDashboard from './SuperAdminDashboard.jsx';
 
 export default function AdminDashboard() {
   const { user } = useAuth();
-  const [overview, setOverview] = useState(null);
-  const [flags, setFlags] = useState([]);
-  const [tickets, setTickets] = useState([]);
-  const [disputes, setDisputes] = useState([]);
-  const [loading, setLoading] = useState(true);
-
-  const loadEmployees = () => {
-    listEmployees()
-      .then(setEmployees)
-      .catch(() => {})
-      .finally(() => setLoading(false));
-  };
-
-  useEffect(() => {
-    async function load() {
-      try {
-        const data = await adminDashboardAPI.fetchOverview();
-        setOverview(data);
-        if (['admin', 'moderator'].includes(user.role)) {
-          setFlags(await adminDashboardAPI.listFlags());
-        }
-        if (['admin', 'support'].includes(user.role)) {
-          const allTickets = await adminDashboardAPI.listTickets();
-          setTickets(allTickets.filter((t) => t.status !== 'resolved'));
-        }
-        const allDisputes = await adminDashboardAPI.listDisputes();
-        setDisputes(allDisputes.filter((d) => d.status !== 'resolved'));
-      } finally {
-        setLoading(false);
-      }
-    }
-    load();
-  }, [user.role]);
-
-  if (loading) return <Spinner />;
-
-  return (
-    <Box className="admin-dashboard" p={4}>
-      <NavMenu />
-      <Heading mb={4}>Admin Dashboard</Heading>
-      {overview && (
-        <SimpleGrid columns={[1, 2, 4]} spacing={4} mb={6}>
-          <Stat className="stat-card">
-            <StatLabel>Active Users</StatLabel>
-            <StatNumber>{overview.activeUsers}</StatNumber>
-          </Stat>
-          <Stat className="stat-card">
-            <StatLabel>Flagged Content</StatLabel>
-            <StatNumber>{overview.flaggedContent}</StatNumber>
-          </Stat>
-          <Stat className="stat-card">
-            <StatLabel>Open Tickets</StatLabel>
-            <StatNumber>{overview.openTickets}</StatNumber>
-          </Stat>
-          <Stat className="stat-card">
-            <StatLabel>Active Disputes</StatLabel>
-            <StatNumber>{overview.activeDisputes}</StatNumber>
-          </Stat>
-        </SimpleGrid>
-      )}
-      <Tabs variant="enclosed">
-        <TabList>
-          {['admin', 'moderator'].includes(user.role) && <Tab>Flagged Content</Tab>}
-          {['admin', 'support'].includes(user.role) && <Tab>Support Tickets</Tab>}
-          <Tab>Disputes</Tab>
-        </TabList>
-        <TabPanels>
-          {['admin', 'moderator'].includes(user.role) && (
-            <TabPanel>
-              <FlaggedContentTable items={flags} />
-            </TabPanel>
-          )}
-          {['admin', 'support'].includes(user.role) && (
-            <TabPanel>
-              <TicketTable items={tickets} />
-            </TabPanel>
-          )}
-          <TabPanel>
-            <DisputeTable items={disputes} />
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
-    </Box>
-  );
+  switch (user?.role) {
+    case 'finance':
+      return <FinanceDashboard />;
+    case 'support':
+      return <SupportDashboard />;
+    case 'management':
+      return <ManagementDashboard />;
+    case 'marketing':
+      return <MarketingDashboard />;
+    case 'hr':
+      return <HRDashboard />;
+    case 'superadmin':
+    case 'admin':
+    default:
+      return <SuperAdminDashboard />;
+  }
 }

--- a/frontend/pages/AdminLogin.jsx
+++ b/frontend/pages/AdminLogin.jsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { Box, Button, Heading, Input, VStack } from '@chakra-ui/react';
+import { useAuth } from '../context/AuthContext.js';
+
+export default function AdminLogin() {
+  const { setUser } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await fetch('/admin/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setUser({ username, role: data.role, token: data.token });
+    }
+  };
+
+  return (
+    <Box p={4}>
+      <Heading mb={4}>Admin Login</Heading>
+      <form onSubmit={handleSubmit}>
+        <VStack spacing={4} align="stretch">
+          <Input placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+          <Input placeholder="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+          <Button type="submit">Login</Button>
+        </VStack>
+      </form>
+    </Box>
+  );
+}

--- a/frontend/pages/FinanceDashboard.jsx
+++ b/frontend/pages/FinanceDashboard.jsx
@@ -1,0 +1,12 @@
+import { Box, Heading } from '@chakra-ui/react';
+import NavMenu from '../components/NavMenu.jsx';
+
+export default function FinanceDashboard() {
+  return (
+    <Box p={4}>
+      <NavMenu />
+      <Heading mb={4}>Finance Dashboard</Heading>
+      {/* TODO: Add graphs, earnings, expenses, invoices, and records */}
+    </Box>
+  );
+}

--- a/frontend/pages/HRDashboard.jsx
+++ b/frontend/pages/HRDashboard.jsx
@@ -1,0 +1,12 @@
+import { Box, Heading } from '@chakra-ui/react';
+import NavMenu from '../components/NavMenu.jsx';
+
+export default function HRDashboard() {
+  return (
+    <Box p={4}>
+      <NavMenu />
+      <Heading mb={4}>HR Dashboard</Heading>
+      {/* TODO: Add employee management and HR tools */}
+    </Box>
+  );
+}

--- a/frontend/pages/ManagementDashboard.jsx
+++ b/frontend/pages/ManagementDashboard.jsx
@@ -1,0 +1,12 @@
+import { Box, Heading } from '@chakra-ui/react';
+import NavMenu from '../components/NavMenu.jsx';
+
+export default function ManagementDashboard() {
+  return (
+    <Box p={4}>
+      <NavMenu />
+      <Heading mb={4}>Management Dashboard</Heading>
+      {/* TODO: Add management widgets and tools */}
+    </Box>
+  );
+}

--- a/frontend/pages/MarketingDashboard.jsx
+++ b/frontend/pages/MarketingDashboard.jsx
@@ -1,0 +1,12 @@
+import { Box, Heading } from '@chakra-ui/react';
+import NavMenu from '../components/NavMenu.jsx';
+
+export default function MarketingDashboard() {
+  return (
+    <Box p={4}>
+      <NavMenu />
+      <Heading mb={4}>Marketing Dashboard</Heading>
+      {/* TODO: Add marketing analytics and campaign tools */}
+    </Box>
+  );
+}

--- a/frontend/pages/SuperAdminDashboard.jsx
+++ b/frontend/pages/SuperAdminDashboard.jsx
@@ -1,0 +1,100 @@
+import { Box, Heading, SimpleGrid, Stat, StatLabel, StatNumber, Tabs, TabList, TabPanels, Tab, TabPanel, Spinner } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import NavMenu from '../components/NavMenu';
+import { useAuth } from '../context/AuthContext.js';
+import FlaggedContentTable from '../components/admin/FlaggedContentTable.jsx';
+import TicketTable from '../components/admin/TicketTable.jsx';
+import DisputeTable from '../components/admin/DisputeTable.jsx';
+import '../api/adminDashboard';
+import EmployeeTable from '../components/admin/EmployeeTable';
+import SystemSettings from '../components/admin/SystemSettings';
+import { listEmployees } from '../api/admin.js';
+import '../styles/AdminDashboard.css';
+
+export default function SuperAdminDashboard() {
+  const { user } = useAuth();
+  const [overview, setOverview] = useState(null);
+  const [flags, setFlags] = useState([]);
+  const [tickets, setTickets] = useState([]);
+  const [disputes, setDisputes] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadEmployees = () => {
+    listEmployees()
+      .then(setEmployees)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await adminDashboardAPI.fetchOverview();
+        setOverview(data);
+        if (['admin', 'moderator'].includes(user.role)) {
+          setFlags(await adminDashboardAPI.listFlags());
+        }
+        if (['admin', 'support'].includes(user.role)) {
+          const allTickets = await adminDashboardAPI.listTickets();
+          setTickets(allTickets.filter((t) => t.status !== 'resolved'));
+        }
+        const allDisputes = await adminDashboardAPI.listDisputes();
+        setDisputes(allDisputes.filter((d) => d.status !== 'resolved'));
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [user.role]);
+
+  if (loading) return <Spinner />;
+
+  return (
+    <Box className="admin-dashboard" p={4}>
+      <NavMenu />
+      <Heading mb={4}>Admin Dashboard</Heading>
+      {overview && (
+        <SimpleGrid columns={[1, 2, 4]} spacing={4} mb={6}>
+          <Stat className="stat-card">
+            <StatLabel>Active Users</StatLabel>
+            <StatNumber>{overview.activeUsers}</StatNumber>
+          </Stat>
+          <Stat className="stat-card">
+            <StatLabel>Flagged Content</StatLabel>
+            <StatNumber>{overview.flaggedContent}</StatNumber>
+          </Stat>
+          <Stat className="stat-card">
+            <StatLabel>Open Tickets</StatLabel>
+            <StatNumber>{overview.openTickets}</StatNumber>
+          </Stat>
+          <Stat className="stat-card">
+            <StatLabel>Active Disputes</StatLabel>
+            <StatNumber>{overview.activeDisputes}</StatNumber>
+          </Stat>
+        </SimpleGrid>
+      )}
+      <Tabs variant="enclosed">
+        <TabList>
+          {['admin', 'moderator'].includes(user.role) && <Tab>Flagged Content</Tab>}
+          {['admin', 'support'].includes(user.role) && <Tab>Support Tickets</Tab>}
+          <Tab>Disputes</Tab>
+        </TabList>
+        <TabPanels>
+          {['admin', 'moderator'].includes(user.role) && (
+            <TabPanel>
+              <FlaggedContentTable items={flags} />
+            </TabPanel>
+          )}
+          {['admin', 'support'].includes(user.role) && (
+            <TabPanel>
+              <TicketTable items={tickets} />
+            </TabPanel>
+          )}
+          <TabPanel>
+            <DisputeTable items={disputes} />
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Box>
+  );
+}

--- a/frontend/pages/SupportDashboard.jsx
+++ b/frontend/pages/SupportDashboard.jsx
@@ -1,0 +1,12 @@
+import { Box, Heading } from '@chakra-ui/react';
+import NavMenu from '../components/NavMenu.jsx';
+
+export default function SupportDashboard() {
+  return (
+    <Box p={4}>
+      <NavMenu />
+      <Heading mb={4}>Support Dashboard</Heading>
+      {/* TODO: Add chat, tickets, dispute handling, and help centre management */}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add admin routes and controller support for multiple roles
- provide role-based frontend dashboard shell and login page
- include placeholder dashboards for finance, support, management, marketing and HR

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e1ce3f6c8320a737b3b24ff88754