### PR TITLE
feat: enforce installation wizard before app access

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,7 +11,9 @@ import GlobalSearchPage from './pages/GlobalSearchPage.jsx';
 import LandingPage from './pages/LandingPage.jsx';
 import LiveFeedPage from './pages/LiveFeedPage.jsx';
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
+import { InstallProvider, useInstall } from './context/InstallContext.jsx';
 import Layout from './components/Layout.jsx';
+import InstallationWizardPage from './pages/InstallationWizardPage.jsx';
 
 function Protected({ children }) {
   const { user, loading } = useAuth();
@@ -19,80 +21,122 @@ function Protected({ children }) {
   return user ? children : <Navigate to="/login" replace />;
 }
 
+function RequireInstall({ children }) {
+  const { installed, loading } = useInstall();
+  if (loading) return null;
+  return installed ? children : <Navigate to="/install" replace />;
+}
+
 export default function App() {
   return (
     <ChakraProvider value={defaultSystem}>
-      <AuthProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/login" element={<LoginPage />} />
-            <Route path="/signup" element={<SignupPage />} />
-            <Route path="/landing" element={<LandingPage />} />
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
-            <Route
-              path="/dashboard"
-              element={
-                <Protected>
-                  <Layout>
-                    <DashboardPage />
-                  </Layout>
-                </Protected>
-              }
-            />
-            <Route
-              path="/profile"
-              element={
-                <Protected>
-                  <Layout>
-                    <ProfilePage />
-                  </Layout>
-                </Protected>
-              }
-            />
-            <Route
-              path="/settings"
-              element={
-                <Protected>
-                  <Layout>
-                    <SettingsDashboardPage />
-                  </Layout>
-                </Protected>
-              }
-            />
-            <Route
-              path="/kl"
-              element={
-                <Protected>
-                  <Layout>
-                    <KlEditionPage />
-                  </Layout>
-                </Protected>
-              }
-            />
-            <Route
-              path="/search"
-              element={
-                <Protected>
-                  <Layout>
-                    <GlobalSearchPage />
-                  </Layout>
-                </Protected>
-              }
-            />
-            <Route
-              path="/feed"
-              element={
-                <Protected>
-                  <Layout>
-                    <LiveFeedPage />
-                  </Layout>
-                </Protected>
-              }
-            />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Routes>
-        </BrowserRouter>
-      </AuthProvider>
+      <InstallProvider>
+        <AuthProvider>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/install" element={<InstallationWizardPage />} />
+              <Route
+                path="/login"
+                element={
+                  <RequireInstall>
+                    <LoginPage />
+                  </RequireInstall>
+                }
+              />
+              <Route
+                path="/signup"
+                element={
+                  <RequireInstall>
+                    <SignupPage />
+                  </RequireInstall>
+                }
+              />
+              <Route
+                path="/landing"
+                element={
+                  <RequireInstall>
+                    <LandingPage />
+                  </RequireInstall>
+                }
+              />
+              <Route path="/" element={<Navigate to="/dashboard" replace />} />
+              <Route
+                path="/dashboard"
+                element={
+                  <RequireInstall>
+                    <Protected>
+                      <Layout>
+                        <DashboardPage />
+                      </Layout>
+                    </Protected>
+                  </RequireInstall>
+                }
+              />
+              <Route
+                path="/profile"
+                element={
+                  <RequireInstall>
+                    <Protected>
+                      <Layout>
+                        <ProfilePage />
+                      </Layout>
+                    </Protected>
+                  </RequireInstall>
+                }
+              />
+              <Route
+                path="/settings"
+                element={
+                  <RequireInstall>
+                    <Protected>
+                      <Layout>
+                        <SettingsDashboardPage />
+                      </Layout>
+                    </Protected>
+                  </RequireInstall>
+                }
+              />
+              <Route
+                path="/kl"
+                element={
+                  <RequireInstall>
+                    <Protected>
+                      <Layout>
+                        <KlEditionPage />
+                      </Layout>
+                    </Protected>
+                  </RequireInstall>
+                }
+              />
+              <Route
+                path="/search"
+                element={
+                  <RequireInstall>
+                    <Protected>
+                      <Layout>
+                        <GlobalSearchPage />
+                      </Layout>
+                    </Protected>
+                  </RequireInstall>
+                }
+              />
+              <Route
+                path="/feed"
+                element={
+                  <RequireInstall>
+                    <Protected>
+                      <Layout>
+                        <LiveFeedPage />
+                      </Layout>
+                    </Protected>
+                  </RequireInstall>
+                }
+              />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Routes>
+          </BrowserRouter>
+        </AuthProvider>
+      </InstallProvider>
     </ChakraProvider>
   );
 }

--- a/frontend/src/components/NavMenu.jsx
+++ b/frontend/src/components/NavMenu.jsx
@@ -3,11 +3,19 @@ import { Box, VStack, Link, Text } from '@chakra-ui/react';
 import { NavLink } from 'react-router-dom';
 import { menu } from '../nav/menu.js';
 import { useAuth } from '../context/AuthContext.jsx';
+import { useInstall } from '../context/InstallContext.jsx';
 import '../styles/NavMenu.css';
 
 export default function NavMenu() {
   const { user } = useAuth();
+  const { installed } = useInstall();
   if (!user) return null;
+  const filteredMenu = installed
+    ? menu.map(section => ({
+        ...section,
+        items: section.items.filter(item => item.path !== '/install')
+      }))
+    : menu;
   return (
     <Box
       as="aside"
@@ -18,7 +26,7 @@ export default function NavMenu() {
       h="100vh"
       overflowY="auto"
     >
-      {menu.map((section) => (
+      {filteredMenu.map((section) => (
         <Box key={section.heading} mb={4}>
           <Text fontWeight="bold" mb={2} color="blue.600">
             {section.heading}

--- a/frontend/src/context/InstallContext.jsx
+++ b/frontend/src/context/InstallContext.jsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { getInstallStatus } from '../api/install.js';
+
+const InstallContext = createContext(null);
+
+export function InstallProvider({ children }) {
+  const [installed, setInstalled] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = async () => {
+    try {
+      const data = await getInstallStatus();
+      setInstalled(Boolean(data?.installed));
+    } catch {
+      setInstalled(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  return (
+    <InstallContext.Provider value={{ installed, loading, refresh }}>
+      {children}
+    </InstallContext.Provider>
+  );
+}
+
+export function useInstall() {
+  return useContext(InstallContext);
+}
+

--- a/frontend/src/pages/InstallationWizardPage.jsx
+++ b/frontend/src/pages/InstallationWizardPage.jsx
@@ -21,6 +21,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { getInstallStatus, runInstallation, checkDatabaseConnection } from '../api/install.js';
+import { useInstall } from '../context/InstallContext.jsx';
 import '../styles/InstallationWizardPage.css';
 
 export default function InstallationWizardPage() {
@@ -35,6 +36,7 @@ export default function InstallationWizardPage() {
   const [error, setError] = useState('');
   const [complete, setComplete] = useState(false);
   const [dbCheck, setDbCheck] = useState(null);
+  const { refresh } = useInstall();
 
   const errorSuggestions = {
     'Admin user already exists': 'Try a different username.',
@@ -81,6 +83,7 @@ export default function InstallationWizardPage() {
     } else {
       try {
         await runInstallation({ dbConfig, admin, app });
+        await refresh();
         setComplete(true);
       } catch (e) {
         const msg = e.response?.data?.error || e.message;

--- a/frontend/tests/AboutSection.test.jsx
+++ b/frontend/tests/AboutSection.test.jsx
@@ -1,14 +1,11 @@
 import { render, screen } from '@testing-library/react';
-import { ChakraProvider, Theme } from '@chakra-ui/react';
-import AboutSection from '../src/components/AboutSection'; 
 import '@testing-library/jest-dom';
 import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
-import AboutSection from '../src/components/AboutSection';
+import AboutSection from '../src/components/AboutSection.jsx';
 
 describe('AboutSection', () => {
   it('renders provided bio', () => {
     render(
-      <ChakraProvider theme={Theme}>
       <ChakraProvider value={defaultSystem}>
         <AboutSection bio="Hello world" />
       </ChakraProvider>
@@ -19,9 +16,7 @@ describe('AboutSection', () => {
 
   it('renders fallback when no bio provided', () => {
     render(
-      <ChakraProvider theme={Theme}>
       <ChakraProvider value={defaultSystem}>
-
         <AboutSection />
       </ChakraProvider>
     );

--- a/frontend/tests/JobSearchBar.test.jsx
+++ b/frontend/tests/JobSearchBar.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { ChakraProvider, Theme } from '@chakra-ui/react';
 import { describe, it, expect, vi } from 'vitest';
+import '@testing-library/jest-dom';
 import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
 import JobSearchBar from '../src/components/JobSearchBar.jsx';
 
@@ -8,7 +8,6 @@ describe('JobSearchBar', () => {
   it('calls onSearch with keyword and location', () => {
     const handleSearch = vi.fn();
     render(
-      <ChakraProvider theme={Theme}>
       <ChakraProvider value={defaultSystem}>
         <JobSearchBar onSearch={handleSearch} />
       </ChakraProvider>

--- a/frontend/tests/LiveEngagementAnalyticsPage.test.jsx
+++ b/frontend/tests/LiveEngagementAnalyticsPage.test.jsx
@@ -1,11 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi } from 'vitest';
-import { ChakraProvider, Theme } from '@chakra-ui/react';
 import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
 import LiveEngagementAnalyticsPage from '../src/pages/LiveEngagementAnalyticsPage.jsx';
-vi.mock('react-chartjs-2', () => ({ __esModule: true, Line: () => null }));
 
+vi.mock('react-chartjs-2', () => ({ __esModule: true, Line: () => null }));
 vi.mock('../src/api/startupAnalytics.js', () => ({
   fetchStartupAnalytics: () => Promise.resolve({
     profileViews: 10,
@@ -18,7 +17,6 @@ vi.mock('../src/api/startupAnalytics.js', () => ({
 describe('LiveEngagementAnalyticsPage', () => {
   it.skip('renders analytics stats', async () => {
     render(
-      <ChakraProvider theme={Theme}>
       <ChakraProvider value={defaultSystem}>
         <LiveEngagementAnalyticsPage />
       </ChakraProvider>


### PR DESCRIPTION
## Summary
- add install status context and provider
- gate all routes until setup completed and expose `/install` wizard
- hide install wizard link after setup
- refresh install state on wizard completion
- fix broken Chakra provider usage in unit tests

## Testing
- `npm test --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_68942c60d74c83208d3533158ee5d729