### PR TITLE
feat: add global chakra styles

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <title>Workhouse</title>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
     />
     <link
       rel="stylesheet"

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -10,7 +10,6 @@ import {
 } from '@chakra-ui/react';
 import NavBar from './NavBar.jsx';
 import NavMenu from './NavMenu.jsx';
-import '../styles/Layout.css';
 
 export default function Layout({ children }) {
   const { isOpen, onOpen, onClose } = useDisclosure();

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import './styles/global.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/frontend/src/styles/Layout.css
+++ b/frontend/src/styles/Layout.css
@@ -1,7 +1,0 @@
-.layout {
-  width: 100%;
-}
-
-.layout main {
-  flex: 1;
-}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,0 +1,26 @@
+:root {
+  --brand-primary: #035ee8;
+  --brand-bg: #f7f9fc;
+}
+
+html, body {
+  background: var(--brand-bg);
+  color: #2d3748;
+  font-family: 'Inter', sans-serif;
+  line-height: 1.5;
+}
+
+.layout {
+  width: 100%;
+}
+
+.chakra-button {
+  border-radius: 0.375rem;
+  font-weight: 600;
+  background: var(--brand-primary);
+  color: #fff;
+}
+
+.chakra-button:hover {
+  background: #0047b6;
+}

--- a/frontend/tests/AboutSection.test.jsx
+++ b/frontend/tests/AboutSection.test.jsx
@@ -1,16 +1,25 @@
 import { render, screen } from '@testing-library/react';
+import { ChakraProvider, Theme } from '@chakra-ui/react';
 import AboutSection from '../src/components/AboutSection';
 import '@testing-library/jest-dom';
 
 describe('AboutSection', () => {
   it('renders provided bio', () => {
-    render(<AboutSection bio="Hello world" />);
+    render(
+      <ChakraProvider theme={Theme}>
+        <AboutSection bio="Hello world" />
+      </ChakraProvider>
+    );
     expect(screen.getByText('About Me')).toBeInTheDocument();
     expect(screen.getByText('Hello world')).toBeInTheDocument();
   });
 
   it('renders fallback when no bio provided', () => {
-    render(<AboutSection />);
+    render(
+      <ChakraProvider theme={Theme}>
+        <AboutSection />
+      </ChakraProvider>
+    );
     expect(screen.getByText('No bio provided.')).toBeInTheDocument();
   });
 });

--- a/frontend/tests/JobSearchBar.test.jsx
+++ b/frontend/tests/JobSearchBar.test.jsx
@@ -1,11 +1,16 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { ChakraProvider, Theme } from '@chakra-ui/react';
 import { describe, it, expect, vi } from 'vitest';
 import JobSearchBar from '../src/components/JobSearchBar.jsx';
 
 describe('JobSearchBar', () => {
   it('calls onSearch with keyword and location', () => {
     const handleSearch = vi.fn();
-    render(<JobSearchBar onSearch={handleSearch} />);
+    render(
+      <ChakraProvider theme={Theme}>
+        <JobSearchBar onSearch={handleSearch} />
+      </ChakraProvider>
+    );
     fireEvent.change(screen.getByPlaceholderText(/keyword/i), { target: { value: 'dev' } });
     fireEvent.change(screen.getByPlaceholderText(/location/i), { target: { value: 'NY' } });
     fireEvent.click(screen.getByText(/search/i));

--- a/frontend/tests/LiveEngagementAnalyticsPage.test.jsx
+++ b/frontend/tests/LiveEngagementAnalyticsPage.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi } from 'vitest';
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider, Theme } from '@chakra-ui/react';
 import LiveEngagementAnalyticsPage from '../src/pages/LiveEngagementAnalyticsPage.jsx';
 vi.mock('react-chartjs-2', () => ({ Line: () => null }));
 
@@ -17,7 +17,7 @@ vi.mock('../src/api/startupAnalytics.js', () => ({
 describe('LiveEngagementAnalyticsPage', () => {
   it('renders analytics stats', async () => {
     render(
-      <ChakraProvider>
+      <ChakraProvider theme={Theme}>
         <LiveEngagementAnalyticsPage />
       </ChakraProvider>
     );


### PR DESCRIPTION
## Summary
- add global stylesheet with brand colors and button styling
- load Inter font and hook global styles into React entry
- ensure layout uses Chakra flex components and global classes

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading '_config'))*

------
https://chatgpt.com/codex/tasks/task_e_6894282b02dc8320af5ce23a1d704e8a