### PR TITLE
Load environment variables during setup

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const path = require('path');
 
 // Reuse Express from the backend dependencies to avoid duplicating

--- a/backend/scripts/clearSeedData.js
+++ b/backend/scripts/clearSeedData.js
@@ -1,3 +1,4 @@
+require('../config/env');
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');

--- a/backend/scripts/dbSetup.js
+++ b/backend/scripts/dbSetup.js
@@ -1,3 +1,4 @@
+require('../config/env');
 const fs = require('fs');
 const path = require('path');
 const net = require('net');

--- a/backend/scripts/seedData.js
+++ b/backend/scripts/seedData.js
@@ -1,3 +1,4 @@
+require('../config/env');
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
+const dotenv = require('dotenv');
 
 const root = path.resolve(__dirname, '..');
 
@@ -14,6 +15,16 @@ const envExample = path.join(root, '.env.example');
 if (!fs.existsSync(envPath) && fs.existsSync(envExample)) {
   fs.copyFileSync(envExample, envPath);
   console.log('Created .env from .env.example');
+}
+
+// Load environment variables so child processes inherit them
+dotenv.config({ path: envPath });
+
+// Ensure backend has an .env file for its config loader
+const backendEnv = path.join(root, 'backend', '.env');
+if (!fs.existsSync(backendEnv)) {
+  fs.copyFileSync(envPath, backendEnv);
+  console.log('Created backend/.env from .env');
 }
 
 console.log('Installing dependencies...');


### PR DESCRIPTION
## Summary
- load `.env` config during `npm run setup` so child processes receive environment values
- ensure backend environment file exists and database scripts load shared config
- wire root server to read `.env` on startup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68940cdcd3608320beed10285ef59167