### PR TITLE
feat(workspace): enhance dashboard summary

### DIFF
--- a/frontend/components/WorkspaceSummary.jsx
+++ b/frontend/components/WorkspaceSummary.jsx
@@ -1,30 +1,37 @@
 import { SimpleGrid, Stat, StatLabel, StatNumber } from '@chakra-ui/react';
 import '../styles/WorkspaceSummary.css';
 
-export default function WorkspaceSummary({ data = [] }) {
-  if (!data.length) return null;
-  const totals = data.reduce(
-    (acc, item) => ({
-      activeUsers: acc.activeUsers + (item.activeUsers || 0),
-      projectsCreated: acc.projectsCreated + (item.projectsCreated || 0),
-      messagesExchanged: acc.messagesExchanged + (item.messagesExchanged || 0),
-    }),
-    { activeUsers: 0, projectsCreated: 0, messagesExchanged: 0 }
-  );
+export default function WorkspaceSummary({ stats }) {
+  if (!stats) return null;
+  const {
+    activeUsers = 0,
+    projects = 0,
+    tasks = 0,
+    team = 0,
+    budget = 0,
+  } = stats;
 
   return (
-    <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4} className="workspace-summary">
+    <SimpleGrid columns={{ base: 1, md: 5 }} spacing={4} className="workspace-summary">
       <Stat>
         <StatLabel>Active Users</StatLabel>
-        <StatNumber>{totals.activeUsers}</StatNumber>
+        <StatNumber>{activeUsers}</StatNumber>
       </Stat>
       <Stat>
         <StatLabel>Projects</StatLabel>
-        <StatNumber>{totals.projectsCreated}</StatNumber>
+        <StatNumber>{projects}</StatNumber>
       </Stat>
       <Stat>
-        <StatLabel>Messages</StatLabel>
-        <StatNumber>{totals.messagesExchanged}</StatNumber>
+        <StatLabel>Tasks</StatLabel>
+        <StatNumber>{tasks}</StatNumber>
+      </Stat>
+      <Stat>
+        <StatLabel>Team Members</StatLabel>
+        <StatNumber>{team}</StatNumber>
+      </Stat>
+      <Stat>
+        <StatLabel>Budget Spent</StatLabel>
+        <StatNumber>${budget.toFixed(2)}</StatNumber>
       </Stat>
     </SimpleGrid>
   );

--- a/frontend/pages/Dashboard.jsx
+++ b/frontend/pages/Dashboard.jsx
@@ -8,7 +8,6 @@ import { ChakraProvider, Box, Heading, Button } from '@chakra-ui/react';
 import { Link as RouterLink } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import NavMenu from '../components/NavMenu';
-import WorkspaceSummary from '../components/WorkspaceSummary';
 import { fetchWorkspaceOverview } from '../api/workspace';
 import { ChakraProvider, Box, Heading, Link } from '@chakra-ui/react';
 import { Link as RouterLink } from 'react-router-dom';
@@ -47,7 +46,6 @@ export default function Dashboard() {
         <Button colorScheme="teal" onClick={() => (window.location.href = '/ads')}>Manage Ads</Button>
         <Button as={RouterLink} to="/opportunities" colorScheme="teal">
           Manage Opportunities
-        <WorkspaceSummary data={overview} />
         <Button as={RouterLink} to="/workspace" mt={6} colorScheme="teal">
           Open Workspace
         <Link as={RouterLink} to="/ads" color="blue.500">

--- a/frontend/pages/WorkspaceDashboard.jsx
+++ b/frontend/pages/WorkspaceDashboard.jsx
@@ -1,12 +1,25 @@
-import { Box, Heading, SimpleGrid, Spinner, useToast } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
-import { ChakraProvider, Box, Heading, SimpleGrid, Spinner, Flex, Button } from '@chakra-ui/react';
+import {
+  ChakraProvider,
+  Box,
+  Heading,
+  SimpleGrid,
+  Spinner,
+  useToast,
+  Flex,
+  Button,
+} from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
 import NavMenu from '../components/NavMenu';
 import WorkspaceSummary from '../components/WorkspaceSummary';
 import ProjectCard from '../components/ProjectCard';
-import { fetchWorkspaceOverview, fetchProjects, fetchProjectTasks, fetchProjectBudget, fetchProjectTeam } from '../api/workspace';
+import {
+  fetchWorkspaceOverview,
+  fetchProjects,
+  fetchProjectTasks,
+  fetchProjectBudget,
+  fetchProjectTeam,
+} from '../api/workspace';
 import '../styles/WorkspaceDashboard.css';
 
 export default function WorkspaceDashboard() {
@@ -41,22 +54,15 @@ export default function WorkspaceDashboard() {
     load();
   }, [toast]);
 
+  const stats = {
+    activeUsers: overview.reduce((sum, o) => sum + (o.activeUsers || 0), 0),
+    projects: projects.length,
+    tasks: projects.reduce((sum, p) => sum + (p.tasks?.length || 0), 0),
+    team: projects.reduce((sum, p) => sum + (p.team?.length || 0), 0),
+    budget: projects.reduce((sum, p) => sum + (p.budget?.totalSpent || 0), 0),
+  };
+
   return (
-    <Box p={4} className="workspace-dashboard">
-      <Heading mb={4}>Workspace Dashboard</Heading>
-      {loading ? (
-        <Spinner />
-      ) : (
-        <>
-          <WorkspaceSummary data={overview} />
-          <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4} mt={4}>
-            {projects.map((p) => (
-              <ProjectCard key={p.id} project={p} />
-            ))}
-          </SimpleGrid>
-        </>
-      )}
-    </Box>
     <ChakraProvider>
       <NavMenu />
       <Box p={4} className="workspace-dashboard">
@@ -70,7 +76,7 @@ export default function WorkspaceDashboard() {
           <Spinner />
         ) : (
           <>
-            <WorkspaceSummary data={overview} />
+            <WorkspaceSummary stats={stats} />
             <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4} mt={4}>
               {projects.map((p) => (
                 <ProjectCard key={p.id} project={p} />
@@ -82,3 +88,4 @@ export default function WorkspaceDashboard() {
     </ChakraProvider>
   );
 }
+


### PR DESCRIPTION
## Summary
- expand workspace summary with tasks, team and budget metrics
- rebuild workspace dashboard layout with aggregated stats and calendar link
- drop obsolete workspace summary usage from main dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893eb1a3bd48320bd10ce2366753db9