### PR TITLE
feat: add job application progress tracking

### DIFF
--- a/backend/controllers/job.js
+++ b/backend/controllers/job.js
@@ -7,6 +7,7 @@ const {
   updateJob,
   deleteJob,
   getJobApplications,
+  updateApplicationProgress,
 } = require('../services/job');
 
 async function acceptJobHandler(req, res) {
@@ -88,6 +89,17 @@ async function getJobApplicationsHandler(req, res) {
   }
 }
 
+async function updateApplicationProgressHandler(req, res) {
+  const { agencyId, jobId, appId } = req.params;
+  try {
+    const application = await updateApplicationProgress(agencyId, jobId, appId, req.body);
+    res.json(application);
+  } catch (err) {
+    logger.error('Failed to update application progress', { error: err.message, jobId, appId });
+    res.status(400).json({ error: err.message });
+  }
+}
+
 module.exports = {
   acceptJobHandler,
   assignJobHandler,
@@ -96,4 +108,5 @@ module.exports = {
   updateJobHandler,
   deleteJobHandler,
   getJobApplicationsHandler,
+  updateApplicationProgressHandler,
 };

--- a/backend/models/job.js
+++ b/backend/models/job.js
@@ -30,6 +30,11 @@ function findById(id) {
   return jobs.get(id);
 }
 
+// Alias used by existing middleware
+function findJobById(id) {
+  return findById(id);
+}
+
 function listJobs() {
   return Array.from(jobs.values());
 }
@@ -76,9 +81,34 @@ function assignJob(id, employeeId) {
 function addApplication(jobId, application) {
   const apps = jobApplications.get(jobId);
   if (!apps) return null;
-  const record = { id: randomUUID(), appliedAt: new Date(), ...application };
+  const record = {
+    id: randomUUID(),
+    appliedAt: new Date(),
+    stage: 0,
+    notes: '',
+    feedback: '',
+    ...application,
+  };
   apps.push(record);
   return record;
+}
+
+function updateApplicationProgress(jobId, appId, updates) {
+  const apps = jobApplications.get(jobId);
+  if (!apps) return null;
+  const app = apps.find((a) => a.id === appId);
+  if (!app) return null;
+  if (typeof updates.stage === 'number') {
+    app.stage = updates.stage;
+  }
+  if (typeof updates.notes === 'string') {
+    app.notes = updates.notes;
+  }
+  if (typeof updates.feedback === 'string') {
+    app.feedback = updates.feedback;
+  }
+  app.updatedAt = new Date();
+  return app;
 }
 
 function getApplications(jobId) {
@@ -88,6 +118,7 @@ function getApplications(jobId) {
 module.exports = {
   createJob,
   findById,
+  findJobById,
   listJobs,
   findJobsByAgency,
   updateJob,
@@ -96,4 +127,5 @@ module.exports = {
   assignJob,
   addApplication,
   getApplications,
+  updateApplicationProgress,
 };

--- a/backend/routes/jobs.js
+++ b/backend/routes/jobs.js
@@ -8,6 +8,8 @@ const {
   assignmentParamSchema,
   createJobSchema,
   updateJobSchema,
+  applicationProgressSchema,
+  applicationProgressParamSchema,
 } = require('../validation/job');
 const {
   acceptJobHandler,
@@ -17,6 +19,7 @@ const {
   updateJobHandler,
   deleteJobHandler,
   getJobApplicationsHandler,
+  updateApplicationProgressHandler,
 } = require('../controllers/job');
 
 const router = express.Router();
@@ -29,5 +32,13 @@ router.get('/:agencyId/jobs', auth, listJobsHandler);
 router.put('/:agencyId/jobs/update/:jobId', auth, jobOwnership, validate(updateJobSchema), updateJobHandler);
 router.delete('/:agencyId/jobs/delete/:jobId', auth, jobOwnership, deleteJobHandler);
 router.get('/:agencyId/jobs/:jobId/applications', auth, jobOwnership, getJobApplicationsHandler);
+router.put(
+  '/:agencyId/jobs/:jobId/applications/:appId/progress',
+  auth,
+  jobOwnership,
+  validate(applicationProgressParamSchema, 'params'),
+  validate(applicationProgressSchema),
+  updateApplicationProgressHandler,
+);
 
 module.exports = router;

--- a/backend/services/job.js
+++ b/backend/services/job.js
@@ -54,6 +54,15 @@ async function getJobApplications(agencyId, jobId) {
   return jobModel.getApplications(jobId);
 }
 
+async function updateApplicationProgress(agencyId, jobId, appId, updates) {
+  const job = jobModel.findJobById(jobId);
+  if (!job || job.agencyId !== agencyId) throw new Error('Job not found');
+  const application = jobModel.updateApplicationProgress(jobId, appId, updates);
+  if (!application) throw new Error('Application not found');
+  logger.info('Application progress updated', { jobId, appId, agencyId });
+  return application;
+}
+
 module.exports = {
   acceptJob,
   assignJob,
@@ -62,4 +71,5 @@ module.exports = {
   updateJob,
   deleteJob,
   getJobApplications,
+  updateApplicationProgress,
 };

--- a/backend/tests/jobs.test.js
+++ b/backend/tests/jobs.test.js
@@ -8,4 +8,10 @@ describe('jobs routes', () => {
     expect(content).toMatch(/express\.Router\(/);
     expect(content).toMatch(/module\.exports\s*=\s*router/);
   });
+
+  test('should include application progress route', () => {
+    const filePath = path.join(__dirname, '../routes/jobs.js');
+    const content = fs.readFileSync(filePath, 'utf8');
+    expect(content).toMatch(/applications\/\:appId\/progress/);
+  });
 });

--- a/backend/validation/job.js
+++ b/backend/validation/job.js
@@ -24,9 +24,22 @@ const updateJobSchema = Joi.object({
   status: Joi.string().valid('open', 'closed'),
 }).min(1);
 
+const applicationProgressParamSchema = Joi.object({
+  jobId: Joi.string().guid({ version: 'uuidv4' }).required(),
+  appId: Joi.string().guid({ version: 'uuidv4' }).required(),
+}).unknown(true);
+
+const applicationProgressSchema = Joi.object({
+  stage: Joi.number().integer().min(0).max(6),
+  notes: Joi.string().allow('', null),
+  feedback: Joi.string().allow('', null),
+}).min(1);
+
 module.exports = {
   jobIdParamSchema,
   assignmentParamSchema,
   createJobSchema,
   updateJobSchema,
+  applicationProgressSchema,
+  applicationProgressParamSchema,
 };

--- a/frontend/src/api/applicationProgress.js
+++ b/frontend/src/api/applicationProgress.js
@@ -1,0 +1,6 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function updateApplicationProgress(agencyId, jobId, applicationId, payload) {
+  const { data } = await apiClient.put(`/agency/${agencyId}/jobs/${jobId}/applications/${applicationId}/progress`, payload);
+  return data;
+}

--- a/frontend/src/components/JobApplicationTracker.jsx
+++ b/frontend/src/components/JobApplicationTracker.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import { Box, Button, Input, Text, Textarea, VStack, Progress } from '@chakra-ui/react';
+import { updateApplicationProgress } from '../api/applicationProgress.js';
+
+export default function JobApplicationTracker({ agencyId, jobId, application }) {
+  const [stage, setStage] = useState(application.stage || 0);
+  const [notes, setNotes] = useState(application.notes || '');
+  const [feedback, setFeedback] = useState(application.feedback || '');
+
+  async function save() {
+    await updateApplicationProgress(agencyId, jobId, application.id, {
+      stage,
+      notes,
+      feedback,
+    });
+  }
+
+  return (
+    <Box borderWidth="1px" borderRadius="md" p={4} mt={2}>
+      <Text mb={2}>Stage {stage + 1} of 7</Text>
+      <Progress value={((stage + 1) / 7) * 100} mb={4} />
+      <VStack align="stretch" spacing={2}>
+        <Input
+          type="number"
+          min={0}
+          max={6}
+          value={stage}
+          onChange={(e) => setStage(Number(e.target.value))}
+        />
+        <Textarea
+          placeholder="ATS Notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+        />
+        <Textarea
+          placeholder="Interview Feedback"
+          value={feedback}
+          onChange={(e) => setFeedback(e.target.value)}
+        />
+        <Button colorScheme="teal" onClick={save}>Save Progress</Button>
+      </VStack>
+    </Box>
+  );
+}

--- a/frontend/src/pages/ApplicationInterviewManagementPage.jsx
+++ b/frontend/src/pages/ApplicationInterviewManagementPage.jsx
@@ -16,10 +16,15 @@ import {
   Spinner,
   Text,
   Select,
+  SimpleGrid,
+  Stat,
+  StatLabel,
+  StatNumber,
 } from '@chakra-ui/react';
 import { getUserApplications } from '../api/applications.js';
 import { getUserInterviews, getEmployerInterviews } from '../api/interviews.js';
 import { useAuth } from '../context/AuthContext.jsx';
+import JobApplicationTracker from '../components/JobApplicationTracker.jsx';
 import '../styles/ApplicationInterviewManagementPage.css';
 
 export default function ApplicationInterviewManagementPage() {
@@ -50,6 +55,16 @@ export default function ApplicationInterviewManagementPage() {
   return (
     <Box className="application-interview-management-page" p={4}>
       <Heading size="lg" mb={4}>Applications & Interviews</Heading>
+      <SimpleGrid columns={[1, 2]} spacing={4} mb={4}>
+        <Stat>
+          <StatLabel>Total Applications</StatLabel>
+          <StatNumber>{applications.length}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Scheduled Interviews</StatLabel>
+          <StatNumber>{interviews.length}</StatNumber>
+        </Stat>
+      </SimpleGrid>
       <Tabs>
         <TabList>
           <Tab>Applications</Tab>
@@ -83,6 +98,16 @@ export default function ApplicationInterviewManagementPage() {
               </Tbody>
             </Table>
             {!applications.length && <Text mt={4}>No applications yet.</Text>}
+            {applications.map((app) => (
+              <Box key={app.id} mt={6}>
+                <Heading size="sm" mb={2}>{app.jobTitle || app.id}</Heading>
+                <JobApplicationTracker
+                  agencyId={user?.username}
+                  jobId={app.jobId}
+                  application={app}
+                />
+              </Box>
+            ))}
           </TabPanel>
           <TabPanel>
             <Select


### PR DESCRIPTION
## Summary
- extend job model to track application stages, ATS notes, and feedback
- expose `/applications/:appId/progress` API for employers
- add Chakra UI tracker and statistics widgets to application management page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e3dbf3d48320a642a7c6d9d31cd7