### PR TITLE
feat: apply argon styling to dashboards

### DIFF
--- a/frontend/argonTheme.js
+++ b/frontend/argonTheme.js
@@ -1,0 +1,39 @@
+import { extendTheme } from '@chakra-ui/react';
+
+const argonTheme = extendTheme({
+  colors: {
+    brand: {
+      50: '#e9f7fe',
+      100: '#d0eefc',
+      200: '#a0def9',
+      300: '#70cdf5',
+      400: '#41bdf2',
+      500: '#11cdef',
+      600: '#0fa3c2',
+      700: '#0c7a94',
+      800: '#085066',
+      900: '#042739',
+    },
+  },
+  styles: {
+    global: {
+      body: {
+        bg: 'gray.50',
+      },
+    },
+  },
+  components: {
+    Stat: {
+      baseStyle: {
+        container: {
+          p: 6,
+          borderRadius: 'lg',
+          boxShadow: '0 0 2rem 0 rgba(136, 152, 170, 0.15)',
+          backgroundColor: 'white',
+        },
+      },
+    },
+  },
+});
+
+export default argonTheme;

--- a/frontend/components/dashboards/ClientDashboard.css
+++ b/frontend/components/dashboards/ClientDashboard.css
@@ -1,6 +1,0 @@
-.client-dashboard .stat-card {
-  padding: 1rem;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  background: #ffffff;
-}

--- a/frontend/components/dashboards/ClientDashboard.jsx
+++ b/frontend/components/dashboards/ClientDashboard.jsx
@@ -1,6 +1,5 @@
 import { Box, SimpleGrid, Stat, StatLabel, StatNumber, Spinner, Text } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
-import './ClientDashboard.css';
 import '../../api/dashboard';
 
 export default function ClientDashboard() {
@@ -21,17 +20,17 @@ export default function ClientDashboard() {
   if (!data) return <Text>Unable to load dashboard.</Text>;
 
   return (
-    <Box className="client-dashboard">
-      <SimpleGrid columns={[1, 3]} spacing={4}>
-        <Stat className="stat-card">
+    <Box className="client-dashboard" p={6}>
+      <SimpleGrid columns={{ base: 1, md: 3 }} spacing={6}>
+        <Stat>
           <StatLabel>Active Contracts</StatLabel>
           <StatNumber>{data.activeContracts}</StatNumber>
         </Stat>
-        <Stat className="stat-card">
+        <Stat>
           <StatLabel>Pending Proposals</StatLabel>
           <StatNumber>{data.pendingProposals}</StatNumber>
         </Stat>
-        <Stat className="stat-card">
+        <Stat>
           <StatLabel>Total Spend</StatLabel>
           <StatNumber>${data.totalSpend}</StatNumber>
         </Stat>

--- a/frontend/components/dashboards/FreelancerDashboard.css
+++ b/frontend/components/dashboards/FreelancerDashboard.css
@@ -1,6 +1,0 @@
-.freelancer-dashboard .stat-card {
-  padding: 1rem;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
-  background: #ffffff;
-}

--- a/frontend/components/dashboards/FreelancerDashboard.jsx
+++ b/frontend/components/dashboards/FreelancerDashboard.jsx
@@ -1,6 +1,5 @@
 import { Box, SimpleGrid, Stat, StatLabel, StatNumber, Spinner, Text } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
-import './FreelancerDashboard.css';
 import '../../api/dashboard';
 
 export default function FreelancerDashboard() {
@@ -21,17 +20,17 @@ export default function FreelancerDashboard() {
   if (!data) return <Text>Unable to load dashboard.</Text>;
 
   return (
-    <Box className="freelancer-dashboard">
-      <SimpleGrid columns={[1, 3]} spacing={4}>
-        <Stat className="stat-card">
+    <Box className="freelancer-dashboard" p={6}>
+      <SimpleGrid columns={{ base: 1, md: 3 }} spacing={6}>
+        <Stat>
           <StatLabel>Active Contracts</StatLabel>
           <StatNumber>{data.activeContracts}</StatNumber>
         </Stat>
-        <Stat className="stat-card">
+        <Stat>
           <StatLabel>Pending Proposals</StatLabel>
           <StatNumber>{data.pendingProposals}</StatNumber>
         </Stat>
-        <Stat className="stat-card">
+        <Stat>
           <StatLabel>Total Earnings</StatLabel>
           <StatNumber>${data.totalEarnings}</StatNumber>
         </Stat>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
-import { ChakraProvider, defaultSystem } from '@chakra-ui/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import argonTheme from '../argonTheme.js';
 import LoginPage from './pages/LoginPage.jsx';
 import SignupPage from './pages/SignupPage.jsx';
 import DashboardPage from './pages/DashboardPage.jsx';
@@ -29,7 +30,7 @@ function RequireInstall({ children }) {
 
 export default function App() {
   return (
-    <ChakraProvider value={defaultSystem}>
+    <ChakraProvider theme={argonTheme}>
       <InstallProvider>
         <AuthProvider>
           <BrowserRouter>


### PR DESCRIPTION
## Summary
- style client and freelancer dashboards with Argon-inspired layout
- introduce shared Argon Chakra theme

## Testing
- `npm test --workspace frontend`


------
https://chatgpt.com/codex/tasks/task_e_68942ffb83e48320bd179a31a0db7e89