### PR TITLE
feat: add admin system settings frontend

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -10,6 +10,8 @@ const adminAuthRoutes = require('./routes/adminAuth');
 const dashboardRoutes = require('./routes/dashboard');
 const adminDashboardRoutes = require('./routes/adminDashboard');
 const searchRoutes = require('./routes/search');
+const systemSettingsRoutes = require('./routes/systemSettings');
+const employeeRoutes = require('./routes/employee');
 const api = require("./api");
 const { initDb } = require('./utils/db');
 const logger = require('./utils/logger');
@@ -28,6 +30,8 @@ app.use('/n8n', n8nRoutes);
 app.use('/tasks', tasksRoutes);
 app.use('/admin', adminAuthRoutes);
 app.use('/admin', adminDashboardRoutes);
+app.use('/admin', systemSettingsRoutes);
+app.use('/hr', employeeRoutes);
 app.use('/search', searchRoutes);
 app.use('/dashboard', dashboardRoutes);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import SettingsDashboardPage from './pages/SettingsDashboardPage.jsx';
 import GlobalSearchPage from './pages/GlobalSearchPage.jsx';
 import LandingPage from './pages/LandingPage.jsx';
 import LiveFeedPage from './pages/LiveFeedPage.jsx';
+import AdminSystemSettingsPage from './pages/AdminSystemSettingsPage.jsx';
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 import Layout from './components/Layout.jsx';
 
@@ -85,6 +86,16 @@ export default function App() {
                 <Protected>
                   <Layout>
                     <LiveFeedPage />
+                  </Layout>
+                </Protected>
+              }
+            />
+            <Route
+              path="/admin/system-settings"
+              element={
+                <Protected>
+                  <Layout>
+                    <AdminSystemSettingsPage />
                   </Layout>
                 </Protected>
               }

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -1,0 +1,39 @@
+import apiClient from '../utils/apiClient.js';
+
+export async function fetchSystemSettings() {
+  const { data } = await apiClient.get('/admin/system-settings');
+  return data;
+}
+
+export async function updateSystemSettings(payload) {
+  const { data } = await apiClient.put('/admin/system-settings', payload);
+  return data;
+}
+
+export async function listEmployees() {
+  const { data } = await apiClient.get('/hr/employees');
+  return data;
+}
+
+export async function createEmployee(payload) {
+  const { data } = await apiClient.post('/hr/employees', payload);
+  return data;
+}
+
+export async function updateEmployee(id, payload) {
+  const { data } = await apiClient.put(`/hr/employees/${id}`, payload);
+  return data;
+}
+
+export async function deleteEmployee(id) {
+  await apiClient.delete(`/hr/employees/${id}`);
+}
+
+export default {
+  fetchSystemSettings,
+  updateSystemSettings,
+  listEmployees,
+  createEmployee,
+  updateEmployee,
+  deleteEmployee,
+};

