### PR TITLE
feat: enhance live feed with filters and engagement

### DIFF
--- a/backend/controllers/liveFeed.js
+++ b/backend/controllers/liveFeed.js
@@ -1,4 +1,12 @@
-const { getPosts, createPost, getEvents, likePost } = require('../services/liveFeed');
+const {
+  getPosts,
+  createPost,
+  getEvents,
+  likePost,
+  commentPost,
+  sharePost,
+  reportPost,
+} = require('../services/liveFeed');
 const logger = require('../utils/logger');
 
 async function listPosts(req, res) {
@@ -31,4 +39,39 @@ async function likePostHandler(req, res) {
   res.json(post);
 }
 
-module.exports = { listPosts, createPostHandler, listEventsHandler, likePostHandler };
+async function commentPostHandler(req, res) {
+  const { postId } = req.params;
+  const post = await commentPost(postId, req.user, req.body);
+  if (!post) {
+    return res.status(404).json({ error: 'Post not found' });
+  }
+  res.json(post);
+}
+
+async function sharePostHandler(req, res) {
+  const { postId } = req.params;
+  const post = await sharePost(postId);
+  if (!post) {
+    return res.status(404).json({ error: 'Post not found' });
+  }
+  res.json(post);
+}
+
+async function reportPostHandler(req, res) {
+  const { postId } = req.params;
+  const post = await reportPost(postId);
+  if (!post) {
+    return res.status(404).json({ error: 'Post not found' });
+  }
+  res.json(post);
+}
+
+module.exports = {
+  listPosts,
+  createPostHandler,
+  listEventsHandler,
+  likePostHandler,
+  commentPostHandler,
+  sharePostHandler,
+  reportPostHandler,
+};

--- a/backend/models/liveFeed.js
+++ b/backend/models/liveFeed.js
@@ -1,5 +1,7 @@
 const { randomUUID } = require('crypto');
 
+// Demo posts covering a wide range of categories that may appear in the
+// live feed. Each post tracks basic engagement metrics and metadata.
 const posts = [
   {
     id: randomUUID(),
@@ -8,6 +10,108 @@ const posts = [
     category: 'general',
     createdAt: new Date(),
     likes: 0,
+    comments: [],
+    shares: 0,
+    reports: 0,
+  },
+  {
+    id: randomUUID(),
+    author: 'Alice',
+    content: 'New gig available: Graphic design project.',
+    category: 'gig',
+    createdAt: new Date(),
+    likes: 1,
+    comments: [],
+    shares: 0,
+    reports: 0,
+  },
+  {
+    id: randomUUID(),
+    author: 'Bob',
+    content: 'Freelance contract: 6 month web dev position.',
+    category: 'contract',
+    createdAt: new Date(),
+    likes: 2,
+    comments: [],
+    shares: 0,
+    reports: 0,
+  },
+  {
+    id: randomUUID(),
+    author: 'Carol',
+    content: 'Jane Doe just created a new profile.',
+    category: 'profile',
+    createdAt: new Date(),
+    likes: 0,
+    comments: [],
+    shares: 0,
+    reports: 0,
+  },
+  {
+    id: randomUUID(),
+    author: 'CourseBot',
+    content: 'New course published: Advanced React Patterns.',
+    category: 'course',
+    createdAt: new Date(),
+    likes: 0,
+    comments: [],
+    shares: 0,
+    reports: 0,
+  },
+  {
+    id: randomUUID(),
+    author: 'EventsTeam',
+    content: 'Live webinar scheduled: Intro to Data Science.',
+    category: 'webinar',
+    createdAt: new Date(),
+    likes: 0,
+    comments: [],
+    shares: 0,
+    reports: 0,
+  },
+  {
+    id: randomUUID(),
+    author: 'Academy',
+    content: 'Free course class: Python Basics starts tomorrow.',
+    category: 'class',
+    createdAt: new Date(),
+    likes: 0,
+    comments: [],
+    shares: 0,
+    reports: 0,
+  },
+  {
+    id: randomUUID(),
+    author: 'Podcaster',
+    content: 'Live podcast scheduled: Startup Stories.',
+    category: 'podcast',
+    createdAt: new Date(),
+    likes: 0,
+    comments: [],
+    shares: 0,
+    reports: 0,
+  },
+  {
+    id: randomUUID(),
+    author: 'TaskMaster',
+    content: 'New task uploaded: Fix bug in authentication flow.',
+    category: 'tasks',
+    createdAt: new Date(),
+    likes: 0,
+    comments: [],
+    shares: 0,
+    reports: 0,
+  },
+  {
+    id: randomUUID(),
+    author: 'Networking',
+    content: 'Upcoming networking session: Tech meet this Friday.',
+    category: 'networking',
+    createdAt: new Date(),
+    likes: 0,
+    comments: [],
+    shares: 0,
+    reports: 0,
   },
 ];
 
@@ -20,7 +124,17 @@ function listPosts(category) {
 }
 
 function addPost({ author, content, category }) {
-  const post = { id: randomUUID(), author, content, category, createdAt: new Date(), likes: 0 };
+  const post = {
+    id: randomUUID(),
+    author,
+    content,
+    category,
+    createdAt: new Date(),
+    likes: 0,
+    comments: [],
+    shares: 0,
+    reports: 0,
+  };
   posts.unshift(post);
   return post;
 }
@@ -40,4 +154,35 @@ function addLike(postId) {
   return post;
 }
 
-module.exports = { listPosts, addPost, listEvents, getPost, addLike };
+function addComment(postId, { author, content }) {
+  const post = getPost(postId);
+  if (!post) return null;
+  const comment = { id: randomUUID(), author, content, createdAt: new Date() };
+  post.comments.push(comment);
+  return post;
+}
+
+function addShare(postId) {
+  const post = getPost(postId);
+  if (!post) return null;
+  post.shares = (post.shares || 0) + 1;
+  return post;
+}
+
+function reportPost(postId) {
+  const post = getPost(postId);
+  if (!post) return null;
+  post.reports = (post.reports || 0) + 1;
+  return post;
+}
+
+module.exports = {
+  listPosts,
+  addPost,
+  listEvents,
+  getPost,
+  addLike,
+  addComment,
+  addShare,
+  reportPost,
+};

--- a/backend/routes/liveFeed.js
+++ b/backend/routes/liveFeed.js
@@ -1,8 +1,22 @@
 const express = require('express');
 const auth = require('../middleware/auth');
 const validate = require('../middleware/validate');
-const { postSchema, categoryQuerySchema, postIdParamSchema } = require('../validation/liveFeed');
-const { listPosts, createPostHandler, listEventsHandler, likePostHandler } = require('../controllers/liveFeed');
+const {
+  postSchema,
+  categoryQuerySchema,
+  postIdParamSchema,
+  commentSchema,
+  reportSchema,
+} = require('../validation/liveFeed');
+const {
+  listPosts,
+  createPostHandler,
+  listEventsHandler,
+  likePostHandler,
+  commentPostHandler,
+  sharePostHandler,
+  reportPostHandler,
+} = require('../controllers/liveFeed');
 
 const router = express.Router();
 
@@ -10,5 +24,20 @@ router.get('/posts', auth, validate(categoryQuerySchema, 'query'), listPosts);
 router.post('/posts', auth, validate(postSchema, 'body'), createPostHandler);
 router.get('/events', auth, listEventsHandler);
 router.post('/posts/:postId/like', auth, validate(postIdParamSchema, 'params'), likePostHandler);
+router.post(
+  '/posts/:postId/comments',
+  auth,
+  validate(postIdParamSchema, 'params'),
+  validate(commentSchema, 'body'),
+  commentPostHandler
+);
+router.post('/posts/:postId/share', auth, validate(postIdParamSchema, 'params'), sharePostHandler);
+router.post(
+  '/posts/:postId/report',
+  auth,
+  validate(postIdParamSchema, 'params'),
+  validate(reportSchema, 'body'),
+  reportPostHandler
+);
 
 module.exports = router;

--- a/backend/services/liveFeed.js
+++ b/backend/services/liveFeed.js
@@ -28,4 +28,46 @@ async function likePost(postId) {
   return post;
 }
 
-module.exports = { getPosts, createPost, getEvents, likePost };
+async function commentPost(postId, user, data) {
+  const content = sanitize(data.content);
+  const post = model.addComment(postId, {
+    author: user.username || 'Anonymous',
+    content,
+  });
+  if (!post) {
+    logger.warn('Attempted to comment on missing post', { postId });
+    return null;
+  }
+  logger.info('Comment added to post', { postId, userId: user.id });
+  return post;
+}
+
+async function sharePost(postId) {
+  const post = model.addShare(postId);
+  if (!post) {
+    logger.warn('Attempted to share missing post', { postId });
+    return null;
+  }
+  logger.info('Post shared', { postId });
+  return post;
+}
+
+async function reportPost(postId) {
+  const post = model.reportPost(postId);
+  if (!post) {
+    logger.warn('Attempted to report missing post', { postId });
+    return null;
+  }
+  logger.info('Post reported', { postId });
+  return post;
+}
+
+module.exports = {
+  getPosts,
+  createPost,
+  getEvents,
+  likePost,
+  commentPost,
+  sharePost,
+  reportPost,
+};

--- a/backend/tests/liveFeed.test.js
+++ b/backend/tests/liveFeed.test.js
@@ -7,5 +7,8 @@ describe('liveFeed routes', () => {
     const content = fs.readFileSync(filePath, 'utf8');
     expect(content).toMatch(/express\.Router\(/);
     expect(content).toMatch(/module\.exports\s*=\s*router/);
+    expect(content).toMatch(/posts\/:postId\/comments/);
+    expect(content).toMatch(/posts\/:postId\/share/);
+    expect(content).toMatch(/posts\/:postId\/report/);
   });
 });

--- a/backend/validation/liveFeed.js
+++ b/backend/validation/liveFeed.js
@@ -1,16 +1,48 @@
 const Joi = require('joi');
 
+const categories = [
+  'employment',
+  'freelancing',
+  'education',
+  'networking',
+  'local',
+  'general',
+  'gig',
+  'contract',
+  'profile',
+  'course',
+  'webinar',
+  'class',
+  'podcast',
+  'task',
+  'tasks',
+];
+
 const postSchema = Joi.object({
   content: Joi.string().min(1).max(500).required(),
-  category: Joi.string().valid('employment', 'freelancing', 'education', 'networking', 'local', 'general').optional(),
+  category: Joi.string().valid(...categories).optional(),
 });
 
 const categoryQuerySchema = Joi.object({
-  category: Joi.string().valid('employment', 'freelancing', 'education', 'networking', 'local', 'general').optional(),
+  category: Joi.string().valid(...categories).optional(),
 });
 
 const postIdParamSchema = Joi.object({
   postId: Joi.string().required(),
 });
 
-module.exports = { postSchema, categoryQuerySchema, postIdParamSchema };
+const commentSchema = Joi.object({
+  content: Joi.string().min(1).max(250).required(),
+});
+
+const reportSchema = Joi.object({
+  reason: Joi.string().max(250).optional(),
+});
+
+module.exports = {
+  postSchema,
+  categoryQuerySchema,
+  postIdParamSchema,
+  commentSchema,
+  reportSchema,
+};

--- a/frontend/src/api/liveFeed.js
+++ b/frontend/src/api/liveFeed.js
@@ -20,3 +20,18 @@ export async function likePost(postId) {
   const { data } = await apiClient.post(`/live-feed/posts/${postId}/like`);
   return data;
 }
+
+export async function commentPost(postId, payload) {
+  const { data } = await apiClient.post(`/live-feed/posts/${postId}/comments`, payload);
+  return data;
+}
+
+export async function sharePost(postId) {
+  const { data } = await apiClient.post(`/live-feed/posts/${postId}/share`);
+  return data;
+}
+
+export async function reportPost(postId, payload = {}) {
+  const { data } = await apiClient.post(`/live-feed/posts/${postId}/report`, payload);
+  return data;
+}

--- a/frontend/src/styles/LiveFeedPage.css
+++ b/frontend/src/styles/LiveFeedPage.css
@@ -10,3 +10,15 @@
 .events-sidebar {
   max-width: 250px;
 }
+
+.post-meta {
+  color: #666;
+}
+
+.post-actions button {
+  margin-right: 4px;
+}
+
+.comment {
+  margin-left: 8px;
+}

--- a/frontend/src/utils/actionQueue.js
+++ b/frontend/src/utils/actionQueue.js
@@ -1,0 +1,12 @@
+export default class ActionQueue {
+  constructor() {
+    this.queue = Promise.resolve();
+  }
+
+  enqueue(action) {
+    this.queue = this.queue.then(() => action()).catch((err) => {
+      console.error('ActionQueue error', err);
+    });
+    return this.queue;
+  }
+}


### PR DESCRIPTION
## Summary
- expand live feed posts to track comments, shares, and reports
- add API endpoints and frontend UI for filtering, reacting, commenting, sharing, and reporting posts
- introduce simple action queue to process feed interactions sequentially

## Testing
- `npm test --workspaces`

------
https://chatgpt.com/codex/tasks/task_e_6893e7e34448832094498321b04c462d