### PR TITLE
feat(admin): enhance dashboards with layout and widgets

### DIFF
--- a/frontend/components/DashboardLayout.jsx
+++ b/frontend/components/DashboardLayout.jsx
@@ -1,0 +1,33 @@
+import { Box, Heading } from '@chakra-ui/react';
+import { Navigate } from 'react-router-dom';
+import NavMenu from './NavMenu.jsx';
+import ChatWidget from './widgets/ChatWidget.jsx';
+import UserCountWidget from './widgets/UserCountWidget.jsx';
+import { useAuth } from '../context/AuthContext.js';
+
+/**
+ * Standard layout for admin dashboards. Ensures global navigation,
+ * theme usage and basic widgets are present. Also guards the dashboard
+ * behind the admin login route.
+ */
+export default function DashboardLayout({ title, children, requiredRole }) {
+  const { user } = useAuth();
+
+  if (!user) {
+    return <Navigate to="/admin/login" replace />;
+  }
+
+  if (requiredRole && user.role !== requiredRole) {
+    return <Navigate to="/admin/login" replace />;
+  }
+
+  return (
+    <Box p={4}>
+      <NavMenu />
+      {title && <Heading mb={4}>{title}</Heading>}
+      {children}
+      <UserCountWidget />
+      <ChatWidget />
+    </Box>
+  );
+}

--- a/frontend/components/widgets/ChatWidget.jsx
+++ b/frontend/components/widgets/ChatWidget.jsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { Box, Button, Input, VStack, Text } from '@chakra-ui/react';
+
+/**
+ * Simple chat widget placeholder used across admin dashboards.
+ * Provides a toggled chat window that stores messages locally.
+ */
+export default function ChatWidget() {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+  const [messages, setMessages] = useState([]);
+
+  const handleSend = () => {
+    if (!text.trim()) return;
+    setMessages([...messages, text]);
+    setText('');
+  };
+
+  if (!open) {
+    return (
+      <Button
+        position="fixed"
+        bottom="4"
+        right="4"
+        colorScheme="teal"
+        onClick={() => setOpen(true)}
+      >
+        Chat
+      </Button>
+    );
+  }
+
+  return (
+    <Box
+      position="fixed"
+      bottom="4"
+      right="4"
+      p={4}
+      bg="white"
+      borderWidth="1px"
+      borderRadius="md"
+      w="300px"
+    >
+      <VStack spacing={2} align="stretch">
+        <Text fontWeight="bold">Support Chat</Text>
+        <Box maxH="200px" overflowY="auto">
+          {messages.map((m, idx) => (
+            <Text key={idx}>{m}</Text>
+          ))}
+        </Box>
+        <Input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="Type a message"
+        />
+        <Button colorScheme="teal" onClick={handleSend}>
+          Send
+        </Button>
+        <Button variant="ghost" onClick={() => setOpen(false)}>
+          Close
+        </Button>
+      </VStack>
+    </Box>
+  );
+}

--- a/frontend/components/widgets/UserCountWidget.jsx
+++ b/frontend/components/widgets/UserCountWidget.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { Box, Stat, StatLabel, StatNumber } from '@chakra-ui/react';
+
+/**
+ * Displays a simple user count stat. Attempts to load data from
+ * `/api/users/count` but falls back to zero if unavailable.
+ */
+export default function UserCountWidget() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    fetch('/api/users/count')
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => setCount(data.count ?? 0))
+      .catch(() => setCount(0));
+  }, []);
+
+  return (
+    <Box mb={4}>
+      <Stat>
+        <StatLabel>Total Users</StatLabel>
+        <StatNumber>{count}</StatNumber>
+      </Stat>
+    </Box>
+  );
+}

