### PR TITLE
feat: add user seed data with cleanup script

### DIFF
--- a/backend/data/users.json
+++ b/backend/data/users.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "11111111-1111-1111-1111-111111111111",
+    "username": "demoUser",
+    "password": "password123",
+    "role": "user",
+    "full_name": "Demo User",
+    "email": "demo@example.com",
+    "phone": "1234567890",
+    "location": "Demo City",
+    "bio": "Example bio",
+    "expertise": "Testing"
+  },
+  {
+    "id": "22222222-2222-2222-2222-222222222222",
+    "username": "adminUser",
+    "password": "adminpass",
+    "role": "admin",
+    "full_name": "Admin User",
+    "email": "admin@example.com",
+    "phone": "9876543210",
+    "location": "Admin City",
+    "bio": "Administrator",
+    "expertise": "Administration"
+  }
+]

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "setup": "node scripts/setupWizard.js",
     "db:migrate": "node scripts/dbSetup.js",
     "db:seed": "node scripts/seedData.js",
+    "db:clear": "node scripts/clearSeedData.js",
     "n8n:setup": "node scripts/setupN8n.js"
   },
   "dependencies": {

--- a/backend/scripts/clearSeedData.js
+++ b/backend/scripts/clearSeedData.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+function escape(str) {
+  return str.replace(/'/g, "''");
+}
+
+async function clearUsers() {
+  const dataPath = path.join(__dirname, '..', 'data', 'users.json');
+  if (!fs.existsSync(dataPath)) return;
+  const users = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  const dbName = process.env.DB_NAME || 'workhouse';
+
+  for (const u of users) {
+    const query = `DELETE FROM users WHERE id='${escape(u.id)}';`;
+    execSync(`echo "${query}" | sudo -u postgres psql -d ${dbName}`, { stdio: 'inherit' });
+  }
+  console.log('Cleared users');
+}
+
+async function clearProducts() {
+  const dataPath = path.join(__dirname, '..', 'data', 'products.json');
+  if (!fs.existsSync(dataPath)) return;
+  const products = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  const dbName = process.env.DB_NAME || 'workhouse';
+
+  for (const p of products) {
+    const query = `DELETE FROM products WHERE id='${escape(p.id)}';`;
+    execSync(`echo "${query}" | sudo -u postgres psql -d ${dbName}`, { stdio: 'inherit' });
+  }
+  console.log('Cleared products');
+}
+
+async function run() {
+  await clearUsers();
+  await clearProducts();
+}
+
+run().catch(err => {
+  console.error('Clearing failed:', err);
+  process.exit(1);
+});

--- a/backend/scripts/seedData.js
+++ b/backend/scripts/seedData.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
+const bcrypt = require('bcryptjs');
 
 function escape(str) {
   return str.replace(/'/g, "''");
@@ -19,7 +20,22 @@ async function seedProducts() {
   console.log('Seeded products');
 }
 
+async function seedUsers() {
+  const dataPath = path.join(__dirname, '..', 'data', 'users.json');
+  if (!fs.existsSync(dataPath)) return;
+  const users = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  const dbName = process.env.DB_NAME || 'workhouse';
+
+  for (const u of users) {
+    const hash = bcrypt.hashSync(u.password, 10);
+    const query = `INSERT INTO users (id, username, password_hash, role, full_name, email, phone, location, bio, expertise) VALUES ('${escape(u.id)}', '${escape(u.username)}', '${hash}', '${escape(u.role)}', '${escape(u.full_name)}', '${escape(u.email)}', '${escape(u.phone)}', '${escape(u.location)}', '${escape(u.bio)}', '${escape(u.expertise)}') ON CONFLICT (id) DO UPDATE SET username = EXCLUDED.username, password_hash = EXCLUDED.password_hash, role = EXCLUDED.role, full_name = EXCLUDED.full_name, email = EXCLUDED.email, phone = EXCLUDED.phone, location = EXCLUDED.location, bio = EXCLUDED.bio, expertise = EXCLUDED.expertise;`;
+    execSync(`echo "${query}" | sudo -u postgres psql -d ${dbName}`, { stdio: 'inherit' });
+  }
+  console.log('Seeded users');
+}
+
 async function run() {
+  await seedUsers();
   await seedProducts();
 }
 


### PR DESCRIPTION
## Summary
- add dummy users for database seeding
- extend seed script to populate users and products
- include script to clear seeded data

## Testing
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_6893f531f2508320b8af013e5b7f5969