### PR TITLE
feat: add model performance analytics page

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -9,6 +9,7 @@ const tasksRoutes = require('./routes/tasks');
 const adminAuthRoutes = require('./routes/adminAuth');
 const adminDashboardRoutes = require('./routes/adminDashboard');
 const searchRoutes = require('./routes/search');
+const machineLearningRoutes = require('./routes/machineLearning');
 const api = require("./api");
 const { initDb } = require('./utils/db');
 const logger = require('./utils/logger');
@@ -28,6 +29,7 @@ app.use('/tasks', tasksRoutes);
 app.use('/admin', adminAuthRoutes);
 app.use('/admin', adminDashboardRoutes);
 app.use('/search', searchRoutes);
+app.use('/ml', machineLearningRoutes);
 
 // 404 handler
 app.use((req, res, next) => {

--- a/backend/models/machineLearning.js
+++ b/backend/models/machineLearning.js
@@ -25,6 +25,14 @@ function seedTrends() {
 
 seedTrends();
 
+// Seed a default model performance for demonstration
+addModelPerformance('recommendation', {
+  accuracy: 0.95,
+  precision: 0.92,
+  recall: 0.9,
+  f1Score: 0.91,
+});
+
 function addModelUpdate(modelName, data) {
   const model = models.get(modelName) || { name: modelName, updates: [], performance: [] };
   const update = { id: randomUUID(), data, timestamp: new Date() };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import ProfilePage from './pages/ProfilePage.jsx';
 import SettingsDashboardPage from './pages/SettingsDashboardPage.jsx';
 import GlobalSearchPage from './pages/GlobalSearchPage.jsx';
 import LandingPage from './pages/LandingPage.jsx';
+import ModelPerformancePage from './pages/ModelPerformancePage.jsx';
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 
 function Protected({ children }) {
@@ -32,6 +33,14 @@ export default function App() {
                 element={
                   <Protected>
                     <DashboardPage />
+                  </Protected>
+                }
+              />
+              <Route
+                path="/ml/performance"
+                element={
+                  <Protected>
+                    <ModelPerformancePage />
                   </Protected>
                 }
               />

--- a/frontend/src/api/machineLearning.js
+++ b/frontend/src/api/machineLearning.js
@@ -1,0 +1,8 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function fetchModelPerformance(modelName) {
+  const { data } = await apiClient.get('/ml/model-performance/evaluation', {
+    params: { modelName },
+  });
+  return data;
+}

--- a/frontend/src/nav/menu.js
+++ b/frontend/src/nav/menu.js
@@ -68,6 +68,7 @@ export const menu = [
       { label: 'Content', path: '/content/manage' },
       { label: 'Content Library', path: '/content-library' },
       { label: 'Stats', path: '/stats' },
+      { label: 'Model Performance', path: '/ml/performance' },
       { label: 'Startup Profile', path: '/startups/profile-plan' },
       { label: 'Ecosystem Dashboard', path: '/sim-dashboard' },
       { label: 'Startup Analytics', path: '/startups/analytics' },

--- a/frontend/src/pages/ModelPerformancePage.jsx
+++ b/frontend/src/pages/ModelPerformancePage.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Heading, SimpleGrid, Stat, StatLabel, StatNumber, Spinner, useToast } from '@chakra-ui/react';
+import { fetchModelPerformance } from '../api/machineLearning.js';
+import '../styles/ModelPerformancePage.css';
+
+export default function ModelPerformancePage() {
+  const [metrics, setMetrics] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const toast = useToast();
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await fetchModelPerformance('recommendation');
+        setMetrics(data);
+      } catch (err) {
+        toast({ title: 'Failed to load model performance', status: 'error' });
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [toast]);
+
+  if (loading) return <Spinner />;
+  if (!metrics) return <Box p={4}>No model performance available.</Box>;
+
+  return (
+    <Box className="model-performance-page" p={4}>
+      <Heading mb={4}>Model Performance</Heading>
+      <SimpleGrid columns={[1, 2, 4]} spacing={4}>
+        <Stat>
+          <StatLabel>Accuracy</StatLabel>
+          <StatNumber>{metrics.accuracy}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Precision</StatLabel>
+          <StatNumber>{metrics.precision}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Recall</StatLabel>
+          <StatNumber>{metrics.recall}</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>F1 Score</StatLabel>
+          <StatNumber>{metrics.f1Score}</StatNumber>
+        </Stat>
+      </SimpleGrid>
+    </Box>
+  );
+}

--- a/frontend/styles/ModelPerformancePage.css
+++ b/frontend/styles/ModelPerformancePage.css
@@ -1,0 +1,4 @@
+.model-performance-page {
+  min-height: 100vh;
+  background: #f9f9f9;
+}


### PR DESCRIPTION
## Summary
- mount machine learning routes on the backend and seed default model metrics
- add API and page to view model performance metrics with Chakra UI
- link model performance analytics into app routing and menu

## Testing
- `npm test --workspace backend`
- `npm test --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_6893fcb126748320b35646513f39111f