### PR TITLE
docs: add IDE setup guidelines

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint",
+    "visualstudioexptteam.vscodeintellicode",
+    "eamodio.gitlens"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "editor.formatOnSave": true,
+  "files.eol": "\n",
+  "eslint.workingDirectories": [
+    { "directory": "backend", "changeProcessCWD": true },
+    { "directory": "frontend", "changeProcessCWD": true }
+  ]
+}

--- a/IDE_SETUP.md
+++ b/IDE_SETUP.md
@@ -1,0 +1,39 @@
+# IDE Setup
+
+This project can be developed with any editor, but the repository includes
+recommendations for [Visual Studio Code](https://code.visualstudio.com/).
+
+## Extensions
+The `.vscode/extensions.json` file recommends useful extensions:
+
+- **Prettier** – code formatter.
+- **ESLint** – linting for JavaScript/TypeScript.
+- **Intellicode** – AI-assisted code completion.
+- **GitLens** – Git history and insights.
+
+VS Code prompts to install these when the workspace is opened.
+
+## Settings
+The `.vscode/settings.json` file enables format-on-save and configures ESLint to
+look for configurations in both `frontend` and `backend` directories.
+
+## Node version
+The project targets Node 18+.  Using a version manager such as
+[nvm](https://github.com/nvm-sh/nvm) is recommended:
+
+```bash
+nvm install 18
+nvm use 18
+```
+
+## Formatting and linting
+If you install the recommended extensions, files will be formatted automatically
+on save.  Lint errors will show in the editor and in the Problems panel.
+
+## Debugging
+Both the frontend and backend can be debugged from VS Code:
+
+1. Use **Run and Debug → create a launch.json file**.
+2. For the backend, select *Node.js* and set the program to `backend/app.js`.
+3. For the frontend, select *Vite* or *npm* and run the `dev` script.
+

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ If you prefer separate deployments, create one Vercel project with `frontend/` a
 Detailed endpoint and UI design notes live in:
 - `backend_guide.md` – overview of backend routes and planned services.
 - `frontend_guide.md` – roadmap for frontend pages and design principles.
+- `IDE_SETUP.md` – editor recommendations and debugging tips.
 
 ## Contributing
 Contributions are welcome! Fork the repository, create a branch and open a pull request.


### PR DESCRIPTION
## Summary
- document IDE setup with recommended extensions and debugging tips
- add VS Code settings and extension recommendations
- reference IDE setup guide from README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ea957d3483209fce22595a12ebe5