### PR TITLE
feat: sanitize login inputs

### DIFF
--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -25,6 +25,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext.jsx';
 import { loginWithProvider, resetPassword } from '../api/auth.js';
+import sanitizeInput from '../utils/sanitize.js';
 import '../styles/LoginPage.css';
 
 export default function LoginPage() {
@@ -46,7 +47,12 @@ export default function LoginPage() {
     setLoading(true);
     setError('');
     try {
-      await login(email, password, use2FA ? code : undefined, remember);
+      await login(
+        sanitizeInput(email),
+        sanitizeInput(password),
+        use2FA ? sanitizeInput(code) : undefined,
+        remember
+      );
       navigate('/dashboard');
     } catch (err) {
       setError(err.message);
@@ -57,7 +63,7 @@ export default function LoginPage() {
 
   async function handleReset() {
     try {
-      await resetPassword(email, newPassword);
+      await resetPassword(sanitizeInput(email), sanitizeInput(newPassword));
       toast({ title: 'Password updated', status: 'success', duration: 3000, isClosable: true });
       setNewPassword('');
       onClose();

--- a/frontend/src/utils/sanitize.js
+++ b/frontend/src/utils/sanitize.js
@@ -1,0 +1,3 @@
+export default function sanitizeInput(value) {
+  return String(value).replace(/[<>"'`;()]/g, '').trim();
+}

--- a/frontend/src/utils/sanitize.test.js
+++ b/frontend/src/utils/sanitize.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import sanitizeInput from './sanitize.js';
+
+describe('sanitizeInput', () => {
+  it('removes dangerous characters', () => {
+    const input = '<script>alert("x");</script>';
+    expect(sanitizeInput(input)).toBe('scriptalertx/script');
+  });
+
+  it('trims whitespace', () => {
+    expect(sanitizeInput('  hello  ')).toBe('hello');
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable sanitizeInput utility
- integrate sanitization into login and password reset flows
- cover sanitization logic with unit tests

## Testing
- `npm test --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_6893fca40f4483208923ca60a484dafb