### PR TITLE
Add volunteer engagement analytics widget

### DIFF
--- a/backend/services/volunteering.js
+++ b/backend/services/volunteering.js
@@ -8,6 +8,14 @@ function getVolunteerStats(volunteerId) {
     .getVolunteerEngagement()
     .filter((r) => r.volunteerId === volunteerId);
   const totalHours = engagement.reduce((sum, r) => sum + r.hours, 0);
+  const engagementHistory = engagement
+    .slice()
+    .sort((a, b) => a.date - b.date)
+    .map((r) => ({
+      date: r.date,
+      hours: r.hours,
+      tasksCompleted: r.tasksCompleted,
+    }));
   const activeApplications = applicationModel
     .getApplicationsByUser(volunteerId)
     .filter((a) => a.status === 'pending').length;
@@ -17,7 +25,7 @@ function getVolunteerStats(volunteerId) {
   const feedbackScore = feedbacks.length
     ? feedbacks.reduce((sum, f) => sum + f.rating, 0) / feedbacks.length
     : 0;
-  return { totalHours, activeApplications, feedbackScore };
+  return { totalHours, activeApplications, feedbackScore, engagementHistory };
 }
 
 function getEmployerStats(organizationId) {

--- a/backend/tests/volunteering.test.js
+++ b/backend/tests/volunteering.test.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 const path = require('path');
+const analyticsModel = require('../models/analytics');
+const { getVolunteerStats } = require('../services/volunteering');
 
 describe('volunteering routes', () => {
   test('should define an Express router', () => {
@@ -7,5 +9,15 @@ describe('volunteering routes', () => {
     const content = fs.readFileSync(filePath, 'utf8');
     expect(content).toMatch(/express\.Router\(/);
     expect(content).toMatch(/module\.exports\s*=\s*router/);
+  });
+});
+
+describe('volunteering stats service', () => {
+  test('includes engagement history in volunteer stats', () => {
+    analyticsModel.addVolunteerEngagement('user-test', 4, 2, new Date('2024-01-01'));
+    const stats = getVolunteerStats('user-test');
+    expect(stats.totalHours).toBe(4);
+    expect(Array.isArray(stats.engagementHistory)).toBe(true);
+    expect(stats.engagementHistory.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/components/VolunteerEngagementChart.jsx
+++ b/frontend/src/components/VolunteerEngagementChart.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend);
+
+export default function VolunteerEngagementChart({ data }) {
+  const chartData = {
+    labels: data.map((d) => new Date(d.date).toLocaleDateString()),
+    datasets: [
+      {
+        label: 'Hours',
+        data: data.map((d) => d.hours),
+        borderColor: 'rgba(75,192,192,1)',
+        backgroundColor: 'rgba(75,192,192,0.2)',
+        tension: 0.3,
+      },
+    ],
+  };
+
+  return <Line data={chartData} />;
+}

--- a/frontend/src/pages/VolunteeringDashboardPage.jsx
+++ b/frontend/src/pages/VolunteeringDashboardPage.jsx
@@ -12,6 +12,7 @@ import {
 } from '@chakra-ui/react';
 import { useAuth } from '../context/AuthContext.jsx';
 import { getVolunteeringDashboard } from '../api/volunteering.js';
+import VolunteerEngagementChart from '../components/VolunteerEngagementChart.jsx';
 import '../styles/VolunteeringDashboardPage.css';
 
 export default function VolunteeringDashboardPage() {
@@ -67,6 +68,12 @@ export default function VolunteeringDashboardPage() {
           </>
         )}
       </SimpleGrid>
+      {user?.role !== 'organization' && stats.engagementHistory?.length > 0 && (
+        <Box mb={6} bg="white" p={4} borderRadius="md" borderWidth="1px">
+          <Heading size="md" mb={2}>Hours Over Time</Heading>
+          <VolunteerEngagementChart data={stats.engagementHistory} />
+        </Box>
+      )}
       <Flex gap={4} className="shortcut-buttons">
         {user?.role === 'organization' ? (
           <Button colorScheme="teal" onClick={() => (window.location.href = '/opportunities/manage')}>


### PR DESCRIPTION
## Summary
- extend volunteer stats service with engagement history
- add chart widget displaying volunteer hours over time
- cover new stats with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893e5eb1eb883209f55cc0039e6e1b6