### PR TITLE
feat: improve setup wizard and Apache frontend support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@
 API_BASE_URL=/api
 APP_ID=workhouse
 APP_URL=http://localhost:5173
+SITE_NAME=Workhouse
 
 # --------------------------------------------------
 # Database (PostgreSQL)

--- a/SETUP.md
+++ b/SETUP.md
@@ -17,17 +17,26 @@ From the repository root you can launch the interactive setup wizard:
 npm run setup
 ```
 
-The wizard will ask for PostgreSQL credentials and then run the migrations and
-seeders. All environment variables are written to `backend/.env` with safe
-placeholders so the server starts even if optional keys are missing. The wizard
-also exposes the frontend under `VITE_APP_URL` so the browser UI can resolve
-the correct site address.
+The wizard will show the current configuration from `backend/.env`, logging it
+to `backend/scripts/setup.log`. You can keep the existing values or enter new
+ones for the site name, site URL and database credentials. When finished, the
+wizard runs migrations and seeders, then exposes the frontend under
+`VITE_APP_URL` so the browser UI can resolve the correct site address.
 
 After setup you can start the API with:
 
 ```bash
 npm start
 ```
+
+The frontend dev server can be launched with:
+
+```bash
+npm run start:frontend
+```
+
+For deployment behind Apache, the `frontend/.htaccess` file rewrites requests to
+`index.html` so the Vite single-page app loads correctly.
 
 ## Environment variables
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,8 @@
 # Server
 # --------------------------------------------------
 PORT=5000
+SITE_NAME=Workhouse
+SITE_URL=http://localhost:5173
 
 # --------------------------------------------------
 # Database (PostgreSQL)

--- a/backend/scripts/setupWizard.js
+++ b/backend/scripts/setupWizard.js
@@ -3,7 +3,23 @@ const path = require('path');
 const readline = require('readline');
 const { execSync } = require('child_process');
 
+const envPath = path.join(__dirname, '..', '.env');
+const logPath = path.join(__dirname, 'setup.log');
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+// Load existing configuration if present
+let current = {};
+if (fs.existsSync(envPath)) {
+  const lines = fs.readFileSync(envPath, 'utf8').split('\n');
+  for (const line of lines) {
+    const [k, v] = line.split('=');
+    if (k) current[k.trim()] = v ? v.replace(/^"|"$/g, '').trim() : '';
+  }
+  console.log('Current configuration:');
+  Object.entries(current).forEach(([k, v]) => console.log(`${k}=${v}`));
+} else {
+  console.log('No existing .env found. Using defaults.');
+}
 
 // Launch default browser to show the UI once setup completes
 function openBrowser(url) {
@@ -20,28 +36,31 @@ function openBrowser(url) {
 }
 
 const questions = [
-  { key: 'DB_TYPE', question: 'Database type (postgres/mysql)', default: 'postgres' },
-  { key: 'DB_HOST', question: 'Database host', default: 'localhost' },
-  { key: 'DB_PORT', question: 'Database port', default: '5432' },
-  { key: 'DB_USER', question: 'Database user', default: 'workhouse' },
-  { key: 'DB_PASSWORD', question: 'Database password', default: 'workhouse' },
-  { key: 'DB_NAME', question: 'Database name', default: 'workhouse' },
+  { key: 'SITE_NAME', question: 'Site name', default: current.SITE_NAME || 'Workhouse' },
+  { key: 'SITE_URL', question: 'Site URL', default: current.SITE_URL || 'http://localhost:5173' },
+  { key: 'DB_TYPE', question: 'Database type (postgres/mysql)', default: current.DB_TYPE || 'postgres' },
+  { key: 'DB_HOST', question: 'Database host', default: current.DB_HOST || 'localhost' },
+  { key: 'DB_PORT', question: 'Database port', default: current.DB_PORT || '5432' },
+  { key: 'DB_USER', question: 'Database user', default: current.DB_USER || 'workhouse' },
+  { key: 'DB_PASSWORD', question: 'Database password', default: current.DB_PASSWORD || 'workhouse' },
+  { key: 'DB_NAME', question: 'Database name', default: current.DB_NAME || 'workhouse' },
 ];
 
 const answers = {};
 
 function ask(index = 0) {
   if (index === questions.length) {
-    const envPath = path.join(__dirname, '..', '.env');
     const content =
-      questions.map(q => `${q.key}=${JSON.stringify(answers[q.key])}`).join('\n') + '\n';
+      questions.map(q => `${q.key}=${JSON.stringify(answers[q.key])}`).join('\n') +
+      `\nVITE_APP_URL=${JSON.stringify(answers.SITE_URL)}\n`;
     fs.writeFileSync(envPath, content);
+    fs.appendFileSync(logPath, `${new Date().toISOString()}\n${content}\n`);
     console.log(`Created ${envPath}`);
     try {
       execSync('node scripts/dbSetup.js', { stdio: 'inherit' });
       execSync('node scripts/seedData.js', { stdio: 'inherit' });
       // open frontend for convenience
-      openBrowser('http://localhost:5173');
+      openBrowser(answers.SITE_URL);
     } catch (err) {
       console.error('Setup scripts failed:', err.message);
     }
@@ -50,7 +69,7 @@ function ask(index = 0) {
   }
   const q = questions[index];
   if (q.key === 'DB_PORT') {
-    q.default = answers.DB_TYPE === 'mysql' ? '3306' : '5432';
+    q.default = answers.DB_TYPE === 'mysql' ? '3306' : (current.DB_PORT || '5432');
   }
   rl.question(`${q.question} (${q.default}): `, answer => {
     answers[q.key] = answer || q.default;

--- a/frontend/.htaccess
+++ b/frontend/.htaccess
@@ -1,0 +1,8 @@
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+  RewriteBase /
+  RewriteRule ^index\.html$ - [L]
+  RewriteCond %{REQUEST_FILENAME} !-f
+  RewriteCond %{REQUEST_FILENAME} !-d
+  RewriteRule . /index.html [L]
+</IfModule>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite",
+    "start": "vite",
     "build": "node scripts/build.js",
     "test": "node scripts/test.js"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "workspaces": ["frontend", "backend"],
   "scripts": {
     "test": "npm test --workspaces",
+    "start": "npm start --workspace backend",
     "start:frontend": "npm run dev --workspace frontend",
     "start:backend": "npm start --workspace backend",
     "setup": "npm run setup --workspace backend"


### PR DESCRIPTION
## Summary
- support Apache deployments with SPA-friendly `.htaccess`
- enhance setup wizard to show current env, capture site name/URL and database credentials, and log to `setup.log`
- document new workflow and start commands in setup guide

## Testing
- `npm test`
- `node -e "const fs=require('fs'); const Parser=require('node-sql-parser').Parser; const parser=new Parser({database:'postgresql'}); let sql=fs.readFileSync('backend/database/database.sql','utf8').replace(/\\[^\n]*\n/g,''); try{parser.parse(sql); console.log('Parsed OK');}catch(e){console.error('SQL parse error:', e.message);}}" 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6893f46fe78083208b729122e0bde938