### PR TITLE
Refactor DB seeding to use pg client

### DIFF
--- a/backend/scripts/clearSeedData.js
+++ b/backend/scripts/clearSeedData.js
@@ -1,55 +1,60 @@
 require('../config/env');
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { Client } = require('pg');
 
-function escape(str) {
-  return str.replace(/'/g, "''");
+function getClient() {
+  const database = process.env.DB_NAME || 'workhouse';
+  const host = process.env.DB_HOST || '127.0.0.1';
+  const user = process.env.DB_USER || 'postgres';
+  const password = process.env.DB_PASSWORD || '';
+  const port = process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 5432;
+  return new Client({ host, user, password, port, database });
 }
 
-async function clearUsers() {
+async function clearUsers(client) {
   const dataPath = path.join(__dirname, '..', 'data', 'users.json');
   if (!fs.existsSync(dataPath)) return;
   const users = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
-  const dbName = process.env.DB_NAME || 'workhouse';
 
   for (const u of users) {
-    const query = `DELETE FROM users WHERE id='${escape(u.id)}';`;
-    execSync(`echo "${query}" | sudo -u postgres psql -d ${dbName}`, { stdio: 'inherit' });
+    await client.query('DELETE FROM users WHERE id=$1', [u.id]);
   }
   console.log('Cleared users');
 }
 
-async function clearProducts() {
+async function clearProducts(client) {
   const dataPath = path.join(__dirname, '..', 'data', 'products.json');
   if (!fs.existsSync(dataPath)) return;
   const products = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
-  const dbName = process.env.DB_NAME || 'workhouse';
 
   for (const p of products) {
-    const query = `DELETE FROM products WHERE id='${escape(p.id)}';`;
-    execSync(`echo "${query}" | sudo -u postgres psql -d ${dbName}`, { stdio: 'inherit' });
+    await client.query('DELETE FROM products WHERE id=$1', [p.id]);
   }
   console.log('Cleared products');
 }
 
-async function clearProfiles() {
+async function clearProfiles(client) {
   const dataPath = path.join(__dirname, '..', 'data', 'profiles.json');
   if (!fs.existsSync(dataPath)) return;
   const profiles = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
-  const dbName = process.env.DB_NAME || 'workhouse';
 
   for (const p of profiles) {
-    const query = `DELETE FROM profiles WHERE id='${escape(p.id)}';`;
-    execSync(`echo "${query}" | sudo -u postgres psql -d ${dbName}`, { stdio: 'inherit' });
+    await client.query('DELETE FROM profiles WHERE id=$1', [p.id]);
   }
   console.log('Cleared profiles');
 }
 
 async function run() {
-  await clearUsers();
-  await clearProducts();
-  await clearProfiles();
+  const client = getClient();
+  await client.connect();
+  try {
+    await clearUsers(client);
+    await clearProducts(client);
+    await clearProfiles(client);
+  } finally {
+    await client.end();
+  }
 }
 
 run().catch(err => {

--- a/backend/scripts/seedData.js
+++ b/backend/scripts/seedData.js
@@ -1,65 +1,131 @@
 require('../config/env');
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { Client } = require('pg');
 const bcrypt = require('bcryptjs');
 
-function escape(str) {
-  return str.replace(/'/g, "''");
+function getClient() {
+  const database = process.env.DB_NAME || 'workhouse';
+  const host = process.env.DB_HOST || '127.0.0.1';
+  const user = process.env.DB_USER || 'postgres';
+  const password = process.env.DB_PASSWORD || '';
+  const port = process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 5432;
+  return new Client({ host, user, password, port, database });
 }
 
-async function seedProducts() {
+async function seedProducts(client) {
   const dataPath = path.join(__dirname, '..', 'data', 'products.json');
   if (!fs.existsSync(dataPath)) return;
   const products = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
-  const dbName = process.env.DB_NAME || 'workhouse';
 
   for (const p of products) {
-    const query = `INSERT INTO products (id, name, description, price, image) VALUES ('${escape(p.id)}', '${escape(p.name)}', '${escape(p.description)}', ${p.price}, '${escape(p.image)}') ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, description = EXCLUDED.description, price = EXCLUDED.price, image = EXCLUDED.image;`;
-    execSync(`echo "${query}" | sudo -u postgres psql -d ${dbName}`, { stdio: 'inherit' });
+    await client.query(
+      `INSERT INTO products (id, name, description, price, image)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (id) DO UPDATE
+         SET name = EXCLUDED.name,
+             description = EXCLUDED.description,
+             price = EXCLUDED.price,
+             image = EXCLUDED.image`,
+      [p.id, p.name, p.description, p.price, p.image]
+    );
   }
   console.log('Seeded products');
 }
 
-async function seedUsers() {
+async function seedUsers(client) {
   const dataPath = path.join(__dirname, '..', 'data', 'users.json');
   if (!fs.existsSync(dataPath)) return;
   const users = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
-  const dbName = process.env.DB_NAME || 'workhouse';
 
   for (const u of users) {
     const hash = bcrypt.hashSync(u.password, 10);
-    const query = `INSERT INTO users (id, username, password_hash, role, full_name, email, phone, location, bio, expertise) VALUES ('${escape(u.id)}', '${escape(u.username)}', '${hash}', '${escape(u.role)}', '${escape(u.full_name)}', '${escape(u.email)}', '${escape(u.phone)}', '${escape(u.location)}', '${escape(u.bio)}', '${escape(u.expertise)}') ON CONFLICT (id) DO UPDATE SET username = EXCLUDED.username, password_hash = EXCLUDED.password_hash, role = EXCLUDED.role, full_name = EXCLUDED.full_name, email = EXCLUDED.email, phone = EXCLUDED.phone, location = EXCLUDED.location, bio = EXCLUDED.bio, expertise = EXCLUDED.expertise;`;
-    execSync(`echo "${query}" | sudo -u postgres psql -d ${dbName}`, { stdio: 'inherit' });
+    await client.query(
+      `INSERT INTO users (id, username, password_hash, role, full_name, email, phone, location, bio, expertise)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+       ON CONFLICT (id) DO UPDATE SET
+         username = EXCLUDED.username,
+         password_hash = EXCLUDED.password_hash,
+         role = EXCLUDED.role,
+         full_name = EXCLUDED.full_name,
+         email = EXCLUDED.email,
+         phone = EXCLUDED.phone,
+         location = EXCLUDED.location,
+         bio = EXCLUDED.bio,
+         expertise = EXCLUDED.expertise`,
+      [
+        u.id,
+        u.username,
+        hash,
+        u.role,
+        u.full_name,
+        u.email,
+        u.phone,
+        u.location,
+        u.bio,
+        u.expertise,
+      ]
+    );
   }
   console.log('Seeded users');
 }
 
-async function seedProfiles() {
+async function seedProfiles(client) {
   const dataPath = path.join(__dirname, '..', 'data', 'profiles.json');
   if (!fs.existsSync(dataPath)) return;
   const profiles = JSON.parse(fs.readFileSync(dataPath, 'utf8'));
-  const dbName = process.env.DB_NAME || 'workhouse';
 
   for (const p of profiles) {
-    const contact = escape(JSON.stringify(p.contact || {}));
-    const preferences = escape(JSON.stringify(p.preferences || {}));
-    const portfolio = escape(JSON.stringify(p.portfolio || {}));
-    const visibility = escape(JSON.stringify(p.visibility || {}));
-    const theme = escape(JSON.stringify(p.theme || {}));
-    const skills = `ARRAY[${(p.skills || []).map(s => `'${escape(s)}'`).join(',')}]`;
-    const query = `INSERT INTO profiles (id, user_id, role, full_name, title, location, avatar_url, bio, contact, preferences, skills, portfolio, visibility, theme)
-      VALUES ('${escape(p.id)}', '${escape(p.user_id)}', '${escape(p.role)}', '${escape(p.full_name)}', '${escape(p.title)}', '${escape(p.location)}', '${escape(p.avatar_url)}', '${escape(p.bio)}', '${contact}'::jsonb, '${preferences}'::jsonb, ${skills}, '${portfolio}'::jsonb, '${visibility}'::jsonb, '${theme}'::jsonb)
-      ON CONFLICT (id) DO UPDATE SET user_id = EXCLUDED.user_id, role = EXCLUDED.role, full_name = EXCLUDED.full_name, title = EXCLUDED.title, location = EXCLUDED.location, avatar_url = EXCLUDED.avatar_url, bio = EXCLUDED.bio, contact = EXCLUDED.contact, preferences = EXCLUDED.preferences, skills = EXCLUDED.skills, portfolio = EXCLUDED.portfolio, visibility = EXCLUDED.visibility, theme = EXCLUDED.theme;`;
-    execSync(`echo "${query}" | sudo -u postgres psql -d ${dbName}`, { stdio: 'inherit' });
+    await client.query(
+      `INSERT INTO profiles (id, user_id, role, full_name, title, location, avatar_url, bio,
+                             contact, preferences, skills, portfolio, visibility, theme)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8,
+               $9::jsonb, $10::jsonb, $11::text[], $12::jsonb, $13::jsonb, $14::jsonb)
+       ON CONFLICT (id) DO UPDATE SET
+         user_id = EXCLUDED.user_id,
+         role = EXCLUDED.role,
+         full_name = EXCLUDED.full_name,
+         title = EXCLUDED.title,
+         location = EXCLUDED.location,
+         avatar_url = EXCLUDED.avatar_url,
+         bio = EXCLUDED.bio,
+         contact = EXCLUDED.contact,
+         preferences = EXCLUDED.preferences,
+         skills = EXCLUDED.skills,
+         portfolio = EXCLUDED.portfolio,
+         visibility = EXCLUDED.visibility,
+         theme = EXCLUDED.theme`,
+      [
+        p.id,
+        p.user_id,
+        p.role,
+        p.full_name,
+        p.title,
+        p.location,
+        p.avatar_url,
+        p.bio,
+        JSON.stringify(p.contact || {}),
+        JSON.stringify(p.preferences || {}),
+        p.skills || [],
+        JSON.stringify(p.portfolio || {}),
+        JSON.stringify(p.visibility || {}),
+        JSON.stringify(p.theme || {}),
+      ]
+    );
   }
   console.log('Seeded profiles');
 }
 
 async function run() {
-  await seedUsers();
-  await seedProducts();
-  await seedProfiles();
+  const client = getClient();
+  await client.connect();
+  try {
+    await seedUsers(client);
+    await seedProducts(client);
+    await seedProfiles(client);
+  } finally {
+    await client.end();
+  }
 }
 
 run().catch(err => {

--- a/list_of_errors.md
+++ b/list_of_errors.md
@@ -226,3 +226,41 @@ Unexpected "}"
     at Readable.push (node:internal/streams/readable:392:5)
     at Pipe.onStreamRead (node:internal/stream_base_commons:191:23)
 ```
+
+## Stage 26: Database seeding script
+
+```
+sudo: unknown user postgres
+sudo: error initializing audit plugin sudoers_audit
+Seeding failed: Error: Command failed: echo "INSERT INTO users (id, username, password_hash, role, full_name, email, phone, location, bio, expertise) VALUES ('11111111-1111-1111-1111-111111111111', 'demoUser', '$2a$10$umi25tEHue/EOawsbCuDkuP35NZWozN9yXSVRSxiP01R7m.oBjH7.', 'user', 'Demo User', 'demo@example.com', '1234567890', 'Demo City', 'Example bio', 'Testing') ON CONFLICT (id) DO UPDATE SET username = EXCLUDED.username, password_hash = EXCLUDED.password_hash, role = EXCLUDED.role, full_name = EXCLUDED.full_name, email = EXCLUDED.email, phone = EXCLUDED.phone, location = EXCLUDED.location, bio = EXCLUDED.bio, expertise = EXCLUDED.expertise;" | sudo -u postgres psql -d workhouse
+```
+
+## Stage 27: Database connection
+
+```
+Seeding failed: AggregateError [ECONNREFUSED]:
+    at internalConnectMultiple (node:net:1122:18)
+    at afterConnectMultiple (node:net:1689:7) {
+  code: 'ECONNREFUSED',
+  [errors]: [
+    Error: connect ECONNREFUSED ::1:5432
+        at createConnectionError (node:net:1652:14)
+        at afterConnectMultiple (node:net:1682:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '::1',
+      port: 5432
+    },
+    Error: connect ECONNREFUSED 127.0.0.1:5432
+        at createConnectionError (node:net:1652:14)
+        at afterConnectMultiple (node:net:1682:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 5432
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Summary
- replace sudo-based psql commands with pg Client for database seeding
- update seed cleanup script to use pg Client as well
- log seeding and connection errors in list_of_errors.md

## Testing
- `npm test`
- `npm run db:seed --workspace backend` *(fails: connect ECONNREFUSED)*


------
https://chatgpt.com/codex/tasks/task_e_68941519dec08320af377207a626f5bc