### PR TITLE
chore: add syntax check scripts

### DIFF
--- a/scripts/check-backend.js
+++ b/scripts/check-backend.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { execSync } = require('child_process');
+
+const dirs = [
+  'backend/api',
+  'backend/config',
+  'backend/controllers',
+  'backend/data',
+  'backend/database',
+  'backend/middleware',
+  'backend/models',
+  'backend/routes',
+  'backend/services',
+  'backend/scripts',
+  'backend/utils',
+  'backend/validation',
+  'backend/validators'
+];
+
+const jsFiles = [];
+const pyFiles = [];
+const shFiles = [];
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full);
+    } else {
+      if (full.endsWith('.js')) jsFiles.push(full);
+      else if (full.endsWith('.py')) pyFiles.push(full);
+      else if (full.endsWith('.sh')) shFiles.push(full);
+    }
+  }
+}
+
+dirs.forEach(dir => {
+  if (fs.existsSync(dir)) walk(dir);
+});
+
+// Root-level files
+if (fs.existsSync('backend/app.js')) jsFiles.push('backend/app.js');
+if (fs.existsSync('app.js')) jsFiles.push('app.js');
+if (fs.existsSync('db_setup')) shFiles.push('db_setup');
+
+const errors = [];
+
+jsFiles.forEach(file => {
+  try {
+    const code = fs.readFileSync(file, 'utf8');
+    new vm.Script(code, { filename: file });
+  } catch (err) {
+    errors.push(`JS syntax error in ${file}:\n${err.message}`);
+  }
+});
+
+pyFiles.forEach(file => {
+  try {
+    execSync(`python -m py_compile "${file}"`, { stdio: 'pipe' });
+  } catch (err) {
+    errors.push(`Python syntax error in ${file}:\n${err.stderr.toString()}`);
+  }
+});
+
+shFiles.forEach(file => {
+  try {
+    execSync(`bash -n "${file}"`, { stdio: 'pipe' });
+  } catch (err) {
+    errors.push(`Shell syntax error in ${file}:\n${err.stderr.toString()}`);
+  }
+});
+
+if (errors.length) {
+  console.log('Errors found:');
+  console.log(errors.join('\n\n'));
+  process.exit(1);
+} else {
+  console.log('No syntax errors found in backend.');
+}

--- a/scripts/check-frontend.js
+++ b/scripts/check-frontend.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const esbuild = require(path.join(__dirname, '..', 'frontend', 'node_modules', 'esbuild'));
+
+process.chdir('frontend');
+
+const files = [];
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full);
+    } else if (full.endsWith('.js') || full.endsWith('.jsx')) {
+      files.push(full);
+    }
+  }
+}
+
+walk('src');
+if (fs.existsSync('pages')) walk('pages');
+if (fs.existsSync('scripts')) walk('scripts');
+if (fs.existsSync('components')) walk('components');
+if (fs.existsSync('context')) walk('context');
+if (fs.existsSync('utils')) walk('utils');
+if (fs.existsSync('views')) walk('views');
+if (fs.existsSync('api')) walk('api');
+
+const errors = [];
+for (const file of files) {
+  try {
+    esbuild.transformSync(fs.readFileSync(file, 'utf8'), {
+      loader: file.endsWith('.jsx') ? 'jsx' : 'js',
+      format: 'esm'
+    });
+  } catch (err) {
+    errors.push(`Build error in frontend/${file}:\n${err.message}`);
+  }
+}
+
+if (errors.length) {
+  console.log('Errors found:');
+  console.log(errors.join('\n\n'));
+  process.exit(1);
+} else {
+  console.log('No syntax errors found in frontend.');
+}


### PR DESCRIPTION
## Summary
- add Node.js script to scan backend JS/Python/shell files and report syntax issues
- add esbuild-powered script to check frontend JS/JSX files

## Testing
- `./scripts/check-backend.js`
- `./scripts/check-frontend.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893f807ba50832085de57fb2bea0dbb