### PR TITLE
feat: upgrade user settings to enterprise

### DIFF
--- a/backend/models/settings.js
+++ b/backend/models/settings.js
@@ -10,6 +10,7 @@ function getSettingsByUserId(userId) {
       notifications: { jobUpdates: true, messages: true },
       language: 'en',
       region: 'UTC',
+      accountLevel: 'enterprise',
     }
   );
 }

--- a/backend/tests/settings.test.js
+++ b/backend/tests/settings.test.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { getSettingsByUserId } = require('../models/settings');
 
 describe('settings routes', () => {
   test('should define an Express router', () => {
@@ -7,5 +8,12 @@ describe('settings routes', () => {
     const content = fs.readFileSync(filePath, 'utf8');
     expect(content).toMatch(/express\.Router\(/);
     expect(content).toMatch(/module\.exports\s*=\s*router/);
+  });
+});
+
+describe('default account level', () => {
+  test('new users are upgraded to enterprise', () => {
+    const settings = getSettingsByUserId('test-user');
+    expect(settings.accountLevel).toBe('enterprise');
   });
 });

--- a/backend/validation/settings.js
+++ b/backend/validation/settings.js
@@ -12,6 +12,7 @@ const updateSettingsSchema = Joi.object({
   profileVisibility: Joi.string().valid('public', 'private', 'restricted'),
   language: Joi.string().allow(''),
   region: Joi.string().allow(''),
+  accountLevel: Joi.string().valid('free', 'pro', 'enterprise'),
   notifications: notificationSchema,
 });
 

--- a/frontend/pages/SettingsPage.jsx
+++ b/frontend/pages/SettingsPage.jsx
@@ -25,6 +25,7 @@ export default function SettingsPage() {
     profileVisibility: 'public',
     language: 'en',
     region: 'UTC',
+    accountLevel: 'enterprise',
     notifications: { jobUpdates: true, messages: true },
   });
   const [timezones, setTimezones] = useState([]);
@@ -116,6 +117,14 @@ export default function SettingsPage() {
                     {tz}
                   </option>
                 ))}
+              </Select>
+            </FormControl>
+            <FormControl>
+              <FormLabel>Account Level</FormLabel>
+              <Select name="accountLevel" value={form.accountLevel} onChange={handleChange}>
+                <option value="free">Free</option>
+                <option value="pro">Pro</option>
+                <option value="enterprise">Enterprise</option>
               </Select>
             </FormControl>
             <FormControl display="flex" alignItems="center">


### PR DESCRIPTION
## Summary
- add `accountLevel` with enterprise default in backend settings
- allow updating account level and expose selection on settings page
- ensure default account level tested

## Testing
- `npm test --workspaces 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6893eb3396948320872478b7a8c11639