### PR TITLE
feat: add role-based auth and unified start

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ const path = require('path');
 // installations at the repository root.
 const express = require('./backend/node_modules/express');
 const backend = require('./backend/app');
+const { initDb } = require('./backend/utils/db');
 
 const app = express();
 
@@ -32,8 +33,14 @@ app.use((req, res) => {
 });
 
 const port = process.env.PORT || 3000;
-if (require.main === module) {
+
+async function start() {
+  await initDb();
   app.listen(port, () => console.log(`Server running on port ${port}`));
+}
+
+if (require.main === module) {
+  start();
 }
 
 module.exports = app;

--- a/backend/controllers/adminAuth.js
+++ b/backend/controllers/adminAuth.js
@@ -4,7 +4,7 @@ const { findUser } = require('../models/user');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'devsecret';
 
-const ADMIN_ROLES = ['superadmin', 'admin', 'finance', 'support', 'management', 'marketing', 'hr'];
+const ADMIN_ROLES = ['super_admin', 'admin', 'finance', 'support', 'management', 'marketing', 'hr'];
 
 /**
  * Handle admin login for privileged roles.
@@ -13,11 +13,11 @@ const ADMIN_ROLES = ['superadmin', 'admin', 'finance', 'support', 'management', 
 async function adminLoginHandler(req, res) {
   const { username, password } = req.validatedBody;
   try {
-    const user = findUser(username);
+    const user = await findUser(username);
     if (!user || !ADMIN_ROLES.includes(user.role)) {
       throw new Error('Invalid credentials');
     }
-    const match = await bcrypt.compare(password, user.password);
+    const match = await bcrypt.compare(password, user.password_hash);
     if (!match) {
       throw new Error('Invalid credentials');
     }

--- a/backend/controllers/adminDashboard.js
+++ b/backend/controllers/adminDashboard.js
@@ -1,4 +1,4 @@
-const { users } = require('../models/user');
+const { countUsers } = require('../models/user');
 const supportTickets = require('../models/supportTicket');
 const disputes = require('../models/dispute');
 const flaggedContent = require('../models/flaggedContent');
@@ -7,9 +7,9 @@ const flaggedContent = require('../models/flaggedContent');
  * Provide high level site metrics for the admin dashboard.
  * Requires prior authentication and role-based authorization in route middleware.
  */
-function adminDashboardHandler(req, res) {
+async function adminDashboardHandler(req, res) {
   const overview = {
-    activeUsers: users.size,
+    activeUsers: await countUsers(),
     flaggedContent: flaggedContent.listFlags('pending').length,
     openTickets: supportTickets
       .findAll()

--- a/backend/database/users.sql
+++ b/backend/database/users.sql
@@ -3,7 +3,8 @@ CREATE TABLE IF NOT EXISTS users (
   id UUID PRIMARY KEY,
   username VARCHAR(255) UNIQUE NOT NULL,
   password_hash VARCHAR(255) NOT NULL,
-  role VARCHAR(50) DEFAULT 'user',
+  -- Supported roles: super_admin, admin, buyer, seller
+  role VARCHAR(50) DEFAULT 'buyer' CHECK (role IN ('super_admin','admin','buyer','seller')),
   full_name VARCHAR(255) NOT NULL,
   email VARCHAR(255) NOT NULL,
   phone VARCHAR(20) NOT NULL,
@@ -13,4 +14,6 @@ CREATE TABLE IF NOT EXISTS users (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
 

--- a/backend/middleware/requireAdmin.js
+++ b/backend/middleware/requireAdmin.js
@@ -1,7 +1,8 @@
 const logger = require('../utils/logger');
 
 module.exports = (req, res, next) => {
-  if (req.user?.role !== 'admin') {
+  const role = req.user?.role;
+  if (role !== 'admin' && role !== 'super_admin') {
     logger.error('Admin privileges required', { user: req.user?.username });
     return res.status(403).json({ error: 'Admin access required' });
   }

--- a/backend/tests/adminAuth.test.js
+++ b/backend/tests/adminAuth.test.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const bcrypt = require('bcryptjs');
 const { adminLoginHandler } = require('../controllers/adminAuth');
-const { users, addUser } = require('../models/user');
+const { clearUsers, addUser } = require('../models/user');
 
 describe('admin auth', () => {
   test('route defines an Express router', () => {
@@ -13,9 +13,9 @@ describe('admin auth', () => {
   });
 
   test('adminLoginHandler authenticates admin user only', async () => {
-    users.clear(); // reset in-memory store
+    await clearUsers();
     const hashed = await bcrypt.hash('secret', 10);
-    addUser({ username: 'admin', password: hashed, role: 'admin' });
+    await addUser({ username: 'admin', password: hashed, role: 'admin' });
 
     const req = { validatedBody: { username: 'admin', password: 'secret' } };
     const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };

--- a/backend/tests/adminDashboard.test.js
+++ b/backend/tests/adminDashboard.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { adminDashboardHandler } = require('../controllers/adminDashboard');
-const { users, addUser } = require('../models/user');
+const { clearUsers, addUser } = require('../models/user');
 const supportTickets = require('../models/supportTicket');
 const disputes = require('../models/dispute');
 const flaggedContent = require('../models/flaggedContent');
@@ -14,16 +14,16 @@ describe('admin dashboard', () => {
     expect(content).toMatch(/module\.exports\s*=\s*router/);
   });
 
-  test('adminDashboardHandler returns site metrics', () => {
-    users.clear();
-    addUser({ username: 'a', password: 'p', role: 'admin' });
+  test('adminDashboardHandler returns site metrics', async () => {
+    await clearUsers();
+    await addUser({ username: 'a', password: 'p', role: 'admin' });
     supportTickets.createTicket({ userId: 'a', subject: 's', message: 'm' });
     flaggedContent.flagContent({ contentId: '1', reporterId: 'a', reason: 'spam' });
     disputes.createDispute({ userId: 'a', disputeeId: 'b', category: 'test' });
 
     const req = {};
     const res = { json: jest.fn() };
-    adminDashboardHandler(req, res);
+    await adminDashboardHandler(req, res);
     const payload = res.json.mock.calls[0][0];
     expect(payload.activeUsers).toBeGreaterThanOrEqual(1);
     expect(payload.flaggedContent).toBeGreaterThanOrEqual(1);

--- a/backend/validation/auth.js
+++ b/backend/validation/auth.js
@@ -3,7 +3,7 @@ const Joi = require('joi');
 const registerSchema = Joi.object({
   username: Joi.string().alphanum().min(3).max(30).required(),
   password: Joi.string().min(6).required(),
-  role: Joi.string().optional(),
+  role: Joi.string().valid('super_admin','admin','buyer','seller').default('buyer'),
   fullName: Joi.string().max(255).allow('', null),
   email: Joi.string().email().allow('', null),
   phone: Joi.string().max(20).allow('', null),

--- a/frontend/src/api/dashboard.js
+++ b/frontend/src/api/dashboard.js
@@ -1,7 +1,9 @@
 import apiClient from '../utils/apiClient.js';
 
-export async function getDashboard(role = 'client') {
-  const endpoint = role === 'freelancer' ? '/dashboard/freelancer' : '/dashboard/client';
+export async function getDashboard(role = 'buyer') {
+  let endpoint = '/dashboard/client';
+  if (role === 'seller') endpoint = '/dashboard/freelancer';
+  if (role === 'admin' || role === 'super_admin') endpoint = '/admin/dashboard';
   const { data } = await apiClient.get(endpoint);
   return data;
 }

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -63,6 +63,7 @@ export default function DashboardPage() {
       <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4} mb={6}>
         <Box p={4} borderWidth="1px" borderRadius="md" bg="white">
           <Heading size="md">Welcome, {user?.name || user?.username}</Heading>
+          <Text mt={1}>Role: {user?.role}</Text>
           <Text mt={2}>Glad to have you here.</Text>
         </Box>
         <WeatherWidget />

--- a/frontend/src/pages/SignupPage.jsx
+++ b/frontend/src/pages/SignupPage.jsx
@@ -8,6 +8,7 @@ import {
   Heading,
   HStack,
   Input,
+  Select,
   Text,
   Textarea,
   Progress,
@@ -28,7 +29,8 @@ export default function SignupPage() {
     bio: '',
     expertise: '',
     username: '',
-    password: ''
+    password: '',
+    role: 'buyer'
   });
   const [recaptchaToken, setRecaptchaToken] = useState('');
   const [error, setError] = useState('');
@@ -89,6 +91,13 @@ export default function SignupPage() {
         <FormControl id="password" mb={4} isRequired>
           <FormLabel>Password</FormLabel>
           <Input type="password" name="password" value={form.password} onChange={handleChange} />
+        </FormControl>
+        <FormControl id="role" mb={4} isRequired>
+          <FormLabel>Account Type</FormLabel>
+          <Select name="role" value={form.role} onChange={handleChange}>
+            <option value="buyer">Buyer</option>
+            <option value="seller">Seller</option>
+          </Select>
         </FormControl>
         <FormControl id="location" mb={4} isRequired>
           <FormLabel>Location</FormLabel>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "workspaces": ["frontend", "backend"],
   "scripts": {
     "test": "npm test --workspaces",
-    "start": "npm start --workspace backend",
+    "start": "node app.js",
     "start:frontend": "npm run dev --workspace frontend",
     "start:backend": "npm start --workspace backend",
     "setup": "node scripts/setup.js",


### PR DESCRIPTION
## Summary
- add user roles (super_admin, admin, buyer, seller) with DB-backed model and validations
- expose role-aware dashboard and signup flows on the frontend
- unify front and back start via single `npm start` using app.js

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689410a841008320bd300eb79d358e1e