--- a/frontend/pages/AdminDashboard.jsx
+++ b/frontend/pages/AdminDashboard.jsx
@@ -1,3 +1,4 @@
+import { Navigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext.js';
 import FinanceDashboard from './FinanceDashboard.jsx';
 import SupportDashboard from './SupportDashboard.jsx';
@@ -8,7 +9,10 @@ import SuperAdminDashboard from './SuperAdminDashboard.jsx';
 
 export default function AdminDashboard() {
   const { user } = useAuth();
-  switch (user?.role) {
+  if (!user) {
+    return <Navigate to="/admin/login" replace />;
+  }
+  switch (user.role) {
     case 'finance':
       return <FinanceDashboard />;
     case 'support':

--- a/frontend/pages/FinanceDashboard.jsx
+++ b/frontend/pages/FinanceDashboard.jsx
@@ -1,12 +1,60 @@
-import { Box, Heading } from '@chakra-ui/react';
-import NavMenu from '../components/NavMenu.jsx';
+import {
+  Heading,
+  SimpleGrid,
+  Stat,
+  StatLabel,
+  StatNumber,
+  Table,
+  Thead,
+  Tr,
+  Th,
+  Tbody,
+  Td,
+} from '@chakra-ui/react';
+import DashboardLayout from '../components/DashboardLayout.jsx';
 
 export default function FinanceDashboard() {
+  const invoices = [
+    { id: 1, client: 'Acme Corp', amount: 1200 },
+    { id: 2, client: 'Globex Inc', amount: 850 },
+  ];
+
   return (
-    <Box p={4}>
-      <NavMenu />
-      <Heading mb={4}>Finance Dashboard</Heading>
-      {/* TODO: Add graphs, earnings, expenses, invoices, and records */}
-    </Box>
+    <DashboardLayout title="Finance Dashboard" requiredRole="finance">
+      <SimpleGrid columns={[1, 3]} spacing={4} mb={8}>
+        <Stat>
+          <StatLabel>Revenue</StatLabel>
+          <StatNumber>$12,000</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Expenses</StatLabel>
+          <StatNumber>$8,500</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Invoices</StatLabel>
+          <StatNumber>{invoices.length}</StatNumber>
+        </Stat>
+      </SimpleGrid>
+
+      <Heading size="md" mb={2}>
+        Recent Invoices
+      </Heading>
+      <Table variant="simple">
+        <Thead>
+          <Tr>
+            <Th>Client</Th>
+            <Th isNumeric>Amount</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {invoices.map((inv) => (
+            <Tr key={inv.id}>
+              <Td>{inv.client}</Td>
+              <Td isNumeric>${inv.amount}</Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+    </DashboardLayout>
   );
 }

--- a/frontend/pages/ManagementDashboard.jsx
+++ b/frontend/pages/ManagementDashboard.jsx
@@ -26,7 +26,7 @@ import {
   Legend,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import NavMenu from '../components/NavMenu.jsx';
+import DashboardLayout from '../components/DashboardLayout.jsx';
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
 
@@ -66,9 +66,7 @@ export default function ManagementDashboard() {
   };
 
   return (
-    <Box p={4}>
-      <NavMenu />
-      <Heading mb={4}>Management Dashboard</Heading>
+    <DashboardLayout title="Management Dashboard" requiredRole="management">
       <SimpleGrid columns={[1, 2, 4]} spacing={4} mb={8}>
         <Stat>
           <StatLabel>Active Projects</StatLabel>
@@ -121,6 +119,6 @@ export default function ManagementDashboard() {
           </Tbody>
         </Table>
       </Box>
-    </Box>
+    </DashboardLayout>
   );
 }

--- a/frontend/pages/MarketingDashboard.jsx
+++ b/frontend/pages/MarketingDashboard.jsx
@@ -1,12 +1,23 @@
-import { Box, Heading } from '@chakra-ui/react';
-import NavMenu from '../components/NavMenu.jsx';
+import { SimpleGrid, Stat, StatLabel, StatNumber } from '@chakra-ui/react';
+import DashboardLayout from '../components/DashboardLayout.jsx';
 
 export default function MarketingDashboard() {
   return (
-    <Box p={4}>
-      <NavMenu />
-      <Heading mb={4}>Marketing Dashboard</Heading>
-      {/* TODO: Add marketing analytics and campaign tools */}
-    </Box>
+    <DashboardLayout title="Marketing Dashboard" requiredRole="marketing">
+      <SimpleGrid columns={[1, 3]} spacing={4}>
+        <Stat>
+          <StatLabel>Campaigns</StatLabel>
+          <StatNumber>4</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Leads</StatLabel>
+          <StatNumber>120</StatNumber>
+        </Stat>
+        <Stat>
+          <StatLabel>Conversion</StatLabel>
+          <StatNumber>12%</StatNumber>
+        </Stat>
+      </SimpleGrid>
+    </DashboardLayout>
   );
 }

--- a/frontend/pages/SupportDashboard.jsx
+++ b/frontend/pages/SupportDashboard.jsx
@@ -1,12 +1,19 @@
-import { Box, Heading } from '@chakra-ui/react';
-import NavMenu from '../components/NavMenu.jsx';
+import { Heading } from '@chakra-ui/react';
+import DashboardLayout from '../components/DashboardLayout.jsx';
+import TicketTable from '../components/admin/TicketTable.jsx';
 
 export default function SupportDashboard() {
+  const tickets = [
+    { id: 1, subject: 'Login issue', userId: 'alice', status: 'open' },
+    { id: 2, subject: 'Payment missing', userId: 'bob', status: 'resolved' },
+  ];
+
   return (
-    <Box p={4}>
-      <NavMenu />
-      <Heading mb={4}>Support Dashboard</Heading>
-      {/* TODO: Add chat, tickets, dispute handling, and help centre management */}
-    </Box>
+    <DashboardLayout title="Support Dashboard" requiredRole="support">
+      <Heading size="md" mb={2}>
+        Recent Tickets
+      </Heading>
+      <TicketTable items={tickets} />
+    </DashboardLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add DashboardLayout wrapper with authentication and shared widgets
- extend finance, support, marketing and management dashboards using layout
- require admin login before displaying role-based dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894321e2db88320aef2e0f36a08986a