### PR TITLE
Fix server startup and installation docs

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -17,9 +17,14 @@ data.
    npm start
    ```
 
-2. Open [http://localhost:3000/install](http://localhost:3000/install) in your browser.
-3. Follow the wizard to verify permissions, enter site details, configure the database and create the first admin user.
-4. When the wizard finishes it runs database migrations, seeds data and redirects to the dashboard.
+2. Once the server is running, visit the web-based installer at
+   [http://localhost:3000/install](http://localhost:3000/install).
+3. The wizard walks you through verifying file permissions, entering site
+   details, configuring the database and creating the first administrative
+   account.
+4. After the final step the wizard applies database migrations, seeds sample
+   data and redirects you to the landing page. Use the admin credentials you
+   just created to log in.
 
 ## Quick setup script
 

--- a/app.js
+++ b/app.js
@@ -1,9 +1,10 @@
 require('dotenv').config();
 const path = require('path');
 
-// Reuse Express from the backend dependencies to avoid duplicating
-// installations at the repository root.
-const express = require('./backend/node_modules/express');
+// Use the root-level Express installation, which is hoisted by the
+// workspace setup. Requiring it directly ensures the server starts even
+// when backend dependencies aren't duplicated under `backend/node_modules`.
+const express = require('express');
 const backend = require('./backend/app');
 const { initDb } = require('./backend/utils/db');
 const { getStatus } = require('./backend/models/installation');

--- a/frontend/src/components/NavMenu.jsx
+++ b/frontend/src/components/NavMenu.jsx
@@ -8,8 +8,15 @@ import '../styles/NavMenu.css';
 
 export default function NavMenu() {
   const { user } = useAuth();
-  const { installed } = useInstall();
+  const { installed } = useInstall() || {};
   if (!user) return null;
+
+  const filteredMenu = installed
+    ? menu.map((section) => ({
+        ...section,
+        items: section.items.filter((item) => item.path !== '/install'),
+      }))
+    : menu;
 
   return (
     <Box
@@ -23,28 +30,9 @@ export default function NavMenu() {
       borderRight="1px solid"
       borderColor="gray.200"
     >
-      {menu.map((section) => (
-        <Box key={section.heading} mb={4}>
-          <Text fontWeight="bold" mb={2} className="nav-menu-heading">
-  const filteredMenu = installed
-    ? menu.map(section => ({
-        ...section,
-        items: section.items.filter(item => item.path !== '/install')
-      }))
-    : menu;
-  return (
-    <Box
-      as="aside"
-      w="250px"
-      p={4}
-      bgGradient="linear(to-b, white, blue.100)"
-      color="blue.900"
-      h="100vh"
-      overflowY="auto"
-    >
       {filteredMenu.map((section) => (
         <Box key={section.heading} mb={4}>
-          <Text fontWeight="bold" mb={2} color="blue.600">
+          <Text fontWeight="bold" mb={2} className="nav-menu-heading">
             {section.heading}
           </Text>
           <VStack align="stretch" spacing={1}>
@@ -56,7 +44,7 @@ export default function NavMenu() {
                 px={2}
                 py={1}
                 borderRadius="md"
-                _hover={{ textDecoration: 'none', bg: 'blue.50' }}
+                _hover={{ textDecoration: 'none', bg: 'gray.100' }}
               >
                 {item.label}
               </Link>

--- a/frontend/src/context/InstallContext.jsx
+++ b/frontend/src/context/InstallContext.jsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { getInstallStatus } from '../api/install.js';
 
-const InstallContext = createContext(null);
+export const InstallContext = createContext(null);
 
 export function InstallProvider({ children }) {
   const [installed, setInstalled] = useState(null);

--- a/frontend/tests/NavMenu.test.jsx
+++ b/frontend/tests/NavMenu.test.jsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import { describe, it, expect } from 'vitest';
 import NavMenu from '../src/components/NavMenu.jsx';
 import { AuthContext } from '../src/context/AuthContext.jsx';
+import { InstallContext } from '../src/context/InstallContext.jsx';
 import { BrowserRouter } from 'react-router-dom';
 
 describe('NavMenu', () => {
@@ -10,7 +11,9 @@ describe('NavMenu', () => {
     render(
       <BrowserRouter>
         <AuthContext.Provider value={{ user: { id: 1 }, loading: false }}>
-          <NavMenu />
+          <InstallContext.Provider value={{ installed: true }}>
+            <NavMenu />
+          </InstallContext.Provider>
         </AuthContext.Provider>
       </BrowserRouter>
     );
@@ -21,7 +24,9 @@ describe('NavMenu', () => {
     const { container } = render(
       <BrowserRouter>
         <AuthContext.Provider value={{ user: null, loading: false }}>
-          <NavMenu />
+          <InstallContext.Provider value={{ installed: true }}>
+            <NavMenu />
+          </InstallContext.Provider>
         </AuthContext.Provider>
       </BrowserRouter>
     );


### PR DESCRIPTION
## Summary
- load Express from the monorepo's shared dependencies so `npm start` works
- streamline NavMenu and export InstallContext to support install-aware navigation
- expand setup instructions with web installer steps and admin login note

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6894b269d77c8320bb34d3b7314bc203