### PR TITLE
Serve static files from public directory with SPA-friendly Apache config

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,9 +11,9 @@ const { getStatus } = require('./backend/models/installation');
 
 const app = express();
 
-// Serve the frontend static assets
-const frontendPath = path.join(__dirname, 'frontend');
-app.use(express.static(frontendPath));
+// Serve static assets from the public directory
+const publicPath = path.join(__dirname, 'public');
+app.use(express.static(publicPath));
 
 // Delegate API requests to the backend using a configurable base path
 const apiBase = process.env.API_BASE_URL || '/api';
@@ -31,7 +31,7 @@ app.get('/config.js', (req, res) => {
 // Fallback to index.html for any other request (SPA behavior)
 // Catch-all handler: send back index.html for any unmatched routes
 app.use((req, res) => {
-  res.sendFile(path.join(frontendPath, 'index.html'));
+  res.sendFile(path.join(publicPath, 'index.html'));
 });
 
 const port = process.env.PORT || 3000;

--- a/config/apache.conf.example
+++ b/config/apache.conf.example
@@ -6,11 +6,20 @@
         Options Indexes FollowSymLinks
         AllowOverride All
         Require all granted
+
+        <IfModule mod_rewrite.c>
+            RewriteEngine On
+            RewriteCond %{REQUEST_FILENAME} !-f
+            RewriteCond %{REQUEST_FILENAME} !-d
+            RewriteRule ^ index.html [L]
+        </IfModule>
     </Directory>
 
     ProxyPreserveHost On
     ProxyPass /api http://localhost:3001/
     ProxyPassReverse /api http://localhost:3001/
+
+    ErrorDocument 404 /index.html
 
     ErrorLog ${APACHE_LOG_DIR}/workhouse-error.log
     CustomLog ${APACHE_LOG_DIR}/workhouse-access.log combined

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,11 +1,7 @@
 <IfModule mod_rewrite.c>
   RewriteEngine On
   RewriteBase /
-  # Redirect HTTPS requests to HTTP
-  RewriteCond %{HTTPS} on
-  RewriteRule ^ http://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
-  RewriteRule ^index\.html$ - [L]
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteCond %{REQUEST_FILENAME} !-d
-  RewriteRule . /index.html [L]
+  RewriteRule ^ index.html [L]
 </IfModule>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Workhouse</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Serve static assets from `/public` and fallback to its `index.html`
- Simplify public `.htaccess` rewrite rules
- Add Apache example config that rewrites unknown paths to the SPA entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894d88e91fc832080ea2e749831ef6c