### PR TITLE
Improve live feed widget with backend integration and tests

### DIFF
--- a/frontend/src/components/LiveFeedWidget.jsx
+++ b/frontend/src/components/LiveFeedWidget.jsx
@@ -1,16 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Heading, VStack, Text, Spinner } from '@chakra-ui/react';
 import { getPosts } from '../api/liveFeed.js';
-
-const demoPosts = [
-  { id: 1, author: 'Alice', content: 'First post!' },
-  { id: 2, author: 'Bob', content: 'Another update' },
-  { id: 3, author: 'Eve', content: 'Hello world' }
-];
+import sanitizeInput from '../utils/sanitize.js';
+import '../styles/LiveFeedWidget.css';
 
 export default function LiveFeedWidget() {
-  const [posts, setPosts] = useState(demoPosts);
+  const [posts, setPosts] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     async function load() {
@@ -20,7 +17,8 @@ export default function LiveFeedWidget() {
           setPosts(data.slice(0, 3));
         }
       } catch (err) {
-        // ignore errors and fall back to demo data
+        console.error('Failed to load live feed', err);
+        setError('Unable to load feed');
       } finally {
         setLoading(false);
       }
@@ -30,22 +28,41 @@ export default function LiveFeedWidget() {
 
   if (loading) {
     return (
-      <Box p={4} borderWidth="1px" borderRadius="md" bg="white" textAlign="center">
+      <Box
+        className="live-feed-widget"
+        p={4}
+        borderWidth="1px"
+        borderRadius="md"
+        bg="white"
+        textAlign="center"
+      >
         <Spinner />
       </Box>
     );
   }
 
   return (
-    <Box p={4} borderWidth="1px" borderRadius="md" bg="white">
-      <Heading size="sm" mb={2}>Live Feed</Heading>
-      <VStack align="stretch" spacing={1}>
-        {posts.map((p) => (
-          <Text key={p.id} fontSize="sm">
-            <strong>{p.author}:</strong> {p.content}
-          </Text>
-        ))}
-      </VStack>
+    <Box className="live-feed-widget" p={4} borderWidth="1px" borderRadius="md" bg="white">
+      <Heading size="sm" mb={2}>
+        Live Feed
+      </Heading>
+      {error ? (
+        <Text fontSize="sm" color="red.500">
+          {error}
+        </Text>
+      ) : posts.length ? (
+        <VStack align="stretch" spacing={1}>
+          {posts.map((p) => (
+            <Text key={p.id} fontSize="sm">
+              <strong>{sanitizeInput(p.author)}:</strong> {sanitizeInput(p.content)}
+            </Text>
+          ))}
+        </VStack>
+      ) : (
+        <Text fontSize="sm" color="gray.500">
+          No activity yet.
+        </Text>
+      )}
     </Box>
   );
 }

--- a/frontend/src/components/LiveFeedWidget.test.jsx
+++ b/frontend/src/components/LiveFeedWidget.test.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
+import LiveFeedWidget from './LiveFeedWidget.jsx';
+import * as api from '../api/liveFeed.js';
+
+describe('LiveFeedWidget', () => {
+  it('renders posts from the API', async () => {
+    vi.spyOn(api, 'getPosts').mockResolvedValue([
+      { id: 1, author: 'Alice', content: 'Hello' }
+    ]);
+
+    render(
+      <ChakraProvider value={defaultSystem}>
+        <LiveFeedWidget />
+      </ChakraProvider>
+    );
+
+    expect(await screen.findByText(/Alice:/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/styles/LiveFeedWidget.css
+++ b/frontend/src/styles/LiveFeedWidget.css
@@ -1,0 +1,4 @@
+.live-feed-widget {
+  max-height: 200px;
+  overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded demo data in `LiveFeedWidget` with secure backend-driven content and robust error handling.
- Style live feed output with a dedicated CSS module and add unit test coverage for API interaction.

## Testing
- `npm test --workspace frontend` *(fails: existing AboutSection, JobSearchBar, and LiveEngagementAnalyticsPage tests contain syntax errors)*
- `npx vitest run frontend/src/components/LiveFeedWidget.test.jsx --environment jsdom`

------
https://chatgpt.com/codex/tasks/task_e_68942c53c6a4832084c0626b2bcd31e7