### PR TITLE
Add profile seed data and cleanup utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Workhouse/
    ```bash
    npm run setup
    ```
+4. **Populate sample data** (optional):
+   ```bash
+   npm run db:seed --workspace backend  # load demo users, products and profiles
+   # later you can remove them with
+   npm run db:clear --workspace backend
+   ```
 
 ## Running the App
 ### Development

--- a/agents.md
+++ b/agents.md
@@ -5,7 +5,7 @@ The following stages outline tasks to bring the Workhouse platform to a producti
 ## Stage 1: Backend Foundation
 - Consolidate backend and frontend under unified `app.js` orchestrator.
 - Expose backend API and frontend assets on separate ports via the unified server.
-- Add database models, migrations, and seeding strategy.
+- Add database models, migrations, and seeding strategy with dummy data and cleanup scripts.
 - Implement automated testing for core services.
 
 ## Stage 2: Frontend Integration

--- a/backend/data/profiles.json
+++ b/backend/data/profiles.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "33333333-3333-3333-3333-333333333333",
+    "user_id": "11111111-1111-1111-1111-111111111111",
+    "role": "mentor",
+    "full_name": "Demo User",
+    "title": "Developer",
+    "location": "Demo City",
+    "avatar_url": "https://via.placeholder.com/150",
+    "bio": "Experienced developer",
+    "contact": { "email": "demo@example.com" },
+    "preferences": { "theme": "dark" },
+    "skills": ["javascript", "node.js"],
+    "portfolio": { "website": "https://demo.dev" },
+    "visibility": { "profile": "public" },
+    "theme": { "color": "blue" }
+  },
+  {
+    "id": "44444444-4444-4444-4444-444444444444",
+    "user_id": "22222222-2222-2222-2222-222222222222",
+    "role": "mentee",
+    "full_name": "Admin User",
+    "title": "Administrator",
+    "location": "Admin City",
+    "avatar_url": "https://via.placeholder.com/150",
+    "bio": "Aspiring administrator",
+    "contact": { "email": "admin@example.com" },
+    "preferences": { "theme": "light" },
+    "skills": ["management", "planning"],
+    "portfolio": { "website": "https://admin.example.com" },
+    "visibility": { "profile": "private" },
+    "theme": { "color": "green" }
+  }
+]

--- a/backend/scripts/clearSeedData.js
+++ b/backend/scripts/clearSeedData.js
@@ -32,9 +32,23 @@ async function clearProducts() {
   console.log('Cleared products');
 }
 
+async function clearProfiles() {
+  const dataPath = path.join(__dirname, '..', 'data', 'profiles.json');
+  if (!fs.existsSync(dataPath)) return;
+  const profiles = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
+  const dbName = process.env.DB_NAME || 'workhouse';
+
+  for (const p of profiles) {
+    const query = `DELETE FROM profiles WHERE id='${escape(p.id)}';`;
+    execSync(`echo "${query}" | sudo -u postgres psql -d ${dbName}`, { stdio: 'inherit' });
+  }
+  console.log('Cleared profiles');
+}
+
 async function run() {
   await clearUsers();
   await clearProducts();
+  await clearProfiles();
 }
 
 run().catch(err => {


### PR DESCRIPTION
## Summary
- expand Stage 1 roadmap with explicit dummy data seeding and cleanup guidance
- seed and clear profile records alongside existing users/products
- document optional sample data scripts in README

## Testing
- `node backend/scripts/seedData.js` *(fails: unknown user postgres)*
- `node backend/scripts/clearSeedData.js` *(fails: unknown user postgres)*
- `npm test --workspaces`


------
https://chatgpt.com/codex/tasks/task_e_6893f8caede483209fd084c46d90497c