--- a/frontend/src/components/EmployeeTable.jsx
+++ b/frontend/src/components/EmployeeTable.jsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import {
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Button,
+  IconButton,
+  useDisclosure,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  FormControl,
+  FormLabel,
+  Input,
+} from '@chakra-ui/react';
+import { EditIcon, DeleteIcon } from '@chakra-ui/icons';
+import {
+  createEmployee,
+  updateEmployee,
+  deleteEmployee,
+} from '../api/admin.js';
+import '../styles/EmployeeTable.css';
+
+export default function EmployeeTable({ employees, onRefresh }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [form, setForm] = useState({ name: '', role: '', email: '' });
+  const [editingId, setEditingId] = useState(null);
+
+  const openAdd = () => {
+    setEditingId(null);
+    setForm({ name: '', role: '', email: '' });
+    onOpen();
+  };
+
+  const openEdit = (emp) => {
+    setEditingId(emp.id);
+    setForm({ name: emp.name || '', role: emp.role || '', email: emp.email || '' });
+    onOpen();
+  };
+
+  const handleSubmit = async () => {
+    if (editingId) {
+      await updateEmployee(editingId, form);
+    } else {
+      await createEmployee(form);
+    }
+    onClose();
+    onRefresh();
+  };
+
+  const handleDelete = async (id) => {
+    await deleteEmployee(id);
+    onRefresh();
+  };
+
+  return (
+    <>
+      <Button colorScheme="teal" onClick={openAdd} mb={4}>
+        Add Employee
+      </Button>
+      <Table className="employee-table" variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Name</Th>
+            <Th>Role</Th>
+            <Th>Email</Th>
+            <Th></Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {employees.map((emp) => (
+            <Tr key={emp.id}>
+              <Td>{emp.name}</Td>
+              <Td>{emp.role}</Td>
+              <Td>{emp.email}</Td>
+              <Td>
+                <IconButton
+                  icon={<EditIcon />}
+                  mr={2}
+                  onClick={() => openEdit(emp)}
+                  aria-label="Edit"
+                />
+                <IconButton
+                  icon={<DeleteIcon />}
+                  colorScheme="red"
+                  onClick={() => handleDelete(emp.id)}
+                  aria-label="Delete"
+                />
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>{editingId ? 'Edit Employee' : 'Add Employee'}</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <FormControl mb={3}>
+              <FormLabel>Name</FormLabel>
+              <Input
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+              />
+            </FormControl>
+            <FormControl mb={3}>
+              <FormLabel>Role</FormLabel>
+              <Input
+                value={form.role}
+                onChange={(e) => setForm({ ...form, role: e.target.value })}
+              />
+            </FormControl>
+            <FormControl mb={3}>
+              <FormLabel>Email</FormLabel>
+              <Input
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+              />
+            </FormControl>
+          </ModalBody>
+          <ModalFooter>
+            <Button colorScheme="teal" mr={3} onClick={handleSubmit}>
+              Save
+            </Button>
+            <Button variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+}

--- a/frontend/src/pages/AdminSystemSettingsPage.jsx
+++ b/frontend/src/pages/AdminSystemSettingsPage.jsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Heading,
+  FormControl,
+  FormLabel,
+  Switch,
+  Stack,
+  Spinner,
+} from '@chakra-ui/react';
+import EmployeeTable from '../components/EmployeeTable.jsx';
+import {
+  fetchSystemSettings,
+  updateSystemSettings,
+  listEmployees,
+} from '../api/admin.js';
+import '../styles/AdminSystemSettingsPage.css';
+
+export default function AdminSystemSettingsPage() {
+  const [settings, setSettings] = useState({
+    liveChatEnabled: false,
+    disputeResolutionEnabled: false,
+  });
+  const [employees, setEmployees] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchSystemSettings().then(setSettings).catch(console.error);
+    loadEmployees();
+  }, []);
+
+  const loadEmployees = async () => {
+    try {
+      const data = await listEmployees();
+      setEmployees(data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleSetting = async (key) => {
+    const updated = { ...settings, [key]: !settings[key] };
+    setSettings(updated);
+    try {
+      await updateSystemSettings(updated);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <Box className="settings-page" p={4}>
+      <Heading mb={4}>System Settings</Heading>
+      <Stack spacing={4} mb={8}>
+        <FormControl display="flex" alignItems="center">
+          <FormLabel htmlFor="liveChat" mb="0">
+            Live Chat
+          </FormLabel>
+          <Switch
+            id="liveChat"
+            isChecked={settings.liveChatEnabled}
+            onChange={() => toggleSetting('liveChatEnabled')}
+          />
+        </FormControl>
+        <FormControl display="flex" alignItems="center">
+          <FormLabel htmlFor="dispute" mb="0">
+            Dispute Resolution
+          </FormLabel>
+          <Switch
+            id="dispute"
+            isChecked={settings.disputeResolutionEnabled}
+            onChange={() => toggleSetting('disputeResolutionEnabled')}
+          />
+        </FormControl>
+      </Stack>
+
+      <Heading size="md" mb={4}>
+        Employees
+      </Heading>
+      {loading ? (
+        <Spinner />
+      ) : (
+        <EmployeeTable employees={employees} onRefresh={loadEmployees} />
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/styles/AdminSystemSettingsPage.css
+++ b/frontend/src/styles/AdminSystemSettingsPage.css
@@ -1,0 +1,3 @@
+.settings-page {
+  background-color: #f7fafc;
+}

--- a/frontend/src/styles/EmployeeTable.css
+++ b/frontend/src/styles/EmployeeTable.css
@@ -1,0 +1,4 @@
+.employee-table th,
+.employee-table td {
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- integrate systemSettings and employee routes into backend
- add admin system settings page with employee management
- wire up admin API and reusable EmployeeTable component

## Testing
- `npm test --workspace frontend` *(fails: The symbol "ChakraProvider" has already been declared; Expected "}" but found ":"; Unexpected end of file before a closing "ChakraProvider" tag)*

------
https://chatgpt.com/codex/tasks/task_e_68942d67c1a48320acd6bd368b0ea21c